### PR TITLE
fix: update dead links to reference implementations

### DIFF
--- a/src/pages/protocol/tip20/overview.mdx
+++ b/src/pages/protocol/tip20/overview.mdx
@@ -163,7 +163,7 @@ By using TIP-20 tokens as quote tokens, the DEX benefits from the same payment-o
   />
   <Card
     description="Solidity reference implementation of the TIP-20 standard"
-    to="https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/TIP20.sol"
+    to="https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TIP20.sol"
     icon="lucide:file-text"
     title="Reference Implementation"
   />

--- a/src/pages/protocol/tip403/overview.mdx
+++ b/src/pages/protocol/tip403/overview.mdx
@@ -27,7 +27,7 @@ TIP-403 is Tempo's policy registry system that enables TIP-20 tokens to enforce 
   />
   <Card
     description="Solidity reference implementation of the TIP-403 standard"
-    to="https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/TIP403Registry.sol"
+    to="https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TIP403Registry.sol"
     icon="lucide:file-text"
     title="Reference Implementation"
   />

--- a/src/pages/protocol/tips/tip-1005.mdx
+++ b/src/pages/protocol/tips/tip-1005.mdx
@@ -54,9 +54,9 @@ The fix requires:
 
 ## Reference implementation changes
 
-The fix requires changes to two functions in [`docs/specs/src/StablecoinDEX.sol`](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol):
+The fix requires changes to two functions in [`tips/ref-impls/src/StablecoinDEX.sol`](https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/StablecoinDEX.sol):
 
-### 1. `_fillOrder` ([line 551-556](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol#L551-L556))
+### 1. `_fillOrder` ([line 551-556](https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/StablecoinDEX.sol#L551-L556))
 
 Add an optional `quoteOverride` parameter. When non-zero and the order is an ask, use `quoteOverride` directly for the maker's balance increment instead of computing `ceil(fillAmount * price)`.
 
@@ -73,7 +73,7 @@ uint128 quoteAmount = quoteOverride > 0
 balances[order.maker][book.quote] += quoteAmount;
 ```
 
-### 2. `_fillOrdersExactIn` ([line 923-926](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol#L923-L926))
+### 2. `_fillOrdersExactIn` ([line 923-926](https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/StablecoinDEX.sol#L923-L926))
 
 In the partial fill branch for asks, pass `remainingIn` as the quote override:
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -243,7 +243,7 @@ export default defineConfig({
               },
               {
                 text: 'Reference Implementation',
-                link: 'https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/TIP20.sol',
+                link: 'https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TIP20.sol',
               },
               {
                 text: 'Rust Implementation',
@@ -279,7 +279,7 @@ export default defineConfig({
               },
               {
                 text: 'Reference Implementation',
-                link: 'https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/TIP403Registry.sol',
+                link: 'https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TIP403Registry.sol',
               },
               {
                 text: 'Rust Implementation',
@@ -313,7 +313,7 @@ export default defineConfig({
                   },
                   {
                     text: 'Reference Implementation',
-                    link: 'https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/FeeManager.sol',
+                    link: 'https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/FeeManager.sol',
                   },
                   {
                     text: 'Rust Implementation',
@@ -393,7 +393,7 @@ export default defineConfig({
               },
               {
                 text: 'Reference Implementation',
-                link: 'https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/stablecoinDex.sol',
+                link: 'https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/stablecoinDex.sol',
               },
               {
                 text: 'Rust Implementation',


### PR DESCRIPTION
## Summary

Updates dead links pointing to the old `docs/specs/src` path to the new `tips/ref-impls/src` path following the migration in https://github.com/tempoxyz/tempo/pull/2159.

## Motivation

A partner reported broken links in our documentation. The reference implementation files were moved from `docs/specs/src` to `tips/ref-impls/src` but the docs site still had the old paths.

## Changes

| File | Links Fixed |
|------|-------------|
| `vocs.config.ts` | 4 (TIP20.sol, TIP403Registry.sol, FeeManager.sol, stablecoinDex.sol) |
| `tip20/overview.mdx` | 1 |
| `tip403/overview.mdx` | 1 |
| `tip-1005.mdx` | 4 (StablecoinDEX.sol references) |