### PR TITLE
fix: remove broken sub-block-specification redirect

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -624,12 +624,7 @@ export default defineConfig({
     },
     {
       source: '/errors/tx/SubblockNonceKey',
-      destination: '/protocol/blockspace/subblock-specification#4-block-validity-rules',
-    },
-    {
-      source: '/protocol/blockspace/sub-block-specification',
-      destination: '/protocol/blockspace/subblock-specification',
-      status: 301,
+      destination: '/protocol/blockspace/sub-block-specification#4-block-validity-rules',
     },
     {
       source: '/stablecoin-exchange/:path*',


### PR DESCRIPTION
## Problem

Direct links to `/protocol/blockspace/sub-block-specification` were returning 404, even though:
- The page works when navigated to from the sidebar
- The URL shown in the browser matches the expected path

## Root Cause

There was a misconfigured redirect in `vocs.config.ts`:
```ts
{
  source: '/protocol/blockspace/sub-block-specification',
  destination: '/protocol/blockspace/subblock-specification', // ← doesn't exist!
  status: 301,
}
```

This redirected to a non-existent path (`subblock-specification` without hyphen), but the actual file is `sub-block-specification.mdx` (with hyphen).

## Fix

- Remove the broken redirect
- Fix the `/errors/tx/SubblockNonceKey` redirect to point to the correct hyphenated path

Fixes: Direct URL access for the sub-block specification page