### PR TITLE
fix: changelog version links now include pathname

### DIFF
--- a/patches/vocs@0.0.0.patch
+++ b/patches/vocs@0.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/react/internal/Changelog.client.js b/dist/react/internal/Changelog.client.js
+index dc53ba264977cd2097d1d890cff746413fb61d87..4fc0d8171aecb09d7e9b6b4ada338f7a80ac94ac 100644
+--- a/dist/react/internal/Changelog.client.js
++++ b/dist/react/internal/Changelog.client.js
+@@ -115,7 +115,7 @@ function VersionOutline(props) {
+                             ...indicatorStyle,
+                         }, "data-v-version-indicator": true }), releases.map((release) => {
+                         const isActive = activeVersion === release.version;
+-                        return (_jsx("li", { "data-v-version-item": true, "data-version": release.version, className: "vocs:scroll-my-4", children: _jsx("a", { href: `#${release.version}`, className: cx('vocs:block vocs:leading-snug vocs:py-1 vocs:pl-3 vocs:cursor-pointer vocs:font-mono vocs:text-xs vocs:transition-colors vocs:duration-100', isActive ? 'vocs:text-accent' : 'vocs:text-secondary vocs:hover:text-link'), "data-active": isActive, children: release.version }) }, release.version));
++                        return (_jsx("li", { "data-v-version-item": true, "data-version": release.version, className: "vocs:scroll-my-4", children: _jsx("a", { href: `${typeof window !== 'undefined' ? window.location.pathname : ''}#${release.version}`, className: cx('vocs:block vocs:leading-snug vocs:py-1 vocs:pl-3 vocs:cursor-pointer vocs:font-mono vocs:text-xs vocs:transition-colors vocs:duration-100', isActive ? 'vocs:text-accent' : 'vocs:text-secondary vocs:hover:text-link'), "data-active": isActive, children: release.version }) }, release.version));
+                     })] })] }));
+     return createPortal(outline, document.body);
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vocs@0.0.0:
+    hash: 6ed066b5d21fdf161d7ddcd134bc85a417ccaf0d40cdd7ba0149082fea57b021
+    path: patches/vocs@0.0.0.patch
+
 importers:
 
   .:
@@ -76,7 +81,7 @@ importers:
         version: 2.44.4(typescript@5.9.3)(zod@4.3.5)
       vocs:
         specifier: https://pkg.pr.new/wevm/vocs@d503413
-        version: https://pkg.pr.new/wevm/vocs@d503413(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react-server-dom-webpack@19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1))(react@19.2.3)(rollup@4.56.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.2(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react-server-dom-webpack@19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1))(react@19.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: https://pkg.pr.new/wevm/vocs@d503413(patch_hash=6ed066b5d21fdf161d7ddcd134bc85a417ccaf0d40cdd7ba0149082fea57b021)(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react-server-dom-webpack@19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1))(react@19.2.3)(rollup@4.56.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.2(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react-server-dom-webpack@19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1))(react@19.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wagmi:
         specifier: 3.4.1
         version: 3.4.1(@tanstack/query-core@5.90.19)(@tanstack/react-query@5.90.19(react@19.2.3))(@types/react@19.2.9)(ox@0.11.3(typescript@5.9.3)(zod@4.3.5))(react@19.2.3)(typescript@5.9.3)(viem@2.44.4(typescript@5.9.3)(zod@4.3.5))
@@ -7063,7 +7068,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vocs@https://pkg.pr.new/wevm/vocs@d503413(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react-server-dom-webpack@19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1))(react@19.2.3)(rollup@4.56.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.2(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react-server-dom-webpack@19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1))(react@19.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vocs@https://pkg.pr.new/wevm/vocs@d503413(patch_hash=6ed066b5d21fdf161d7ddcd134bc85a417ccaf0d40cdd7ba0149082fea57b021)(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react-server-dom-webpack@19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1))(react@19.2.3)(rollup@4.56.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.2(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react-server-dom-webpack@19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1))(react@19.2.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@base-ui/react': 1.1.0(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  vocs@0.0.0: patches/vocs@0.0.0.patch


### PR DESCRIPTION
## Problem

Clicking on versions in the changelog redirects to `https://docs.tempo.xyz/#v1.0.0-rc.5` instead of scrolling to that version on `https://docs.tempo.xyz/changelog`.

## Root Cause

The vocs changelog component used relative hash links (`#v1.0.0`) which navigated to `/#v1.0.0` instead of `/changelog#v1.0.0`.

## Solution

This PR adds a pnpm patch to vocs that prepends `window.location.pathname` to the href, making the links work correctly on non-root pages.

## Upstream

Filed issue for a proper fix: https://github.com/wevm/vocs/issues/387

cc @alexey