### PR TITLE
fix: add width/height to tokenlist images to prevent layout shift

### DIFF
--- a/src/components/TokenList.tsx
+++ b/src/components/TokenList.tsx
@@ -31,7 +31,7 @@ export function TokenListDemo() {
             className="flex items-center gap-2 text-content"
             href={`https://tokenlist.tempo.xyz/asset/42431/${token.address}`}
           >
-            <img src={token.logoURI} alt={token.name} className="size-7.5" />
+            <img src={token.logoURI} alt={token.name} width={30} height={30} className="size-7.5" />
             <span className="font-medium text-xl tracking-wider">{token.name}</span>
           </a>
         </li>

--- a/src/components/TokenList.tsx
+++ b/src/components/TokenList.tsx
@@ -31,7 +31,7 @@ export function TokenListDemo() {
             className="flex items-center gap-2 text-content"
             href={`https://tokenlist.tempo.xyz/asset/42431/${token.address}`}
           >
-            <img src={token.logoURI} alt={token.name} width={30} height={30} className="size-7.5" />
+            <img src={token.logoURI} alt={token.name} width={64} height={64} className="size-7.5" />
             <span className="font-medium text-xl tracking-wider">{token.name}</span>
           </a>
         </li>


### PR DESCRIPTION
Adds explicit `width` and `height` attributes (30x30) to token icons in the TokenListDemo component to prevent Cumulative Layout Shift (CLS) when images load.

The icons are SVGs served from the tokenlist API, so dimensions are known upfront.