### PR TITLE
docs: add EIP-4337 and EIP-7702 comparison pages

### DIFF
--- a/src/pages/protocol/transactions/eip-4337.mdx
+++ b/src/pages/protocol/transactions/eip-4337.mdx
@@ -1,0 +1,62 @@
+---
+title: EIP-4337 Comparison
+description: "How Tempo Transactions achieve EIP-4337 goals without bundlers, paymasters, or EntryPoint contracts."
+---
+
+# EIP-4337 and Tempo Transactions
+
+EIP-4337 introduced account abstraction to Ethereum through a system of bundlers, paymasters, and an EntryPoint contract. Tempo Transactions achieve the same goals through protocol-native features that require no additional infrastructure.
+
+## EIP-4337 Design Goals
+
+EIP-4337 enables several key capabilities for Ethereum accounts:
+
+- **Fee sponsorship**: Third parties can pay gas fees on behalf of users
+- **Batched operations**: Multiple calls can execute atomically in one transaction
+- **Alternative signatures**: Accounts can use signature schemes beyond secp256k1
+- **Custom validation**: Accounts can define arbitrary validation logic
+
+## How Tempo Achieves These Goals
+
+Tempo Transactions provide these capabilities at the protocol level.
+
+### Fee Sponsorship
+
+EIP-4337 requires deploying a Paymaster contract, funding it with ETH, and running or paying for bundler infrastructure. The Paymaster validates sponsorship requests and the bundler aggregates UserOperations.
+
+Tempo Transactions include a `fee_payer_signature` field directly in the transaction. A sponsor signs the transaction to agree to pay fees. The protocol validates both signatures and deducts fees from the sponsor. No contracts or infrastructure are required. See the [fee sponsorship guide](/guide/payments/sponsor-user-fees) for implementation details.
+
+### Batched Operations
+
+EIP-4337 bundles multiple UserOperations through an external bundler service. Each UserOperation can contain one call.
+
+Tempo Transactions include a native `calls` array. Multiple contract calls execute atomically in a single transaction. The protocol handles execution directly without external services.
+
+### Alternative Signatures
+
+EIP-4337 requires deploying a custom validation contract for each signature scheme. The contract must implement signature verification logic.
+
+Tempo Transactions natively support secp256k1, P256, and WebAuthn signatures. The protocol verifies these signatures directly. Passkey authentication works without custom contracts. See the [passkey accounts guide](/guide/use-accounts/embed-passkeys) for implementation details.
+
+### Gas Token Flexibility
+
+EIP-4337 Paymasters can accept alternative tokens but must convert them to ETH internally.
+
+Tempo Transactions pay fees directly in any USD stablecoin that has liquidity on the Fee AMM. No conversion infrastructure is needed. See the [stablecoin fees guide](/guide/payments/pay-fees-in-any-stablecoin) for implementation details.
+
+## Integration Comparison
+
+| Aspect | EIP-4337 | Tempo Transactions |
+|--------|----------|-------------------|
+| Contracts to deploy | EntryPoint, Paymaster, Account | None required |
+| Infrastructure to run | Bundler service | None required |
+| Fee payment | ETH via Paymaster | Any USD stablecoin |
+| Signature verification | Custom validation contract | Protocol-native |
+
+## When to Use EIP-4337 on Tempo
+
+Tempo has the ERC-4337 EntryPoint contract deployed for projects that require compatibility with existing 4337 tooling. Consider using native Tempo Transactions for lower gas costs and simpler integration.
+
+## Getting Started
+
+To start using Tempo Transactions, see the [Tempo Transactions guide](/guide/tempo-transaction) for SDK integration in TypeScript, Rust, Go, and Python. For the full technical specification, see the [Tempo Transaction Specification](/protocol/transactions/spec-tempo-transaction).

--- a/src/pages/protocol/transactions/eip-7702.mdx
+++ b/src/pages/protocol/transactions/eip-7702.mdx
@@ -1,0 +1,62 @@
+---
+title: EIP-7702 Comparison
+description: "How Tempo Transactions extend EIP-7702 delegation with additional signature schemes and native features."
+---
+
+# EIP-7702 and Tempo Transactions
+
+EIP-7702 allows EOAs to delegate to smart contract code temporarily within a transaction. Tempo Transactions build on this foundation and extend it with additional capabilities.
+
+## EIP-7702 Design Goals
+
+EIP-7702 enables EOAs to:
+
+- **Delegate to contract code**: An EOA can execute as if it were a smart contract
+- **Batch transactions**: Through delegation to a batching contract
+- **Maintain EOA properties**: The account remains an EOA after the transaction
+
+## How Tempo Extends EIP-7702
+
+Tempo Transactions support EIP-7702 style delegation through the `aa_authorization_list` field. This field follows EIP-7702 semantics for delegation and execution.
+
+### Extended Signature Support
+
+EIP-7702 on Ethereum only supports secp256k1 signatures for the authorization.
+
+Tempo extends this to support all Tempo signature types. Authorizations can be signed with secp256k1, P256, or WebAuthn. This enables delegation from passkey-based accounts.
+
+### Native Features Beyond Delegation
+
+EIP-7702 provides delegation as a building block. Applications must implement higher-level features through the delegated contract.
+
+Tempo Transactions include these features natively:
+
+- **Fee sponsorship**: Built into the transaction type, not requiring delegation. See the [fee sponsorship guide](/guide/payments/sponsor-user-fees).
+- **Scheduled execution**: Native `validAfter` and `validBefore` timestamp windows for time-bounded transactions.
+- **Parallelizable nonces**: Multiple nonce keys for concurrent transactions. See the [parallel transactions guide](/guide/payments/send-parallel-transactions).
+- **Access keys**: Delegate signing to secondary keys with configurable permissions. See the [Account Keychain specification](/protocol/transactions/AccountKeychain).
+
+### Combining Delegation with Native Features
+
+Tempo Transactions can use EIP-7702 delegation alongside native features. An application can delegate an EOA to contract code while also using fee sponsorship and batched calls from the protocol.
+
+## Feature Comparison
+
+| Feature | EIP-7702 | Tempo Transactions |
+|---------|----------|-------------------|
+| EOA delegation | Yes | Yes |
+| Signature schemes | secp256k1 only | secp256k1, P256, WebAuthn |
+| Fee sponsorship | Via delegated contract | Native |
+| Batching | Via delegated contract | Native |
+| Scheduled execution | Not available | Native |
+| Concurrent nonces | Not available | Native |
+
+## Implementation
+
+The `aa_authorization_list` field in Tempo Transactions contains authorizations that follow EIP-7702 structure. Each authorization delegates an account to a specified implementation contract and is signed by the account authority.
+
+For full details on the authorization format, see the [Tempo Transaction Specification](/protocol/transactions/spec-tempo-transaction).
+
+## Getting Started
+
+To start using Tempo Transactions, see the [Tempo Transactions guide](/guide/tempo-transaction) for SDK integration in TypeScript, Rust, Go, and Python.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -345,6 +345,14 @@ export default defineConfig({
                 link: '/protocol/transactions/spec-tempo-transaction',
               },
               {
+                text: 'EIP-4337 Comparison',
+                link: '/protocol/transactions/eip-4337',
+              },
+              {
+                text: 'EIP-7702 Comparison',
+                link: '/protocol/transactions/eip-7702',
+              },
+              {
                 text: 'Account Keychain Precompile Specification',
                 link: '/protocol/transactions/AccountKeychain',
               },


### PR DESCRIPTION
Adds two new documentation pages under Tempo Transactions explaining how Tempo achieves account abstraction goals:

## EIP-4337 Comparison
Explains how Tempo Transactions provide:
- Fee sponsorship without Paymasters
- Batching without bundlers
- Alternative signatures without custom validation contracts
- Gas token flexibility without conversion infrastructure

## EIP-7702 Comparison
Explains how Tempo extends EIP-7702:
- Extended signature support (P256, WebAuthn)
- Native features beyond delegation (sponsorship, scheduling, parallel nonces, access keys)

Both pages include links to implementation guides.