### PR TITLE
docs: add Base Fee Model section to fee specification

### DIFF
--- a/src/pages/protocol/fees/spec-fee.mdx
+++ b/src/pages/protocol/fees/spec-fee.mdx
@@ -31,7 +31,7 @@ The fixed base fee combined with USD-denominated payment provides predictable un
 
 Congestion is managed through:
 
-- **Payment lanes**: Reserved blockspace for TIP-20 transfers as specified in the [Payment Lane Specification](/protocol/blockspace/payment-lane-specification). Approximately 94% of blockspace is reserved for payment transactions, with the remaining 6% available for general computation. This allocation is conservative and may increase over time as total throughput scales.
+- **Payment lanes**: Reserved blockspace for TIP-20 transfers as specified in the [Payment Lane Specification](/protocol/blockspace/payment-lane-specification). Approximately 94% of blockspace is reserved for payment transactions, with the remaining 6% available for general computation. This allocation is conservative and the blockspace available for general computation may increase over time as total throughput scales.
 - **Priority fees**: The `max_priority_fee_per_gas` field allows transactions to bid for faster inclusion during periods of high demand.
 - **Block gas limits**: Standard per-block gas limits constrain total computation per block.
 


### PR DESCRIPTION
Adds a Base Fee Model subsection to the fee specification page.

## Changes
- Added **Base Fee Model** subsection under Fee Units
- Documents fixed base fee (vs EIP-1559 dynamic)
- Explains congestion management mechanisms:
  - Payment lanes for reserved TIP-20 blockspace
  - Priority fees for bidding during high demand
  - Block gas limits for computation constraints
- Added title to frontmatter for SEO

This addresses the documentation gap around how Tempo handles congestion with fixed fees, which came up during RFP preparation.