### PR TITLE
fix: isolate wagmi state between mipd and non-mipd pages

### DIFF
--- a/src/wagmi.config.ts
+++ b/src/wagmi.config.ts
@@ -14,7 +14,7 @@ const rpId = (() => {
 })()
 
 export function getConfig(options: getConfig.Options = {}) {
-  const { multiInjectedProviderDiscovery } = options
+  const { multiInjectedProviderDiscovery = false } = options
   return createConfig({
     batch: {
       multicall: false,


### PR DESCRIPTION
Pages with `mipd: true` frontmatter now have isolated wagmi state from pages without it.