### PR TITLE
fix: correct RPC node link from /usage to /rpc

### DIFF
--- a/src/pages/guide/node/index.mdx
+++ b/src/pages/guide/node/index.mdx
@@ -31,7 +31,7 @@ Prebuilt binaries are available for:
   />
   <Card
     description="Configure and run a full RPC node"
-    to="/guide/node/usage"
+    to="/guide/node/rpc"
     icon="lucide:play"
     title="Running an RPC Node"
   />


### PR DESCRIPTION
Fixes broken link on the node overview page.

The 'Running an RPC Node' card was linking to `/guide/node/usage` (which doesn't exist) instead of `/guide/node/rpc`.

Reported in [#product-docs](https://tempoxyz.slack.com/archives/C09SB72CWJC/p1769632615499209)