### PR TITLE
fix: redirect trailing slashes to prevent 500 errors

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "trailingSlash": false
+}


### PR DESCRIPTION
## Summary

Fixes 500 errors when accessing URLs with trailing slashes (e.g. `/protocol/` vs `/protocol`).

## Problem

Vocs/Waku's router expects paths without trailing slashes. When a user accesses a URL with a trailing slash, the framework throws "Path must not end with `/`" and returns a 500 error.

## Solution

Add `vercel.json` with `trailingSlash: false` to automatically redirect trailing slash URLs to their canonical non-slash versions with a 308 permanent redirect at the edge layer before the request reaches the application.

## Testing

- `https://docs.tempo.xyz/protocol/` will redirect to `https://docs.tempo.xyz/protocol`
- All existing non-trailing-slash URLs continue to work normally

Thread: https://tempoxyz.slack.com/archives/C09SB72CWJC/p1769729266093459