### PR TITLE
docs: clarify valid_before/valid_after unit is seconds

### DIFF
--- a/src/pages/protocol/transactions/spec-tempo-transaction.mdx
+++ b/src/pages/protocol/transactions/spec-tempo-transaction.mdx
@@ -42,8 +42,8 @@ pub struct TempoTransaction {
     // Optional features
     fee_token: Option<Address>,                 // Optional fee token preference
     fee_payer_signature: Option<Signature>,     // Sponsored transactions (secp256k1 only)
-    valid_before: Option<u64>,                  // Transaction expiration timestamp
-    valid_after: Option<u64>,                   // Transaction can only be included after this timestamp
+    valid_before: Option<u64>,                  // Transaction expiration timestamp (seconds)
+    valid_after: Option<u64>,                   // Transaction can only be included after this timestamp (seconds)
     key_authorization: Option<SignedKeyAuthorization>, // Access key authorization (optional)
     aa_authorization_list: Vec<TempoSignedAuthorization>, // EIP-7702 style authorizations with AA signatures
 }


### PR DESCRIPTION
Clarifies that `valid_before` and `valid_after` timestamps are in seconds, as specified in TIP-1009.