### PR TITLE
docs: add Chainstack to node providers

### DIFF
--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -204,6 +204,12 @@ Sign up through the [Alchemy dashboard](https://dashboard.alchemy.com) and visit
 
 Sign up through the [Blockdaemon Developer Dashboard](https://app.blockdaemon.com/) and deploy a Tempo node by navigating to **Nodes & RPC → Deploy a Node**.
 
+### Chainstack
+
+[Chainstack](https://chainstack.com) provides managed blockchain infrastructure with high-performance, secure RPC nodes. The platform offers reliable Tempo endpoints with built-in monitoring and analytics.
+
+Create an account through the [Chainstack console](https://console.chainstack.com) to deploy Tempo nodes and access RPC endpoints.
+
 ### Conduit
 
 [Conduit](https://conduit.xyz) provides high-performance RPC infrastructure for Tempo Testnet. Developers can create API keys and access Tempo Testnet endpoints through the [Conduit app](https://app.conduit.xyz). 


### PR DESCRIPTION
## Summary
Adds Chainstack to the Developer Tools docs page under Node Providers.

## Changes
- Added Chainstack entry in alphabetical order (between Blockdaemon and Conduit)
- Matched existing docs tone and formatting

Thread: https://tempoxyz.slack.com/archives/C0A332FHV0A/p1769813057912309