### PR TITLE
docs: add skills-npm for npm package agent skills

### DIFF
--- a/src/pages/guide/building-with-ai.mdx
+++ b/src/pages/guide/building-with-ai.mdx
@@ -129,6 +129,26 @@ $ cp -r agent-skills/skills/tempo ~/.config/agents/skills/
 
 Or add to your project's [`.agents/skills/`](https://github.com/tempoxyz/agent-skills/tree/main/skills) directory for project-specific access.
 
+### npm Package Skills
+
+For packages that ship their own agent skills, use [`skills-npm`](https://github.com/antfu/skills-npm) to automatically discover and symlink them:
+
+```bash
+pnpm add -D skills-npm
+```
+
+Add a `prepare` script to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "prepare": "skills-npm"
+  }
+}
+```
+
+Skills from installed npm packages are symlinked to `skills/npm-<package-name>-<skill-name>` for your agent. Add `skills/npm-*` to your `.gitignore`.
+
 ### Usage
 
 Once installed, the skill is automatically available. The agent will use it when relevant tasks are detected.

--- a/src/pages/guide/building-with-ai.mdx
+++ b/src/pages/guide/building-with-ai.mdx
@@ -133,9 +133,17 @@ Or add to your project's [`.agents/skills/`](https://github.com/tempoxyz/agent-s
 
 For packages that ship their own agent skills, use [`skills-npm`](https://github.com/antfu/skills-npm) to automatically discover and symlink them:
 
-```bash
+:::code-group
+```bash [npm]
+npm add -D skills-npm
+```
+```bash [pnpm]
 pnpm add -D skills-npm
 ```
+```bash [bun]
+bun add -D skills-npm
+```
+:::
 
 Add a `prepare` script to your `package.json`:
 


### PR DESCRIPTION
Adds a section to the Building with AI page documenting [skills-npm](https://github.com/antfu/skills-npm) - a CLI that discovers agent skills shipped inside npm packages and symlinks them for coding agents.

This allows packages to bundle their own agent skills that get automatically installed when users `npm install` the package.