### PR TITLE
test: unskip faucet e2e test

### DIFF
--- a/e2e/faucet.spec.ts
+++ b/e2e/faucet.spec.ts
@@ -1,8 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-// Skip: This test depends on external faucet service and is flaky in CI
-// TODO: Mock the faucet response or increase timeout
-test.skip('fund an address via faucet', async ({ page }) => {
+test('fund an address via faucet', async ({ page }) => {
   await page.goto('/quickstart/faucet')
 
   // Switch to "Fund an address" tab


### PR DESCRIPTION
Testing if the faucet e2e test passes in CI now that the external service may be more stable.