### PR TITLE
docs: add Quote Tokens section, move pathUSD as subpage

### DIFF
--- a/src/pages/protocol/exchange/quote-tokens/index.mdx
+++ b/src/pages/protocol/exchange/quote-tokens/index.mdx
@@ -1,0 +1,61 @@
+---
+description: Quote tokens define trading pairs on Tempo's decentralized exchange. Each TIP-20 can select any other TIP-20 as its quote token.
+---
+
+# Quote Tokens
+
+## Overview
+
+On Tempo's [decentralized exchange](/protocol/exchange/spec.mdx), each TIP-20 token selects another TIP-20 as its **quote token**—the token it trades against. This creates a tree structure that guarantees exactly one path between any two tokens, reducing liquidity fragmentation and simplifying routing.
+
+## How Quote Tokens Work
+
+When creating a TIP-20, you specify a quote token:
+
+```solidity
+TIP20 token = factory.createToken(
+  "My Company USD",
+  "MCUSD",
+  "USD",
+  quoteToken, // The token this will trade against
+  msg.sender,
+  bytes32("my-unique-salt")
+);
+```
+
+This means your token trades directly against the quote token on the DEX. Users can swap between tokens that share a common quote token, or that are connected through a multi-hop path.
+
+## Choosing a Quote Token
+
+You can choose **any** existing TIP-20 as your quote token. Common options include:
+
+- **[pathUSD](/protocol/exchange/quote-tokens/pathUSD)** — A USD-denominated stablecoin designed specifically for use as a quote token
+- **Another stablecoin** — Any other USD stablecoin on Tempo
+- **A different token** — Any TIP-20 that makes sense for your use case
+
+The choice is entirely up to the token issuer. Using pathUSD is optional.
+
+## Tree Structure
+
+The quote token system creates a tree structure where all tokens sharing a currency denomination are connected:
+
+```
+               USDX
+                |
+             pathUSD -- USDY -- USDZ
+                |
+               USDA
+```
+
+This structure:
+- **Guarantees single-path routing** between any two tokens
+- **Concentrates liquidity** instead of fragmenting it across multiple pairs
+- **Simplifies price discovery** even for thinly-traded pairs
+
+## Quote Tokens
+
+<Cards>
+  <Card title="pathUSD" href="/protocol/exchange/quote-tokens/pathUSD">
+    A USD stablecoin designed as an optional quote token for DEX trading pairs
+  </Card>
+</Cards>

--- a/src/pages/protocol/exchange/quote-tokens/pathUSD.mdx
+++ b/src/pages/protocol/exchange/quote-tokens/pathUSD.mdx
@@ -1,20 +1,22 @@
 ---
-description: pathUSD is a USD-denominated stablecoin serving as an optional quote token for DEX trading pairs and fallback gas token on Tempo.
+description: pathUSD is a USD-denominated stablecoin available as one option for a quote token on Tempo's DEX. Use of pathUSD is optional.
 ---
 
 # pathUSD
 
-## Abstract
+pathUSD is one of many possible [quote tokens](/protocol/exchange/quote-tokens) on Tempo. It is a USD-denominated stablecoin that token issuers can optionally select when creating their TIP-20.
 
-pathUSD is a USD-denominated stablecoin that can be used as a quote token on Tempo's decentralized exchange. It is the first stablecoin deployed to the chain, and is used as a fallback gas token when the user or validator does not specify a gas token. Use of pathUSD is optional.
+:::info
+**pathUSD is optional.** Token issuers can choose any TIP-20 as their quote token—pathUSD is simply one available option.
+:::
 
-## Motivation
+## Overview
 
-Each USD TIP-20 on Tempo can choose any other USD TIP-20 as its [quote token](/protocol/exchange/spec.mdx#quote-tokens)—the token it is paired against on the [native decentralized exchange](/protocol/exchange/spec.mdx). This guarantees that there is one path between any two tokens, which reduces fragmentation of liquidity and simplifies routing.
+Each USD TIP-20 on Tempo can choose any other USD TIP-20 as its [quote token](/protocol/exchange/quote-tokens)—the token it is paired against on the [native decentralized exchange](/protocol/exchange/spec.mdx). This guarantees that there is one path between any two tokens, which reduces fragmentation of liquidity and simplifies routing.
 
-While on other chains, most liquidity accrues to a few stablecoins, or even one, Tempo offers a USD-denominated stablecoin, pathUSD, that other stablecoins can choose as their quote token. PathUSD is not meant to compete as a consumer-facing stablecoin. Use of pathUSD is optional, and tokens are able to list any other token as their quote token if they choose.
+Tempo offers pathUSD as one option that stablecoins can choose as their quote token if they wish. pathUSD is not meant to compete as a consumer-facing stablecoin—it exists purely as a routing mechanism for those who choose to use it.
 
-pathUSD can also be accepted as a fee token by validators.
+pathUSD can also be accepted as a fee token by validators, and is used as the fallback gas token when no other is specified.
 
 ## Specification
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -401,8 +401,18 @@ export default defineConfig({
                 link: '/protocol/exchange/spec',
               },
               {
-                text: 'pathUSD',
-                link: '/protocol/exchange/pathUSD',
+                text: 'Quote Tokens',
+                collapsed: true,
+                items: [
+                  {
+                    text: 'Overview',
+                    link: '/protocol/exchange/quote-tokens',
+                  },
+                  {
+                    text: 'pathUSD',
+                    link: '/protocol/exchange/quote-tokens/pathUSD',
+                  },
+                ],
               },
               {
                 text: 'Executing Swaps',
@@ -708,6 +718,11 @@ export default defineConfig({
     {
       source: '/quickstart/tip20',
       destination: '/protocol/tip20/overview',
+      status: 301,
+    },
+    {
+      source: '/protocol/exchange/pathUSD',
+      destination: '/protocol/exchange/quote-tokens/pathUSD',
       status: 301,
     },
   ],


### PR DESCRIPTION
This PR reorganizes the documentation to add a Quote Tokens section under the Stablecoin DEX:

**Changes:**
- Creates a new Quote Tokens overview page at `/protocol/exchange/quote-tokens`
- Moves pathUSD to `/protocol/exchange/quote-tokens/pathUSD` as a subpage
- Updates pathUSD content to clarify it's one of many quote token options
- Adds Quote Tokens as a collapsible menu item with pathUSD nested underneath
- Adds 301 redirect from the old `/protocol/exchange/pathUSD` URL to preserve existing links

**Navigation structure:**
```
Stablecoin DEX
├── Overview
├── Specification
├── Quote Tokens         ← NEW
│   ├── Overview         ← NEW
│   └── pathUSD          ← MOVED
├── Executing Swaps
├── ...
```