### PR TITLE
fix: use correct decimals (6) for native currency

### DIFF
--- a/src/components/guides/steps/wallet/ConnectWallet.tsx
+++ b/src/components/guides/steps/wallet/ConnectWallet.tsx
@@ -100,7 +100,7 @@ export function ConnectWallet(props: DemoStepProps) {
                 addEthereumChainParameter: {
                   nativeCurrency: {
                     name: 'USD',
-                    decimals: 18,
+                    decimals: 6,
                     symbol: 'USD',
                   },
                   blockExplorerUrls: ['https://explore.tempo.xyz'],


### PR DESCRIPTION
Fixes the `addEthereumChainParameter.nativeCurrency.decimals` value from 18 to 6.

Tempo's native USD uses 6 decimals per TIP-20 spec, not 18. This was causing wallets to display incorrect balance amounts when adding Tempo network.

Found by @struong in https://tempoxyz.slack.com/archives/C0A87C21805/p1770093855753439