### PR TITLE
docs(foundry): update tempo args to use --tempo. prefix, add anvil section

### DIFF
--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -292,4 +292,6 @@ The following flags are available for `cast` and `forge script` for Tempo-specif
 | `--tempo.sponsor-signature <SIG>` | Pre-signed sponsor signature for gasless transactions | `--tempo.sponsor-signature 0x...` |
 | `--tempo.print-sponsor-hash` | Print fee payer signature hash and exit (for sponsor to sign) | `--tempo.print-sponsor-hash` |
 
+Ledger and Trezor wallets are not yet compatible with any `--tempo.*` option.
+
 


### PR DESCRIPTION
## Summary

Updates the Foundry docs to reflect the new tempo-foundry CLI args and adds anvil support documentation.

### Changes

- Update all flag examples to use `--tempo.fee-token`, `--tempo.nonce-key`, `--tempo.expiring-nonce`, `--tempo.valid-before`, `--tempo.valid-after`
- Add **Local Development with Anvil** section with examples for:
  - Starting anvil in Tempo mode (`anvil --tempo --hardfork t1`)
  - Forking live Tempo networks
  - 2D nonces, expiring nonces, and batch transactions on anvil
- Add **Tempo-Specific CLI Flags** reference table
- Document `TEMPO_FEE_TOKEN` environment variable

### Reference

Based on [tempo-check.sh](https://github.com/tempoxyz/tempo-foundry/blob/tempo/.github/scripts/tempo-check.sh)

cc @zerosnacks @onbjerg