### PR TITLE
docs: add release signature verification guide

### DIFF
--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -51,7 +51,7 @@ docker logs tempo
 
 ## Verifying Releases
 
-All release artifacts are cryptographically signed starting from **v1.1.0**. We recommend verifying signatures before running any binary.
+All release artifacts are cryptographically signed starting after **v1.1.0**. We recommend verifying signatures before running any binary.
 
 ### Binary Signatures (GPG)
 


### PR DESCRIPTION
Adds a **Verifying Releases** section to the installation page covering:

- **GPG** — binary signature verification (signed from v1.1.0 onwards), with fingerprint and embedded public key
- **Cosign** — Docker image keyless verification via GitHub Actions OIDC
- **SHA256** — checksum verification

Companion to tempoxyz/tempo PR that adds GPG signing to the release workflow and signature verification to `tempoup`.