### PR TITLE
fix: clarify spending limits behavior

### DIFF
--- a/src/pages/protocol/transactions/AccountKeychain.mdx
+++ b/src/pages/protocol/transactions/AccountKeychain.mdx
@@ -273,8 +273,8 @@ Access Keys cannot escalate their own privileges because:
 - Keys with `enforceLimits == false` have unlimited spending (no limits checked)
 - Spending limits are enforced by the protocol internally calling `verify_and_update_spending()` during execution
 - Limits are per-TIP20 token and deplete as TIP20 tokens are spent
-- Spending limits only track TIP20 token transfers (via `transfer` and `transferFrom`) and approvals
-- For approvals: only increases in approval amount count against the spending limit
+- Spending limits only track TIP20 token transfers (via `transfer` and `transferWithMemo`) and approvals (via `approve`)
+- For approvals: only increases in approval amount count against the spending limit. This means approvals indirectly control `transferFrom` spending, since `transferFrom` requires a prior approval
 - Non-TIP20 asset movements (ETH, NFTs) are not subject to spending limits
 - Root keys (`keyId == address(0)`) have no spending limits - the function returns immediately
 - Failed limit checks revert the entire transaction with `SpendingLimitExceeded`


### PR DESCRIPTION
ref: `SIGP-35`

this PR fixes inaccurate docs stating spending limits track `transferFrom()` calls