### PR TITLE
docs: add ISO 4217 currency code guidance for TIP-20 issuers

### DIFF
--- a/src/pages/guide/issuance/create-a-stablecoin.mdx
+++ b/src/pages/guide/issuance/create-a-stablecoin.mdx
@@ -152,7 +152,7 @@ Now that we have some input fields, we need to add some logic to handle the subm
 After this step, your users will be able to create a stablecoin by clicking the "Create" button!
 
 :::warning
-We **strongly** recommend that for stablecoins, the `currency` field be set to the [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) three-letter code for the underlying fiat currency (e.g., `"USD"`, `"EUR"`, `"GBP"`) — **not** the token symbol. This value is **immutable** after token creation and affects fee payment eligibility, DEX routing, and quote token pairing.
+We **strongly** recommend that for stablecoins, the `currency` field be set to the [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) three-letter code for the underlying fiat currency (e.g., `"USD"`, `"EUR"`, `"GBP"`) — **not** the token symbol. This value is **immutable** after token creation and affects fee payment eligibility, DEX routing, and quote token pairing. **Only `USD` stablecoins can be used to pay transaction fees on Tempo** — if your stablecoin is USD-denominated, the currency must be set to `"USD"` to be eligible for fee payment.
 :::
 
 <Demo.Container name="Create Form">

--- a/src/pages/protocol/tip20/overview.mdx
+++ b/src/pages/protocol/tip20/overview.mdx
@@ -130,7 +130,7 @@ TIP-20 supports an opt-in [reward distribution system](/protocol/tip20-rewards/o
 
 ### Currency Declaration
 
-A TIP-20 token can declare a currency identifier (e.g., `"USD"`, `"EUR"`) that identifies the real-world asset backing the token. This enables proper routing and pricing in Tempo's [Stablecoin DEX](/protocol/exchange). USD-denominated TIP-20 tokens can be used to pay transaction fees and serve as quote tokens in the DEX.
+A TIP-20 token can declare a currency identifier (e.g., `"USD"`, `"EUR"`) that identifies the real-world asset backing the token. This enables proper routing and pricing in Tempo's [Stablecoin DEX](/protocol/exchange). **Only `USD`-denominated stablecoins can be used to pay transaction fees on Tempo.** USD-denominated TIP-20 tokens also serve as quote tokens in the DEX.
 
 Stablecoin currency identifiers should be [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) three-letter currency codes. Common examples include:
 

--- a/src/pages/protocol/tip20/spec.mdx
+++ b/src/pages/protocol/tip20/spec.mdx
@@ -411,7 +411,7 @@ TIP-20 tokens cannot be sent to other TIP-20 token contract addresses. The imple
 Any attempt to transfer to a TIP-20 token address must revert with `InvalidRecipient`. This prevents accidental token loss by sending funds to token contracts instead of user accounts.
 
 ## Currencies and Quote Tokens
-Each TIP-20 token declares a currency identifier and a corresponding `quoteToken` used for pricing and routing in the Stablecoin DEX. Stablecoin currency identifiers should be [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) three-letter codes representing the underlying fiat currency (e.g., `"USD"`, `"EUR"`, `"GBP"`) — not the token's own symbol. The currency is set at token creation and **cannot be changed afterward**. Tokens with `currency == "USD"` must pair with a USD-denominated TIP-20 token.
+Each TIP-20 token declares a currency identifier and a corresponding `quoteToken` used for pricing and routing in the Stablecoin DEX. Stablecoin currency identifiers should be [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) three-letter codes representing the underlying fiat currency (e.g., `"USD"`, `"EUR"`, `"GBP"`) — not the token's own symbol. The currency is set at token creation and **cannot be changed afterward**. **Only tokens with `currency == "USD"` are eligible for paying transaction fees.** Tokens with `currency == "USD"` must pair with a USD-denominated TIP-20 token.
 
 Updating the quote token occurs in two phases:
 1. `setNextQuoteToken` stages a new quote token.


### PR DESCRIPTION
## Summary

Clarifies that TIP-20 `currency` field should use ISO 4217 three-letter codes (e.g., `USD`, `EUR`), not token symbols (e.g., not `USDC`).

## Motivation

Issuers have been setting currency to token symbols instead of the underlying fiat denomination. Since the currency code is immutable after creation, this causes issues with fee payment eligibility, DEX routing, and quote token pairing.

Thread: https://tempoxyz.slack.com/archives/C0A332FHV0A/p1770652624843139

## Changes

- `protocol/tip20/overview.mdx`: added ISO 4217 reference link, common currency codes table, do/don't examples table, immutability warning
- `protocol/tip20/spec.mdx`: clarified currency identifiers are ISO 4217 codes and immutable, updated `createToken` NatSpec
- `guide/issuance/create-a-stablecoin.mdx`: added warning callout before the `createToken` code example

## Testing

Content-only MDX changes — no code logic affected.