### PR TITLE
docs: fix transferFrom() spending limits inconsistency (TMPO2-39)

### DIFF
--- a/src/pages/protocol/transactions/AccountKeychain.mdx
+++ b/src/pages/protocol/transactions/AccountKeychain.mdx
@@ -273,8 +273,9 @@ Access Keys cannot escalate their own privileges because:
 - Keys with `enforceLimits == false` have unlimited spending (no limits checked)
 - Spending limits are enforced by the protocol internally calling `verify_and_update_spending()` during execution
 - Limits are per-TIP20 token and deplete as TIP20 tokens are spent
-- Spending limits only track TIP20 token transfers (via `transfer` and `transferWithMemo`) and approvals (via `approve`)
-- For approvals: only increases in approval amount count against the spending limit. This means approvals indirectly control `transferFrom` spending, since `transferFrom` requires a prior approval
+- Spending limits only track TIP20 `transfer()`, `transferWithMemo()`, `approve()`, and `startReward()` calls
+- `transferFrom()` is NOT subject to spending limits (it is gated only by the ERC-20 allowance mechanism)
+- For approvals: only increases in approval amount count against the spending limit
 - Non-TIP20 asset movements (ETH, NFTs) are not subject to spending limits
 - Root keys (`keyId == address(0)`) have no spending limits - the function returns immediately
 - Failed limit checks revert the entire transaction with `SpendingLimitExceeded`


### PR DESCRIPTION
## Summary

Fixes contradictory documentation about whether `transferFrom()` is subject to Access Key spending limits (audit finding TMPO2-39).

## Motivation

The Spending Limit Enforcement section in AccountKeychain.mdx said "approvals indirectly control `transferFrom` spending" — implying spending limits apply to `transferFrom()`. The Concepts section and the implementation both confirm `transferFrom()` does **not** deduct from spending limits.

## Changes

- Clarify that `transferFrom()` is NOT subject to spending limits (gated only by ERC-20 allowances)
- Add `startReward()` to the Spending Limit Enforcement tracked calls list (was already listed in the Concepts section and spec, but missing here)
- Remove misleading language about approvals "indirectly controlling transferFrom spending"

## Testing

Verified against implementation in `crates/precompiles/src/tip20/mod.rs` — `_transfer_from()` does not call `check_and_update_spending_limit()`.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770659716460929