### PR TITLE
docs: add mainnet credentials callout to RPC node guide

### DIFF
--- a/src/pages/guide/node/rpc.mdx
+++ b/src/pages/guide/node/rpc.mdx
@@ -2,6 +2,8 @@
 description: Set up and run a Tempo RPC node for API access. Download snapshots, configure systemd services, and monitor node health and sync status.
 ---
 
+import { Callout } from 'vocs'
+
 # Running an RPC Node
 
 RPC nodes provide API access to the Tempo network without participating in consensus.
@@ -19,9 +21,9 @@ tempo node \
   --http.api eth,net,web3,txpool,trace
 ```
 
-:::info
+<Callout type="info">
 For mainnet, you have to use the credentials in `--follow` that are issued to you by the Tempo team.
-:::
+</Callout>
 
 An RPC node running in follow mode is a **full node**. It fetches blocks from a trusted RPC endpoint, executes every transaction locally through the EVM, validates each block after execution, and stores complete block data with full state. The only trust assumption is block ordering: your node trusts the RPC endpoint to provide the correct sequence of blocks. All execution and validation happens locally on your machine.
 


### PR DESCRIPTION
## Summary
Adds an info callout to the "Running an RPC Node" page noting that mainnet requires credentials issued by the Tempo team for the `--follow` flag.

## Changes
- Added `:::info` callout in `src/pages/guide/node/rpc.mdx` after the Quick Start code block

## Context
Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770666462809179