### PR TITLE
docs: add Foundry troubleshooting for invariant tests with --fork-url

### DIFF
--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -301,4 +301,15 @@ The following flags are available for `cast` and `forge script` for Tempo-specif
 
 Ledger and Trezor wallets are not yet compatible with any `--tempo.*` option.
 
+## Troubleshooting
+
+### Invariant tests with `--fork-url`
+In some Foundry versions, invariant runs may stall when used with `--fork-url` / `--fork-block-number`.
+
+Workarounds:
+- Run invariants without forking, and use `--fork-url` only for non-invariant tests.
+- If you only need a quick sanity check, temporarily focus on non-invariant tests while forking.
+
+Upstream tracking: https://github.com/foundry-rs/foundry/issues/4656
+
 


### PR DESCRIPTION
Adds a short troubleshooting section about invariant runs stalling with --fork-url, with workarounds and a link to the upstream Foundry issue.

## Motivation
Tempo Foundry users may encounter invariant runs stalling when using `--fork-url`. This is an upstream Foundry issue and is currently not called out in the Tempo Foundry docs page.

## Solution
Added a short Troubleshooting section noting the issue, listing safe workarounds, and linking to the upstream tracking issue.

## PR Checklist
- [x] Added Documentation
- [ ] Added Tests
- [ ] Breaking changes
