### PR TITLE
docs: signatures produced for >v1.1.1

### DIFF
--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -52,7 +52,7 @@ docker logs tempo
 
 ## Verifying Releases
 
-All release artifacts are cryptographically signed starting after **v1.1.0**. We recommend verifying signatures before running any binary.
+All release artifacts are cryptographically signed starting after **v1.1.1**. We recommend verifying signatures before running any binary.
 
 ### Binary Signatures (GPG)
 


### PR DESCRIPTION
## Summary
Updates the installation docs to reflect that release signatures are produced starting after v1.1.1 (not v1.1.0).

## Changes
- Updated "Verifying Releases" section to say signatures start after v1.1.1

Thread: https://tempoxyz.slack.com/archives/C09KCGR4LQ4/p1770677150249639