### PR TITLE
docs: introduce attodollars and microdollars terminology in fee spec

### DIFF
--- a/src/pages/protocol/fees/spec-fee.mdx
+++ b/src/pages/protocol/fees/spec-fee.mdx
@@ -164,7 +164,7 @@ As of [TIP-1010](/protocol/tips/tip-1010), Tempo uses the following mainnet gas 
 | Total block gas limit | 500M gas |
 | General gas limit | 30M gas/block |
 
-A standard TIP-20 transfer (~50,000 gas) costs approximately 1,000 microdollars (0.1 cent / $0.001) at the target base fee.
+A standard TIP-20 transfer (~50,000 gas) costs approximately 1,000 microdollars (0.1 cent / $0.001) at the base fee.
 
 ### Removing validator preference
 


### PR DESCRIPTION
## Summary

- Replaces Ethereum-specific "gwei" and generic "USD per 10^18 gas" with Tempo's native economic terminology (**attodollars** and **microdollars**) in the fee specification
- Updates the "Fee units" section to define and use attodollars (10^-18 USD) and microdollars (10^-6 USD)
- Updates the "Gas Parameters" table to use attodollars instead of gwei
- Removes reference to "18 decimal places of ETH"

Companion to [tempoxyz/tempo#2333](https://github.com/tempoxyz/tempo/pull/2333) which introduces this terminology in the TIPs and Rust codebase.

## Terminology

- **Attodollars**: Gas price unit at 10^-18 USD precision (basefee is denominated in attodollars)
- **Microdollars**: TIP-20 token unit at 10^-6 USD precision (1 token unit = 1 microdollar)
- **Conversion**: attodollars / 10^12 = microdollars


Made with [Cursor](https://cursor.com)