### PR TITLE
docs: correct old testnet deprecation year to 2026

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -47,7 +47,7 @@ Whether you're new to stablecoins, ready to start building, or looking for partn
 
 ## Testnet Migration
 
-We've launched a new testnet to better align with our mainnet release candidate and provide faster feature release cycles. The old testnet will be deprecated on **March 8th, 2025**.
+We've launched a new testnet to better align with our mainnet release candidate and provide faster feature release cycles. The old testnet will be deprecated on **March 8th, 2026**.
 
 **What you need to do:**
 


### PR DESCRIPTION
The Testnet Migration paragraph in the docs' homepage currently states that the old testnet will be deprecated on March 8th, 2025.

This PR updates the date to March 8th, 2026 to reflect the correct timeline and avoid confusion.