### PR TITLE
docs: update commonware-consensus version references

### DIFF
--- a/src/pages/guide/node/validator.mdx
+++ b/src/pages/guide/node/validator.mdx
@@ -8,7 +8,7 @@ description: Configure and run a Tempo validator node. Generate signing keys, pa
 The management of the active validator set is currently permissioned by the Tempo team. If you are interested in becoming a validator, please [get in touch](mailto:partners@tempo.xyz) with the Tempo team.
 :::
 
-Validator nodes secure Tempo by validating blocks and transactions, then using [Threshold Simplex](https://docs.rs/commonware-consensus/0.0.61/commonware_consensus/threshold_simplex/index.html) to reach consensus. They distribute signing shares among themselves to collectively sign block approvals and finalizations.
+Validator nodes secure Tempo by validating blocks and transactions, then using [Threshold Simplex](https://docs.rs/commonware-consensus/latest/commonware_consensus/simplex/index.html#schemebls12381_threshold) to reach consensus. They distribute signing shares among themselves to collectively sign block approvals and finalizations.
 
 ## Cryptographic key hierarchy
 

--- a/src/pages/protocol/blockspace/consensus.mdx
+++ b/src/pages/protocol/blockspace/consensus.mdx
@@ -58,5 +58,5 @@ Treat finalized blocks as irreversible for settlement purposes. No additional co
 
 ## Further Reading
 
-- [Commonware Simplex Documentation](https://docs.rs/commonware-consensus/0.0.65/commonware_consensus/simplex/)
-- [Simplex with BLS12-381 Threshold Scheme](https://docs.rs/commonware-consensus/0.0.65/commonware_consensus/simplex/index.html#schemebls12381_threshold)
+- [Commonware Simplex Documentation](https://docs.rs/commonware-consensus/latest/commonware_consensus/simplex/)
+- [Simplex with BLS12-381 Threshold Scheme](https://docs.rs/commonware-consensus/latest/commonware_consensus/simplex/index.html#schemebls12381_threshold)


### PR DESCRIPTION
## Summary

Update outdated `commonware-consensus` documentation links.

## Changes

- `consensus.mdx`: update links from `0.0.65` to `/latest/`
- `validator.mdx`: update link from `0.0.61` and replace broken 
  `threshold_simplex` reference with `simplex`

## Context

Tempo's `Cargo.toml` uses `commonware-consensus = "2026.2.0"` but docs 
referenced much older versions. Additionally, `threshold_simplex` no longer 
exists as a standalone module — threshold BLS cryptography is now 
`scheme::bls12381_threshold` inside the `simplex` module, so the old link 
returned 404.