### PR TITLE
feat: add reusable Badge pill component

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,28 @@
+const variants = {
+  red: 'bg-red3 text-red11',
+  amber: 'bg-amber3 text-amber11',
+  green: 'bg-green3 text-green11',
+  blue: 'bg-accentTint text-accent',
+  violet: 'bg-violet3 text-violet11',
+  gray: 'bg-gray3 text-gray11',
+} as const
+
+type BadgeVariant = keyof typeof variants
+
+export function Badge({
+  variant = 'gray',
+  children,
+}: {
+  variant?: BadgeVariant
+  children: React.ReactNode
+}) {
+  return (
+    <span
+      className={`inline-flex h-[19px] items-center justify-center rounded-[30px] px-1.5 text-center font-medium text-[9px] uppercase leading-none tracking-[2%] ${variants[variant]}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+export default Badge

--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -2,6 +2,8 @@
 description: Timeline and details for Tempo network upgrades and important releases for node operators.
 ---
 
+import { Badge } from '../../../components/Badge'
+
 # Network Upgrades and Releases
 
 Tempo uses scheduled network upgrades to introduce protocol changes. Each upgrade goes through testnet activation before mainnet. This page also tracks important releases that node operators should be aware of.
@@ -12,7 +14,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| [v1.2.0](https://github.com/tempoxyz/tempo/releases/tag/v1.2.0) | Feb 13, 2026 | Mainnet only | Fixes validation bug rejecting transactions with gas limits above ~16.7M, blocking large contract deployments | 🔴 Required |
+| [v1.2.0](https://github.com/tempoxyz/tempo/releases/tag/v1.2.0) | Feb 13, 2026 | Mainnet only | Fixes validation bug rejecting transactions with gas limits above ~16.7M, blocking large contract deployments | <Badge variant="red">Required</Badge> |
 
 ---
 
@@ -24,7 +26,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 | **TIPs** | [TIP-1000: State Creation Cost Increase](https://docs.tempo.xyz/protocol/tips/tip-1000), [TIP-1009: Expiring Nonces](https://docs.tempo.xyz/protocol/tips/tip-1009), [TIP-1010: Mainnet Gas Parameters](https://docs.tempo.xyz/protocol/tips/tip-1010) |
 | **Testnet** | Feb 5, 2026 15:00 UTC (unix: 1770303600) — Release: [v1.1.0](https://github.com/tempoxyz/tempo/releases/tag/v1.1.0) |
 | **Mainnet** | Feb 12, 2026 15:00 UTC (unix: 1770908400) — Release: [v1.1.1](https://github.com/tempoxyz/tempo/releases/tag/v1.1.1) |
-| **Priority** | 🔴 Required |
+| **Priority** | <Badge variant="red">Required</Badge> |
 
 ---
 
@@ -34,4 +36,4 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 |---|---|
 | **Scope** | Initial mainnet launch |
 | **Mainnet** | Jan 16, 2026 (genesis) — Release: [v1.0.0](https://github.com/tempoxyz/tempo/releases/tag/v1.0.0) |
-| **Priority** | 🔴 Required |
+| **Priority** | <Badge variant="red">Required</Badge> |


### PR DESCRIPTION
## Summary
Adds a reusable `<Badge>` component and replaces emoji priority indicators on the network upgrades page.

## Changes
- New `src/components/Badge.tsx` — pill-style badge following the Demo component pattern (`rounded-[30px]`, 9px uppercase)
- Supports all Radix color variants: `red`, `amber`, `green`, `blue`, `violet`, `gray`
- Updates `network-upgrades.mdx` to use `<Badge variant="red">Required</Badge>` instead of 🔴 emoji

## Usage
```mdx
import { Badge } from '../../../components/Badge'

<Badge variant="red">Required</Badge>
<Badge variant="amber">Recommended</Badge>
<Badge variant="green">Optional</Badge>
```

Stacked on #108.

Prompted by: struong