### PR TITLE
fix: remove broken .mdx links, #TODO placeholders, and outdated deprecation date

### DIFF
--- a/src/pages/guide/use-accounts/embed-passkeys.mdx
+++ b/src/pages/guide/use-accounts/embed-passkeys.mdx
@@ -229,7 +229,7 @@ export const config = createConfig({
 
 Now that you have created your first passkey account, you can now:
 - learn the [Best Practices](#best-practices) below
-- follow a guide on how to [make a payment](#TODO), [create a stablecoin](#TODO), and [more](#TODO) with a passkey account.
+- explore additional guides for making payments and creating stablecoins with your passkey account.
 
 ::::
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -5,7 +5,7 @@ description: Explore Tempo's blockchain documentation, integration guides, and p
 import { Cards, Card } from 'vocs'
 
 :::warning
-**Testnet migration:** We've launched a new testnet. You'll need to update your RPC configuration and redeploy any contracts. The old testnet will be deprecated on March 8th. [See details below](#testnet-migration).
+**Testnet migration:** We've launched a new testnet. You'll need to update your RPC configuration and redeploy any contracts. The old testnet has been deprecated. [See details below](#testnet-migration).
 :::
 
 # Tempo [Documentation, integration guides, and protocol specifications]
@@ -47,7 +47,7 @@ Whether you're new to stablecoins, ready to start building, or looking for partn
 
 ## Testnet Migration
 
-We've launched a new testnet to better align with our mainnet release candidate and provide faster feature release cycles. The old testnet will be deprecated on **March 8th, 2025**.
+We've launched a new testnet to better align with our mainnet release candidate and provide faster feature release cycles. The old testnet has been deprecated.
 
 **What you need to do:**
 

--- a/src/pages/protocol/fees/spec-fee.mdx
+++ b/src/pages/protocol/fees/spec-fee.mdx
@@ -10,7 +10,7 @@ This spec lays out how fees work on Tempo, including how fees are calculated, wh
 
 ## Motivation
 
-On Tempo, users can pay gas fees in any [TIP-20](/protocol/tip20/spec) token whose currency is USD, as long as that stablecoin has sufficient liquidity on the enshrined [fee AMM](/protocol/fees/spec-fee-amm.mdx) against the token that the current validator wants to receive.
+On Tempo, users can pay gas fees in any [TIP-20](/protocol/tip20/spec) token whose currency is USD, as long as that stablecoin has sufficient liquidity on the enshrined [fee AMM](/protocol/fees/spec-fee-amm) against the token that the current validator wants to receive.
 
 In determining *which* token a user pays fees in, we want to maximize customizability (so that wallets or users can implement more sophisticated UX than is possible at the protocol layer), minimize surprise (particularly surprises in which a user pays fees in a stablecoin they did not expect to), and have sane default behavior so that users can begin using basic functions like payments even using wallets that are not customized for Tempo support.
 
@@ -42,11 +42,11 @@ The protocol executes the max fee deduction and refund atomically. If insufficie
 
 ## Fee payer
 
-Tempo supports *sponsored transactions* in which the `fee_payer` is a different address from the `tx.origin` of the transaction. This is supported by Tempo's [new transaction type](/protocol/transactions/spec-tempo-transaction.mdx), which has a `fee_payer_signature` field.
+Tempo supports *sponsored transactions* in which the `fee_payer` is a different address from the `tx.origin` of the transaction. This is supported by Tempo's [new transaction type](/protocol/transactions/spec-tempo-transaction), which has a `fee_payer_signature` field.
 
 If no `fee_payer_signature` is provided, then the `fee_payer` of the transaction is its sender (`tx.origin`).
 
-If the `fee_payer_signature` field is set, then it is used to derive the `fee_payer` for the transaction, as described in the [transaction spec](/protocol/transactions/spec-tempo-transaction.mdx).
+If the `fee_payer_signature` field is set, then it is used to derive the `fee_payer` for the transaction, as described in the [transaction spec](/protocol/transactions/spec-tempo-transaction).
 
 For purposes of [fee token preferences](#fee-token-preferences), the `fee_payer` is the account that chooses the fee token.
 
@@ -90,13 +90,13 @@ The protocol checks preferences at each of these levels, stopping at the first o
 
 * The token must be a TIP-20 token whose currency is USD.
 * The user must have sufficient balance in that token to pay the `gasLimit` on the transaction at the transaction's `gasPrice`.
-* There must be sufficient liquidity on the [fee AMM](/protocol/fees/spec-fee-amm.mdx), as discussed in that specification.
+* There must be sufficient liquidity on the [fee AMM](/protocol/fees/spec-fee-amm), as discussed in that specification.
 
 If no preference is specified at the transaction, account, or contract level, the protocol falls back to [pathUSD](#pathusd).
 
 ### Transaction level
 
-Tempo's [new transaction type](/protocol/transactions/spec-tempo-transaction.mdx), allows transactions to specify a `fee_token` on the transaction. This overrides any preferences set at the account, contract, or validator level.
+Tempo's [new transaction type](/protocol/transactions/spec-tempo-transaction), allows transactions to specify a `fee_token` on the transaction. This overrides any preferences set at the account, contract, or validator level.
 
 For [sponsored transactions](#fee-payer), the `tx.origin` address does not sign over the `fee_token` field (allowing the `fee_payer` to choose the fee token).
 
@@ -108,7 +108,7 @@ To set its preference, the account can call the `setUserToken` function on the F
 
 At this step, the protocol does one more check:
 
-* If the transaction is not a [Tempo transaction](/protocol/transactions/spec-tempo-transaction.mdx) *and* the transaction is a top-level call to the `setUserToken` function on the FeeManager, then the protocol checks the `token` argument to the function:
+* If the transaction is not a [Tempo transaction](/protocol/transactions/spec-tempo-transaction) *and* the transaction is a top-level call to the `setUserToken` function on the FeeManager, then the protocol checks the `token` argument to the function:
   * If that token is a TIP-20 whose currency is USD, that token is used as the fee token (unless the transaction specifies a `fee_token` at the [transaction level](#transaction-level)).
   * If that token is not a TIP-20 or its currency is not USD, the transaction is invalid.
 
@@ -122,14 +122,14 @@ If the top-level call of a transaction is to one of the following functions on a
 
 then that TIP-20 token is used as the user's fee token for that transaction (unless there is a preference specified at the [transaction](#transaction-level) or [account](#account-level) level).
 
-For [Tempo transactions](/protocol/transactions/spec-tempo-transaction.mdx), this rule applies only if _all_ top-level calls are to the same TIP-20 contract, and each such call is to one of the functions listed above, with `fee_payer == tx.origin`.
+For [Tempo transactions](/protocol/transactions/spec-tempo-transaction), this rule applies only if _all_ top-level calls are to the same TIP-20 contract, and each such call is to one of the functions listed above, with `fee_payer == tx.origin`.
 
 
 ### Stablecoin DEX contract
 
-If the top-level call of a transaction is to the [Stablecoin DEX](/protocol/exchange/spec.mdx) contract, the function being called is either `swapExactAmountIn` or `swapExactAmountOut`, and the `tokenIn` argument to that function is the address of a TIP-20 token for which the currency is USD, then the `tokenIn` argument is used as the user's fee token for the transaction (unless there is a preference specified at the [transaction](#transaction-level) or [account](#account-level) level).
+If the top-level call of a transaction is to the [Stablecoin DEX](/protocol/exchange/spec) contract, the function being called is either `swapExactAmountIn` or `swapExactAmountOut`, and the `tokenIn` argument to that function is the address of a TIP-20 token for which the currency is USD, then the `tokenIn` argument is used as the user's fee token for the transaction (unless there is a preference specified at the [transaction](#transaction-level) or [account](#account-level) level).
 
-For [Tempo transactions](/protocol/transactions/spec-tempo-transaction.mdx), this rule applies only if there is only one top-level call in the transaction.
+For [Tempo transactions](/protocol/transactions/spec-tempo-transaction), this rule applies only if there is only one top-level call in the transaction.
 
 ### pathUSD
 

--- a/src/pages/quickstart/verify-contracts.mdx
+++ b/src/pages/quickstart/verify-contracts.mdx
@@ -235,7 +235,7 @@ The `andantino` testnet (chain ID `42429`) has been deprecated. Use `moderato` (
 ## Troubleshooting
 
 :::tip
-If you encounter unexpected failures, you might be running an older version of Foundry/Forge, or you might not be running Tempo's Foundry fork. See the [Foundry setup guide](/sdk/foundry/index.mdx) for installation instructions.
+If you encounter unexpected failures, you might be running an older version of Foundry/Forge, or you might not be running Tempo's Foundry fork. See the [Foundry setup guide](/sdk/foundry) for installation instructions.
 :::
 
 ### Verification Failed


### PR DESCRIPTION
## Summary

- **Remove `.mdx` extensions from 10 internal links** in `spec-fee.mdx` and `verify-contracts.mdx` — Vocs routes use extensionless paths, so links like `/protocol/fees/spec-fee-amm.mdx` result in 404s. Changed to `/protocol/fees/spec-fee-amm`.
- **Replace 3 broken `#TODO` placeholder links** in `embed-passkeys.mdx` (line 232) — `[make a payment](#TODO)`, `[create a stablecoin](#TODO)`, and `[more](#TODO)` all point to non-existent anchors. Replaced with descriptive text until the target guides exist.
- **Update outdated testnet deprecation messaging** in `index.mdx` — The text says the old testnet "will be deprecated on March 8th, 2025" but that date has long passed. Updated to reflect the deprecation has already occurred.

## Files Changed

| File | Change |
|------|--------|
| `src/pages/protocol/fees/spec-fee.mdx` | Remove `.mdx` from 9 internal links |
| `src/pages/quickstart/verify-contracts.mdx` | Remove `.mdx` from 1 internal link |
| `src/pages/guide/use-accounts/embed-passkeys.mdx` | Replace 3 `#TODO` links with text |
| `src/pages/index.mdx` | Update outdated deprecation date (2 occurrences) |

## Note

The `vocs.config.ts` already has `checkDeadlinks: 'warn'` with a TODO comment acknowledging dead link issues — these fixes address several of those warnings.

## Test plan

- [ ] Verify all modified internal links resolve correctly on the docs site
- [ ] Confirm the embed-passkeys "Next Steps" section reads naturally without broken links
- [ ] Check that the index page testnet migration banner reflects current status

