### PR TITLE
docs: align faucet pages with consistent tabs and curl/cast examples

### DIFF
--- a/src/pages/guide/use-accounts/add-funds.mdx
+++ b/src/pages/guide/use-accounts/add-funds.mdx
@@ -6,52 +6,92 @@ mipd: true
 import * as Demo from '../../../components/guides/Demo.tsx'
 import * as Step from '../../../components/guides/steps'
 import * as Token from '../../../components/guides/tokens'
+import { Tabs, Tab } from 'vocs'
 
 # Add Funds to Your Balance
 
 Get test tokens to start building on Tempo testnet.
 
-## Direct Access
+<Tabs>
+  <Tab title="Fund your wallet">
 
-You can access the faucet directly here in the docs.
+<div className="h-4" />
 
-<Demo.Container name="Use the Faucet" footerVariant="balances" tokens={[Token.alphaUsd, Token.betaUsd, Token.thetaUsd]} balanceSource="wallet">
+Connect your wallet to receive test stablecoins directly.
+
+<div className="h-6"/>
+<Demo.Container name="Connect and fund your wallet" footerVariant="balances" tokens={[Token.pathUsd, Token.alphaUsd, Token.betaUsd, Token.thetaUsd]} balanceSource="wallet">
   <Step.ConnectWallet stepNumber={1} />
-  <Step.AddFundsToOthers stepNumber={2} />
+  <Step.AddFundsToWallet stepNumber={2} />
+  <Step.AddTokensToWallet stepNumber={3} />
+  <Step.SetFeeToken stepNumber={4} last />
 </Demo.Container>
 
+  </Tab>
+  <Tab title="Fund an address">
 
-## Testnet Faucet RPC
+<div className="h-4" />
+Send test stablecoins to any address.
 
-The public testnet also offers an RPC endpoint for requesting test tokens.
-The faucet endpoint is only available at the official Tempo testnet RPC endpoint.
+<div className="h-6"/>
+<Demo.Container name="Fund an address">
+  <Step.AddFundsToOthers stepNumber={1} last />
+</Demo.Container>
 
-Request test tokens using the `tempo_fundAddress` RPC method:
+  </Tab>
+  <Tab title="cURL request">
+
+<div className="h-4" />
+
+Request tokens programmatically via the [Tempo API](https://api.tempo.xyz/docs).
+
+<div className="h-4"/>
+
+```bash
+curl "https://api.tempo.xyz/actions/faucet\
+?chainId=42431\
+&address=<YOUR_ADDRESS>"
+```
+
+<div className="h-4"/>
+
+Replace `<YOUR_ADDRESS>` with a lowercase wallet address.
+
+  </Tab>
+  <Tab title="Cast RPC">
+
+<div className="h-4" />
+
+Request tokens using the `tempo_fundAddress` RPC method.
+
+<div className="h-4"/>
 
 ```bash
 cast rpc tempo_fundAddress <YOUR_ADDRESS> \
   --rpc-url https://rpc.moderato.tempo.xyz
 ```
 
+<div className="h-4"/>
+
 Replace `<YOUR_ADDRESS>` with your wallet address.
 
-## What You'll Receive
+  </Tab>
+</Tabs>
 
-The faucet provides test stablecoins:
+The faucet funds the following assets.
 
-- **pathUSD** - `0x20c0000000000000000000000000000000000000`
-- **AlphaUSD** - `0x20c0000000000000000000000000000000000001`
-- **BetaUSD** - `0x20c0000000000000000000000000000000000002`
-- **ThetaUSD** - `0x20c0000000000000000000000000000000000003`
-
-Each request drips a sufficient amount for testing and development.
+| Asset | Address |Amount|
+|-------|---------|----:|
+| [pathUSD](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000000) | `0x20c0000000000000000000000000000000000000` | `1M` |
+| [AlphaUSD](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000001) | `0x20c0000000000000000000000000000000000001` | `1M` |
+| [BetaUSD](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000002) | `0x20c0000000000000000000000000000000000002` | `1M` |
+| [ThetaUSD](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000003) | `0x20c0000000000000000000000000000000000003` | `1M` |
 
 ## Verify Your Balance
 
 After requesting tokens, verify your balance:
 
 ```bash
-# Check AlphaUSD balance
 cast erc20 balance 0x20c0000000000000000000000000000000000001 \
   <YOUR_ADDRESS> \
   --rpc-url https://rpc.moderato.tempo.xyz

--- a/src/pages/quickstart/faucet.mdx
+++ b/src/pages/quickstart/faucet.mdx
@@ -40,6 +40,43 @@ Send test stablecoins to any address.
 </Demo.Container>
 
   </Tab>
+  <Tab title="cURL request">
+
+<div className="h-4" />
+
+Request tokens programmatically via the [Tempo API](https://api.tempo.xyz/docs).
+
+<div className="h-4"/>
+
+```bash
+curl "https://api.tempo.xyz/actions/faucet\
+?chainId=42431\
+&address=<YOUR_ADDRESS>"
+```
+
+<div className="h-4"/>
+
+Replace `<YOUR_ADDRESS>` with a lowercase wallet address.
+
+  </Tab>
+  <Tab title="Cast RPC">
+
+<div className="h-4" />
+
+Request tokens using the `tempo_fundAddress` RPC method.
+
+<div className="h-4"/>
+
+```bash
+cast rpc tempo_fundAddress <YOUR_ADDRESS> \
+  --rpc-url https://rpc.moderato.tempo.xyz
+```
+
+<div className="h-4"/>
+
+Replace `<YOUR_ADDRESS>` with your wallet address.
+
+  </Tab>
 </Tabs>
 
 The faucet funds the following assets.


### PR DESCRIPTION
Aligns the two faucet pages (`/quickstart/faucet` and `/guide/use-accounts/add-funds`) to have consistent components and content.

### Changes
- **Consistent 4-tab layout**: Both pages now have *Fund your wallet*, *Fund an address*, *cURL request*, and *Cast RPC* tabs
- **cURL tab**: Added `curl` example hitting `api.tempo.xyz/actions/faucet` (testnet chainId 42431 by default)
- **Cast RPC tab**: Added `cast rpc tempo_fundAddress` example
- **Aligned components**: add-funds page now uses `AddFundsToWallet` + `AddTokensToWallet` + `SetFeeToken` steps (matching faucet page)
- **Added pathUSD**: Was missing from add-funds token list
- **Asset table**: Added to add-funds page for consistency
- **Consistent naming**: Demo.Container names and tab titles match across both pages