### PR TITLE
docs: mark RPC ports as optional internal for validators

### DIFF
--- a/src/pages/guide/node/system-requirements.mdx
+++ b/src/pages/guide/node/system-requirements.mdx
@@ -56,6 +56,6 @@ We do not recommend using a cloud firewall / NAT gateway as it can introduce add
 |------|----------|---------|--------|
 | 30303 | TCP/UDP | Execution P2P | Public |
 | 8000 | TCP | Consensus P2P | Validators only |
-| 8545 | TCP | HTTP RPC | Optional |
-| 8546 | TCP | WebSocket RPC | Optional |
+| 8545 | TCP | HTTP RPC | Optional (internal for validators) |
+| 8546 | TCP | WebSocket RPC | Optional (internal for validators) |
 | 9000 | TCP | Metrics | Internal |


### PR DESCRIPTION
Updates ports 8545 (HTTP RPC) and 8546 (WebSocket RPC) to indicate they are optional and internal for validators.

Prompted by: zygis