### PR TITLE
docs: add glibc minimum version warning for Linux prebuilt binary

### DIFF
--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -36,6 +36,9 @@ source $HOME/.cargo/env
 cargo install --git https://github.com/tempoxyz/tempo.git tempo --root /usr/local
 tempo --version
 ```
+> ⚠️ Linux Requirement: The prebuilt binaries require glibc ≥ 2.38.
+> Ubuntu 22.04 ships with glibc 2.35 and is NOT supported with the prebuilt binary.
+> Use Ubuntu 24.04+ or build from source instead.
 
 ## Docker
 


### PR DESCRIPTION
What: Added a warning about the minimum glibc ≥ 2.38 requirement 
for prebuilt Linux binaries.

Why: Users on Ubuntu 22.04 encounter cryptic errors with no 
guidance in the docs. This warning helps them avoid confusion.