### PR TITLE
docs: remove andantino deprecation callouts

### DIFF
--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -14,7 +14,6 @@ The versions across networks may not be compatible, as such, please consult the 
 |----------|---------|
 | Mainnet | v1.1.0 |
 | Moderato (Testnet) | v1.1.0 |
-| Andantino (Deprecated Testnet) | v0.8.2 |
 
 ## Pre-built Binary
 

--- a/src/pages/guide/node/validator.mdx
+++ b/src/pages/guide/node/validator.mdx
@@ -91,10 +91,6 @@ The telemetry endpoint does **not** collect any ambient information about the ho
 
 The data is strictly limited to the node's own operational metrics and logs.
 
-:::info[Testnet Chain]
-The `andantino` chainspec is deprecated. New validators should use `--chain moderato`.
-:::
-
 The notable difference between RPC nodes and validator nodes is the omission of the `--follow` argument and the addition of the `--consensus.signing-key` and `--consensus.fee-recipient` arguments. The fee recipient is the address that will receive transaction fees in your validators' proposed blocks.
 
 Once your node is up, it may not start syncing immediately. This is because your node might not be part of the active set. In most cases, your validator will enter the active set in under 6 hours after the on-chain addition of the validator identity.

--- a/src/pages/quickstart/verify-contracts.mdx
+++ b/src/pages/quickstart/verify-contracts.mdx
@@ -229,9 +229,6 @@ View the full API documentation at [contracts.tempo.xyz/docs](https://contracts.
 | Tempo Testnet (Moderato) | `42431` |
 | Tempo Devnet | `31318` |
 
-:::info
-The `andantino` testnet (chain ID `42429`) has been deprecated. Use `moderato` (chain ID `42431`) for testnet development.
-:::
 ## Troubleshooting
 
 :::tip


### PR DESCRIPTION
## Summary
Removes all Andantino deprecation callouts from docs since the testnet is being fully sunset.

## Changes
- Removed deprecation info box from `verify-contracts.mdx`
- Removed Andantino row from version table in `installation.mdx`
- Removed deprecated chainspec callout from `validator.mdx`

Prompted by: goksu