### PR TITLE
docs: add Token List step to issuance guide

### DIFF
--- a/src/pages/guide/issuance/create-a-stablecoin.mdx
+++ b/src/pages/guide/issuance/create-a-stablecoin.mdx
@@ -284,6 +284,7 @@ export const config = createConfig({
 ### Next steps
 
 Now that you have created your first stablecoin, you can now:
+- [Add your token to the Token List](/quickstart/tokenlist#adding-a-new-token) so it appears in wallets, explorers, and other apps on Tempo
 - learn the [Best Practices](#best-practices) below
 - follow a guide on how to [mint](/guide/issuance/mint-stablecoins) and [more](/guide/issuance/manage-stablecoin) with your stablecoin.
 


### PR DESCRIPTION
## Summary
Adds a step in the "Create a Stablecoin" guide's Next Steps section directing issuers to add their token metadata to the Token List after deploying.

## Changes
- Added Token List link to the Next Steps in `guide/issuance/create-a-stablecoin`, pointing to `/quickstart/tokenlist#adding-a-new-token`

Co-Authored-By: struong <10735730+struong@users.noreply.github.com>

Prompted by: struong