### PR TITLE
docs: broaden TIP-20 description from stablecoins to all tokens

### DIFF
--- a/src/pages/protocol/tip20/overview.mdx
+++ b/src/pages/protocol/tip20/overview.mdx
@@ -6,9 +6,9 @@ import { Cards, Card } from 'vocs'
 
 # TIP-20 Token Standard
 
-TIP-20 is Tempo's native token standard for stablecoins and payment tokens. TIP-20 is designed for stablecoin payments, and is the foundation for many token-related functions on Tempo including transaction fees, payment lanes, DEX quote tokens, and optimized routing for DEX liquidity on Tempo.
+TIP-20 is Tempo's native token standard for stablecoins and payment tokens. TIP-20 is designed for payments, and is the foundation for many token-related functions on Tempo including transaction fees, payment lanes, DEX quote tokens, and optimized routing for DEX liquidity on Tempo.
 
-All TIP-20 tokens are created by interacting with the [TIP-20 Factory contract](/protocol/tip20/spec#tip20factory), calling the `createToken` function. If you're issuing a stablecoin on Tempo, we **strongly recommend** using the TIP-20 standard. Learn more about the benefits, or follow the guide on issuance [here](/guide/issuance).
+All TIP-20 tokens are created by interacting with the [TIP-20 Factory contract](/protocol/tip20/spec#tip20factory), calling the `createToken` function. If you're issuing a token on Tempo, we **strongly recommend** using the TIP-20 standard. Learn more about the benefits, or follow the guide on issuance [here](/guide/issuance).
 
 ## Benefits & Features of TIP-20 Tokens
 


### PR DESCRIPTION
Two wording changes in the TIP-20 overview:

- "designed for stablecoin payments" → "designed for payments"
- "If you're issuing a stablecoin on Tempo" → "If you're issuing a token on Tempo"

Prompted by: dan