### PR TITLE
fix: remove stale testnet migration banner (deadline was March 2025)

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -4,10 +4,6 @@ description: Explore Tempo's blockchain documentation, integration guides, and p
 
 import { Cards, Card } from 'vocs'
 
-:::warning
-**Testnet migration:** We've launched a new testnet. You'll need to update your RPC configuration and redeploy any contracts. The old testnet will be deprecated on March 8th. [See details below](#testnet-migration).
-:::
-
 # Tempo [Documentation, integration guides, and protocol specifications]
 
 ## Welcome to Tempo! 
@@ -43,17 +39,5 @@ Whether you're new to stablecoins, ready to start building, or looking for partn
     icon="lucide:mail"
     title="Get In Touch"
   />
-</Cards>
 
-## Testnet Migration
-
-We've launched a new testnet to better align with our mainnet release candidate and provide faster feature release cycles. The old testnet will be deprecated on **March 8th, 2025**.
-
-**What you need to do:**
-
-1. **Update your RPC URL** to `https://rpc.moderato.tempo.xyz`
-2. **Update your chain ID** to `42431`
-3. **Redeploy any contracts** to the new testnet
-4. **Reset any databases or indexers** that depend on old testnet data
-
-See [Connection Details](/quickstart/connection-details#direct-connection-details) for the full configuration.
+> ℹ️ **Current Testnet:** The active testnet is `moderato`. Use RPC `https://rpc.moderato.tempo.xyz` and chain ID `42431`. See [Connection Details](/quickstart/connection-details) for full config.


### PR DESCRIPTION
What:
Removes the outdated testnet migration banner on the homepage.
The March 8th, 2025 deprecation deadline has passed (~1 year ago).

 Why:
New developers landing on the docs see an urgent migration warning
for a deadline that passed a year ago confusing and erodes trust
in the docs. The moderato testnet is now the current active testnet.

:Changes
- Removed stale migration banner from index.mdx
- Removed the full Testnet Migration section
- Added a clean current testnet info note with RPC and chain ID