### PR TITLE
docs: fix chain transport keys and clean up passkey guide

### DIFF
--- a/src/pages/guide/issuance/create-a-stablecoin.mdx
+++ b/src/pages/guide/issuance/create-a-stablecoin.mdx
@@ -77,7 +77,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -138,7 +138,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -206,7 +206,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -274,7 +274,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```

--- a/src/pages/guide/issuance/distribute-rewards.mdx
+++ b/src/pages/guide/issuance/distribute-rewards.mdx
@@ -85,7 +85,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -145,7 +145,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -198,7 +198,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```

--- a/src/pages/guide/issuance/manage-stablecoin.mdx
+++ b/src/pages/guide/issuance/manage-stablecoin.mdx
@@ -82,7 +82,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -161,7 +161,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -274,7 +274,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -345,7 +345,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -454,7 +454,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -534,7 +534,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -608,7 +608,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```

--- a/src/pages/guide/issuance/mint-stablecoins.mdx
+++ b/src/pages/guide/issuance/mint-stablecoins.mdx
@@ -85,7 +85,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -188,7 +188,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -347,7 +347,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```

--- a/src/pages/guide/issuance/use-for-fees.mdx
+++ b/src/pages/guide/issuance/use-for-fees.mdx
@@ -209,7 +209,7 @@ export const config = createConfig({
     keyManager: KeyManager.localStorage(),
   })],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```

--- a/src/pages/guide/stablecoin-dex/managing-fee-liquidity.mdx
+++ b/src/pages/guide/stablecoin-dex/managing-fee-liquidity.mdx
@@ -67,7 +67,7 @@ export const config = createConfig({
   chains: [tempoModerato],
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -135,7 +135,7 @@ export const config = createConfig({
   chains: [tempoModerato],
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -210,7 +210,7 @@ export const config = createConfig({
   chains: [tempoModerato],
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -297,7 +297,7 @@ export const config = createConfig({
   chains: [tempoModerato],
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -367,7 +367,7 @@ export const config = createConfig({
   chains: [tempoModerato],
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -435,7 +435,7 @@ export const config = createConfig({
   chains: [tempoModerato],
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```

--- a/src/pages/guide/use-accounts/connect-to-wallets.mdx
+++ b/src/pages/guide/use-accounts/connect-to-wallets.mdx
@@ -51,7 +51,7 @@ export const config = createConfig({
   connectors: [metaMask()], // [!code ++]
   multiInjectedProviderDiscovery: true, // [!code ++]
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -112,7 +112,7 @@ export const config = createConfig({
   connectors: [metaMask()], // [!code ++]
   multiInjectedProviderDiscovery: true, // [!code ++]
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -172,7 +172,7 @@ export const config = createConfig({
   connectors: [metaMask()], // [!code ++]
   multiInjectedProviderDiscovery: true, // [!code ++]
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -249,7 +249,7 @@ export const config = createConfig({
   connectors: [metaMask()], // [!code ++]
   multiInjectedProviderDiscovery: true, // [!code ++]
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```

--- a/src/pages/guide/use-accounts/embed-passkeys.mdx
+++ b/src/pages/guide/use-accounts/embed-passkeys.mdx
@@ -58,7 +58,7 @@ export const config = createConfig({
   })], // [!code ++]
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -140,7 +140,7 @@ export const config = createConfig({
   })], // [!code ++]
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -218,7 +218,7 @@ export const config = createConfig({
   })], // [!code ++]
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```
@@ -229,21 +229,17 @@ export const config = createConfig({
 
 Now that you have created your first passkey account, you can now:
 - learn the [Best Practices](#best-practices) below
-- follow a guide on how to [make a payment](#TODO), [create a stablecoin](#TODO), and [more](#TODO) with a passkey account.
+- follow a guide on how to [send a payment](/guide/payments/send-a-payment), [create a stablecoin](/guide/issuance/create-a-stablecoin), and [execute swaps](/guide/stablecoin-dex/executing-swaps) with a passkey account.
 
 ::::
 
-{/* 
-
-TODO: note on public key retention with credentialId -> pubKey KV service.
-
-## Notes for Production
-
-### Public Key Retention
-
- */}
-
 ## Best Practices
+
+### Use a Remote Key Manager in Production
+
+`KeyManager.localStorage()` is useful for local development, but production applications should persist credential-to-public-key mappings on a backend service.
+
+Use [`KeyManager.http`](https://wagmi.sh/tempo/keyManagers/http) with your API so users can recover and continue using their passkey account across browser storage resets and device changes.
 
 ### Loading State
 

--- a/src/pages/sdk/typescript/server/handler.keyManager.mdx
+++ b/src/pages/sdk/typescript/server/handler.keyManager.mdx
@@ -36,7 +36,7 @@ export const config = createConfig({
   ],
   chains: [tempoModerato],
   transports: {
-    [tempo.id]: http(),
+    [tempoModerato.id]: http(),
   },
 })
 ```


### PR DESCRIPTION
## Summary
- fix Wagmi snippet transport keys to use `tempoModerato.id` where snippets configure `tempoModerato`
- update `embed-passkeys` next steps to point to real guides instead of placeholder `#TODO` links
- replace unfinished TODO comment with production guidance for remote key management

## Why
These docs snippets are frequently copy/pasted. Using `[tempo.id]` while configuring `tempoModerato` is confusing and can lead to setup mistakes. The passkey guide also exposed unresolved TODO links/text in a user-facing page.

## Validation
- `pnpm check`
- `pnpm check:types`
