### PR TITLE
docs: update moderato and mainnet node versions to v1.4.0

### DIFF
--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -12,8 +12,8 @@ The versions across networks may not be compatible, as such, please consult the 
 
 | Network  | Version |
 |----------|---------|
-| Mainnet | v1.1.0 |
-| Moderato (Testnet) | v1.1.0 |
+| Mainnet | v1.4.0 |
+| Moderato (Testnet) | v1.4.0 |
 | Andantino (Deprecated Testnet) | v0.8.2 |
 
 ## Pre-built Binary


### PR DESCRIPTION
## Summary
Update the node installation page versions table — both Mainnet and Moderato (Testnet) now point to v1.4.0.

## Changes
- Updated Mainnet version from v1.1.0 → v1.4.0
- Updated Moderato version from v1.1.0 → v1.4.0

Prompted by: zygis