### PR TITLE
docs: time-gate andantino deprecation callouts with ShowUntil component

### DIFF
--- a/src/components/ShowUntil.tsx
+++ b/src/components/ShowUntil.tsx
@@ -1,0 +1,16 @@
+const Deadlines = {
+  AndantinoDeprecatedAt: 1773064800000,
+} as const
+
+type Deadline = keyof typeof Deadlines
+
+export function ShowUntil({
+  deadline,
+  children,
+}: {
+  deadline: Deadline
+  children: React.ReactNode
+}) {
+  if (Date.now() > Deadlines[deadline]) return null
+  return <>{children}</>
+}

--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -2,6 +2,8 @@
 description: Install Tempo node using pre-built binaries, build from source with Rust, or run with Docker. Get started in minutes with tempoup.
 ---
 
+import { ShowUntil } from '../../../components/ShowUntil'
+
 # Installation
 
 We provide three different installation paths - installing a pre-built binary, building from source or using our provided Docker image.
@@ -14,7 +16,11 @@ The versions across networks may not be compatible, as such, please consult the 
 |----------|---------|
 | Mainnet | v1.1.0 |
 | Moderato (Testnet) | v1.1.0 |
+<ShowUntil deadline="AndantinoDeprecatedAt">
+
 | Andantino (Deprecated Testnet) | v0.8.2 |
+
+</ShowUntil>
 
 ## Pre-built Binary
 

--- a/src/pages/guide/node/validator.mdx
+++ b/src/pages/guide/node/validator.mdx
@@ -2,6 +2,8 @@
 description: Configure and run a Tempo validator node. Generate signing keys, participate in DKG ceremonies, and troubleshoot consensus issues.
 ---
 
+import { ShowUntil } from '../../../components/ShowUntil'
+
 # Running a validator node
 
 :::info
@@ -91,9 +93,11 @@ The telemetry endpoint does **not** collect any ambient information about the ho
 
 The data is strictly limited to the node's own operational metrics and logs.
 
+<ShowUntil deadline="AndantinoDeprecatedAt">
 :::info[Testnet Chain]
 The `andantino` chainspec is deprecated. New validators should use `--chain moderato`.
 :::
+</ShowUntil>
 
 The notable difference between RPC nodes and validator nodes is the omission of the `--follow` argument and the addition of the `--consensus.signing-key` and `--consensus.fee-recipient` arguments. The fee recipient is the address that will receive transaction fees in your validators' proposed blocks.
 

--- a/src/pages/quickstart/verify-contracts.mdx
+++ b/src/pages/quickstart/verify-contracts.mdx
@@ -3,6 +3,8 @@ title: Contract Verification
 description: Verify your smart contracts on Tempo using contracts.tempo.xyz. Sourcify-compatible verification with Foundry integration.
 ---
 
+import { ShowUntil } from '../../components/ShowUntil'
+
 # Contract Verification
 
 Verify your smart contracts on Tempo using [contracts.tempo.xyz](https://contracts.tempo.xyz), a Sourcify-compatible contract verification service. Verified contracts display source code and ABI in the [Tempo Explorer](https://explore.tempo.xyz), making it easier for users to interact with your contracts.
@@ -229,9 +231,11 @@ View the full API documentation at [contracts.tempo.xyz/docs](https://contracts.
 | Tempo Testnet (Moderato) | `42431` |
 | Tempo Devnet | `31318` |
 
+<ShowUntil deadline="AndantinoDeprecatedAt">
 :::info
 The `andantino` testnet (chain ID `42429`) has been deprecated. Use `moderato` (chain ID `42431`) for testnet development.
 :::
+</ShowUntil>
 ## Troubleshooting
 
 :::tip


### PR DESCRIPTION
Instead of fully removing the callouts, wrap them in a ShowUntil component
that conditionally renders based on a deadline timestamp. The content
auto-hides after March 9, 2026 14:00 UTC without redeployment.

Closes tempoxyz/docs#127

Amp-Thread-ID: https://ampcode.com/threads/T-019cc4a3-5bd1-7662-a396-d10f59fab2c0
Co-authored-by: Amp <amp@ampcode.com>
