### PR TITLE
Fix: Add missing navigation links on Developer Tools page

### DIFF
--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -38,6 +38,7 @@ Integrating with Tempo is easy by leveraging services provided by our infrastruc
     to="#node-infrastructure"
     icon="lucide:server"
     title="Node Infrastructure"
+    Security & Compliance Issuance
   />
   <Card
     description="Build on Tempo with official SDKs for TypeScript, Go, Foundry, and Rust"


### PR DESCRIPTION
Two sections exist on the Developer Tools page but are completely missing from the top navigation block 
Security & Compliance (Blockaid, Chainalysis) and Issuance (Brale). This makes them invisible to anyone scanning the page from the top. Added the two missing anchor links to fix this.