### PR TITLE
chore: remove thirdweb from developer tools page

### DIFF
--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -152,12 +152,6 @@ You can get started now. Simply [create](https://docs.privy.io/wallets/wallets/c
 Check out Privy's [example](https://github.com/privy-io/examples/tree/main/examples/privy-next-tempo) peer-to-peer payments app that uses Tempo transaction memos.
 :::
 
-### thirdweb
-
-[thirdweb](https://thirdweb.com) provides a full-stack developer platform for building modern onchain applications. Developers can create wallets, deploy tokens, use blockchain-native AI tools, and integrate native internet payments—all with built-in support for Tempo. Access the Tempo Testnet via the [thirdweb dashboard](https://thirdweb.com/tempo-testnet) and explore tooling in the [Thirdweb developer docs](https://portal.thirdweb.com).
-
-Try features live in the [thirdweb Playground](https://playground.thirdweb.com) and create an account by signing up [here](https://thirdweb.com/login).
-
 ### Turnkey
 
 [Turnkey](https://www.turnkey.com) provides programmable key management and non-custodial wallet infrastructure for applications that need granular signing policies and automated transaction flows. With Turnkey, developers can securely sign Tempo transactions, automate wallet operations, and build custom logic around how keys are used.


### PR DESCRIPTION
Removes Thirdweb section from the Developer Tools documentation page.

Prompted by: josh