### PR TITLE
feat: add Google Analytics (gtag.js)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 INDEXSUPPLY_API_KEY=
 SLACK_FEEDBACK_WEBHOOK=     # e.g. https://hooks.slack.com/services/...
 VITE_BASE_URL=              # e.g. https://docs.tempo.xyz
+VITE_GA_MEASUREMENT_ID=
 VITE_POSTHOG_HOST=
 VITE_POSTHOG_KEY=
 VITE_TEMPO_ENV=             # testnet|devnet|localnet

--- a/biome.json
+++ b/biome.json
@@ -60,6 +60,16 @@
   },
   "overrides": [
     {
+      "includes": ["vocs.config.tsx"],
+      "linter": {
+        "rules": {
+          "security": {
+            "noDangerouslySetInnerHtml": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["env.d.ts"],
       "linter": {
         "rules": {

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -1,6 +1,8 @@
 import { Changelog, defineConfig, McpSource } from 'vocs/config'
 import { createFeedbackAdapter } from './src/lib/feedback-adapter'
 
+const gaMeasurementId = process.env.VITE_GA_MEASUREMENT_ID
+
 const baseUrl = (() => {
   if (URL.canParse(process.env.VITE_BASE_URL)) return process.env.VITE_BASE_URL
   // VERCEL_BRANCH_URL is the stable URL for the branch (e.g., next.docs.tempo.xyz)
@@ -13,6 +15,19 @@ const baseUrl = (() => {
 })()
 
 export default defineConfig({
+  head: gaMeasurementId ? (
+    <>
+      <script
+        async
+        src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}
+      />
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${gaMeasurementId}');`,
+        }}
+      />
+    </>
+  ) : undefined,
   changelog: Changelog.github({ prereleases: true, repo: 'tempoxyz/tempo' }),
   // TODO: Set back to true once tempoxyz/tempo#tip-1011 dead link is fixed
   checkDeadlinks: 'warn',


### PR DESCRIPTION
Adds Google Analytics gtag snippet to the static HTML `<head>` via Vocs config so Google's verification crawler can detect it.

- Measurement ID sourced from `VITE_GA_MEASUREMENT_ID` env var
- No-ops when the env var is not set

**To activate:** set `VITE_GA_MEASUREMENT_ID` in Vercel environment variables.