### PR TITLE
fix: revert vocs.config.tsx to .ts to fix SSR 500 errors

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -60,7 +60,7 @@
   },
   "overrides": [
     {
-      "includes": ["vocs.config.tsx"],
+      "includes": ["vocs.config.ts"],
       "linter": {
         "rules": {
           "security": {

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,3 +1,4 @@
+import { createElement, Fragment } from 'react'
 import { Changelog, defineConfig, McpSource } from 'vocs/config'
 import { createFeedbackAdapter } from './src/lib/feedback-adapter'
 
@@ -15,19 +16,21 @@ const baseUrl = (() => {
 })()
 
 export default defineConfig({
-  head: gaMeasurementId ? (
-    <>
-      <script
-        async
-        src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}
-      />
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${gaMeasurementId}');`,
-        }}
-      />
-    </>
-  ) : undefined,
+  head: gaMeasurementId
+    ? createElement(
+        Fragment,
+        null,
+        createElement('script', {
+          async: true,
+          src: `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`,
+        }),
+        createElement('script', {
+          dangerouslySetInnerHTML: {
+            __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${gaMeasurementId}');`,
+          },
+        }),
+      )
+    : undefined,
   changelog: Changelog.github({ prereleases: true, repo: 'tempoxyz/tempo' }),
   // TODO: Set back to true once tempoxyz/tempo#tip-1011 dead link is fixed
   checkDeadlinks: 'warn',


### PR DESCRIPTION
## Problem

docs.tempo.xyz is returning 500 errors on every page since PR #150 merged.

The Vocs SSR bundle hardcodes an import to `dist/server/vocs.config.js`. When the source file is `.tsx`, Vite outputs it differently, causing `ERR_MODULE_NOT_FOUND` at runtime.

## Fix

- Revert `vocs.config.tsx` → `vocs.config.ts`
- Replace JSX with `React.createElement` calls for the gtag `head` config (since `.ts` files can't contain JSX)
- Update `biome.json` override to match the new filename

## Impact

This should immediately unblock the production site once merged and deployed.