### PR TITLE
fix: load env vars into process.env for Google Analytics

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,18 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import react from '@vitejs/plugin-react'
 import { Instance } from 'prool'
-import { defineConfig, type Plugin } from 'vite'
+import { defineConfig, loadEnv, type Plugin } from 'vite'
 import { vocs } from 'vocs/vite'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [syncTips(), vocs(), react(), tempoNode()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  for (const key of Object.keys(env)) {
+    if (!(key in process.env)) process.env[key] = env[key]
+  }
+  return {
+    plugins: [syncTips(), vocs(), react(), tempoNode()],
+  }
 })
 
 function tempoNode(): Plugin {


### PR DESCRIPTION
## Problem

Google Analytics gtag.js is not appearing on docs.tempo.xyz despite `VITE_GA_MEASUREMENT_ID` being set in Vercel env vars.

The `vocs.config.ts` reads `process.env.VITE_GA_MEASUREMENT_ID` at the top level, but when the `vocs()` Vite plugin loads this config during initialization, `VITE_*` prefixed env vars haven't been populated into `process.env` yet. The `VERCEL_*` vars work because those are OS-level env vars injected by Vercel's build runner—not Vite-managed env vars.

## Fix

Use Vite's `loadEnv()` in `vite.config.ts` to populate `process.env` with all env vars before the `vocs()` plugin initializes. This matches the pattern already used in the [mpp site's vite.config.ts](https://github.com/tempoxyz/mpp/blob/main/vite.config.ts#L70-L74), where GA works correctly.

## Changes

- `vite.config.ts`: Switch from static `defineConfig({})` to function form `defineConfig(({ mode }) => {})`, call `loadEnv()`, and copy env vars into `process.env`