### PR TITLE
fix: use Vite plugin for Google Analytics (vocs v2 compat)

### DIFF
--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect } from 'react'
+
+declare global {
+  interface Window {
+    dataLayer: unknown[]
+    gtag: (...args: unknown[]) => void
+  }
+}
+
+function GoogleAnalyticsInit({ id }: { id: string }) {
+  useEffect(() => {
+    if (typeof window.gtag !== 'undefined') return
+
+    window.dataLayer = window.dataLayer || []
+    window.gtag = function gtag() {
+      // biome-ignore lint/complexity/noArguments: gtag API requires arguments object
+      window.dataLayer.push(arguments)
+    }
+    window.gtag('js', new Date())
+    window.gtag('config', id)
+
+    const script = document.createElement('script')
+    script.async = true
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${id}`
+    document.head.appendChild(script)
+  }, [id])
+
+  return null
+}
+
+export default function GoogleAnalytics() {
+  const id = import.meta.env.VITE_GA_MEASUREMENT_ID
+  if (!id) return null
+  return <GoogleAnalyticsInit id={id} />
+}

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -4,6 +4,7 @@ import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/react'
 import type React from 'react'
 import { Toaster } from 'sonner'
+import GoogleAnalytics from '../components/GoogleAnalytics'
 import PostHogSetup from '../components/PostHogSetup'
 
 export default function Layout(
@@ -29,6 +30,7 @@ export default function Layout(
       />
       <SpeedInsights />
       <Analytics />
+      <GoogleAnalytics />
       <PostHogSetup />
     </>
   )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,31 +12,9 @@ export default defineConfig(({ mode }) => {
     if (!(key in process.env)) process.env[key] = env[key]
   }
   return {
-    plugins: [googleAnalytics(), syncTips(), vocs(), react(), tempoNode()],
+    plugins: [syncTips(), vocs(), react(), tempoNode()],
   }
 })
-
-function googleAnalytics(): Plugin {
-  const id = process.env.VITE_GA_MEASUREMENT_ID
-  return {
-    name: 'google-analytics',
-    transformIndexHtml() {
-      if (!id) return []
-      return [
-        {
-          tag: 'script',
-          attrs: { async: true, src: `https://www.googletagmanager.com/gtag/js?id=${id}` },
-          injectTo: 'head',
-        },
-        {
-          tag: 'script',
-          children: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${id}');`,
-          injectTo: 'head',
-        },
-      ]
-    },
-  }
-}
 
 function tempoNode(): Plugin {
   return {


### PR DESCRIPTION
## Problem

Google Analytics gtag.js was not appearing on docs.tempo.xyz despite `VITE_GA_MEASUREMENT_ID` being correctly set in Vercel env vars.

This stems from using a `head` config which is not available in vocv2