### PR TITLE
Add Windows WSL installation guide for Foundry

### DIFF
--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -22,7 +22,19 @@ Install regular `foundryup`:
 
 ```bash
 curl -L https://foundry.paradigm.xyz | bash
+``:::tip Windows Users
+The command above does not work on Windows. You need to use WSL (Windows Subsystem for Linux) first.
+
+1. Open PowerShell as Administrator and run:
+```bash
+wsl --install
 ```
+2. Restart your computer when prompted
+3. Open **Ubuntu** from the Start menu
+4. Now run the curl command above inside Ubuntu — it will work correctly
+
+> The verification warning `Verification is still pending` that appears during deployment is normal and not an error — your contract will verify successfully within 15 seconds.
+:::`
 
 Or if you already have `foundryup` installed:
 


### PR DESCRIPTION
The current Foundry installation guide only shows the curl command which fails on Windows with a certificate error. There's no mention of WSL being required. Tested this today on Windows 11, the command silently fails and foundryup is not recognized. Added a Windows tip box explaining WSL is required, how to install it, and a note that the verification pending warning during deployment is normal and not an error. Both issues are undocumented and will trip up any Windows user trying to deploy on Tempo for the first time.