### PR TITLE
docs: remove mainnet credentials callout from RPC guide

### DIFF
--- a/src/pages/guide/node/rpc.mdx
+++ b/src/pages/guide/node/rpc.mdx
@@ -2,8 +2,6 @@
 description: Set up and run a Tempo RPC node for API access. Download snapshots, configure systemd services, and monitor node health and sync status.
 ---
 
-import { Callout } from 'vocs'
-
 # Running an RPC Node
 
 RPC nodes provide API access to the Tempo network without participating in consensus.
@@ -20,10 +18,6 @@ tempo node \
   --http --http.port 8545 \
   --http.api eth,net,web3,txpool,trace
 ```
-
-<Callout type="info">
-For mainnet, you have to use the credentials in `--follow` that are issued to you by the Tempo team.
-</Callout>
 
 An RPC node running in follow mode is a **full node**. It fetches blocks from a trusted RPC endpoint, executes every transaction locally through the EVM, validates each block after execution, and stores complete block data with full state. The only trust assumption is block ordering: your node trusts the RPC endpoint to provide the correct sequence of blocks. All execution and validation happens locally on your machine.
 


### PR DESCRIPTION
Removes the Callout block about mainnet credentials from the RPC node guide, and cleans up the unused `Callout` import.

Prompted by: Alexey