### PR TITLE
fix: update dRPC link from testnet to mainnet

### DIFF
--- a/src/pages/ecosystem/node-infrastructure.mdx
+++ b/src/pages/ecosystem/node-infrastructure.mdx
@@ -29,13 +29,13 @@ Create an account through the [Chainstack console](https://console.chainstack.co
 
 [Conduit](https://conduit.xyz) provides high-performance RPC infrastructure for Tempo Testnet. Developers can create API keys and access Tempo Testnet endpoints through the [Conduit app](https://app.conduit.xyz). 
 
-View the Tempo Testnet RPC endpoint in the [Conduit Hub](https://hub.conduit.xyz/tempo-testnet) and get started with the [Tempo RPC Quickstart](https://docs.conduit.xyz/rpc-nodes/getting-started/tempo-rpc-quickstart).
+View the Tempo Testnet RPC endpoint in the [Conduit Hub](https://hub.conduit.xyz/tempo) and get started with the [Tempo RPC Quickstart](https://docs.conduit.xyz/rpc-nodes/getting-started/tempo-rpc-quickstart).
 
 ## dRPC
 
 [dRPC](https://drpc.org) provides managed Tempo RPC endpoints through NodeCloud, with smart routing, analytics, key control, and front-end protection across 180+ networks. The platform runs on 40 providers in 8 geoclusters, with a free tier and flat-rate plans starting at $10.
 
-Get started by visiting the [Tempo chain page](https://drpc.org/chainlist/tempo-testnet-rpc), and learn more about NodeCloud on the [dRPC NodeCloud page](https://drpc.org/nodecloud-multichain-rpc-management).
+Get started by visiting the [Tempo chain page](https://drpc.org/chainlist/tempo-mainnet-rpc), and learn more about NodeCloud on the [dRPC NodeCloud page](https://drpc.org/nodecloud-multichain-rpc-management).
 
 ## Quicknode
 

--- a/src/pages/ecosystem/security-compliance.mdx
+++ b/src/pages/ecosystem/security-compliance.mdx
@@ -23,7 +23,7 @@ Discover how Hexagate supports Tempo [here](https://www.hexagate.com), or reques
 
 [Elliptic](https://www.elliptic.co) provides blockchain analytics and compliance solutions for detecting and preventing financial crime. Elliptic supports Tempo with transaction screening, wallet risk scoring, and regulatory compliance tools — helping platforms meet AML obligations while operating on the Tempo network.
 
-Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.elliptic.co) or explore their [developer docs](https://docs.elliptic.co/).
+Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.elliptic.co) or explore their [developer docs](https://developers.elliptic.co/docs/getting-started).
 
 ## TRM Labs
 

--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -315,13 +315,13 @@ Create an account through the [Chainstack console](https://console.chainstack.co
 
 [Conduit](https://conduit.xyz) provides high-performance RPC infrastructure for Tempo Testnet. Developers can create API keys and access Tempo Testnet endpoints through the [Conduit app](https://app.conduit.xyz). 
 
-View the Tempo Testnet RPC endpoint in the [Conduit Hub](https://hub.conduit.xyz/tempo-testnet) and get started with the [Tempo RPC Quickstart](https://docs.conduit.xyz/rpc-nodes/getting-started/tempo-rpc-quickstart).
+View the Tempo Testnet RPC endpoint in the [Conduit Hub](https://hub.conduit.xyz/tempo) and get started with the [Tempo RPC Quickstart](https://docs.conduit.xyz/rpc-nodes/getting-started/tempo-rpc-quickstart).
 
 ### dRPC
 
 [dRPC](https://drpc.org) provides managed Tempo RPC endpoints through NodeCloud, with smart routing, analytics, key control, and front-end protection across 180+ networks. The platform runs on 40 providers in 8 geoclusters, with a free tier and flat-rate plans starting at $10.
 
-Get started by visiting the [Tempo chain page](https://drpc.org/chainlist/tempo-testnet-rpc), and learn more about NodeCloud on the [dRPC NodeCloud page](https://drpc.org/nodecloud-multichain-rpc-management).
+Get started by visiting the [Tempo chain page](https://drpc.org/chainlist/tempo-mainnet-rpc), and learn more about NodeCloud on the [dRPC NodeCloud page](https://drpc.org/nodecloud-multichain-rpc-management).
 
 ### Quicknode
 
@@ -353,7 +353,7 @@ Discover how Hexagate supports Tempo [here](https://www.hexagate.com), or reques
 
 [Elliptic](https://www.elliptic.co) provides blockchain analytics and compliance solutions for detecting and preventing financial crime. Elliptic supports Tempo with transaction screening, wallet risk scoring, and regulatory compliance tools — helping platforms meet AML obligations while operating on the Tempo network.
 
-Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.elliptic.co) or explore their [developer docs](https://docs.elliptic.co/).
+Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.elliptic.co) or explore their [developer docs](https://developers.elliptic.co/docs/getting-started).
 
 ### TRM Labs
 


### PR DESCRIPTION
Scanned external links across the docs and found three that return 404 or
fail to resolve after Tempo's mainnet launch:

- **dRPC** chain page: `tempo-testnet-rpc` → `tempo-mainnet-rpc` (404)
- **Conduit Hub**: `tempo-testnet` → `tempo` (testnet page removed)
- **Elliptic developer docs**: `docs.elliptic.co` → `developers.elliptic.co/docs/getting-started` (domain no longer resolves)

All replacement URLs verified with HTTP 200.
