### PR TITLE
fix: update stale Stargate bridge link in getting funds guide

### DIFF
--- a/src/pages/guide/getting-funds.mdx
+++ b/src/pages/guide/getting-funds.mdx
@@ -51,7 +51,7 @@ codex exec "Read https://tempo.xyz/SKILL.md and fund my Tempo Wallet"
 
 Use one of these supported bridges to move assets to Tempo:
 
-- **[LayerZero (Stargate)](/guide/bridge-usdc-stargate)**: Bridge USDC to and from Tempo via Stargate. See the [full bridging guide](/guide/bridge-usdc-stargate) for contract addresses, code examples, and EndpointDollar details.
+- **[LayerZero (Stargate)](/guide/bridge-layerzero)**: Bridge USDC to and from Tempo via Stargate. See the [full bridging guide](/guide/bridge-layerzero) for contract addresses, code examples, and EndpointDollar details.
 - **[Squid](https://app.squidrouter.com/)**: Swap and bridge assets to Tempo in one flow.
 - **[Relay](https://relay.link/)**: Bridge assets to Tempo with low fees.
 - **[Across](https://app.across.to/)**: Bridge assets to Tempo quickly with competitive fees.


### PR DESCRIPTION
## Summary

Updates the LayerZero / Stargate links on the Getting Funds page to point to the current bridge guide.

## Root Cause

`src/pages/guide/getting-funds.mdx` still linked to the legacy route `/guide/bridge-usdc-stargate`.

That old route is redirected in `vercel.json`, so opening it in a new tab can still land on the right page. But normal in-app navigation uses the client-side route directly, which currently shows `Page Not Found`.

## User Impact

Before this change, users clicking the LayerZero / Stargate links from the Getting Funds page could hit a broken docs page during normal navigation.

## Changes

- update the `LayerZero (Stargate)` link to `/guide/bridge-layerzero`
- update the `full bridging guide` link to `/guide/bridge-layerzero`

## Validation

- confirmed the stale route was still referenced in `src/pages/guide/getting-funds.mdx`
- confirmed the current canonical guide is `src/pages/guide/bridge-layerzero.mdx`
- confirmed the sidebar also points to `/guide/bridge-layerzero`
- confirmed the old route still exists only as a server redirect in `vercel.json`

## Screenshot

Attached: `Page Not Found` shown when clicking the stale link via normal site navigation.                                                           <img width="1919" height="937" alt="image" src="https://github.com/user-attachments/assets/63cc60ea-46a0-49b5-91cd-62d9f29d2c6d" />
