### PR TITLE
docs(node): add v1.5.2 release and fee-recipient warning

### DIFF
--- a/src/pages/cli/node.mdx
+++ b/src/pages/cli/node.mdx
@@ -33,8 +33,12 @@ Flags grouped by function:
 | Flag | Description |
 | --- | --- |
 | `--consensus.signing-key <path>` | Path to validator signing key |
-| `--consensus.fee-recipient <addr>` | Address to receive validator fees |
+| `--consensus.fee-recipient <addr>` | Deprecated validator fee-recipient flag. Migrate to on-chain fee-recipient management via Validator Config V2. |
 | `--consensus.datadir <path>` | Separate volume for consensus data |
+
+:::warning
+`--consensus.fee-recipient` is deprecated as of `v1.5.2` and will be removed in an upcoming release. See [Validator Config V2](/guide/node/validator-config-v2).
+:::
 
 ### Observability
 

--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -15,6 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
+| [v1.5.2](https://github.com/tempoxyz/tempo/releases/tag/v1.5.2) | Apr 8, 2026 | Moderato + Mainnet | Maintenance release with the latest reth update, payload builder and RPC improvements, and validator fee-recipient migration support. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.5.1](https://github.com/tempoxyz/tempo/releases/tag/v1.5.1) | Mar 29, 2026 | Moderato + Mainnet | Security patch for RPC endpoints that accept `stateOverride`, including `eth_call` and `debug_traceCall`. This release is required for RPC providers and other public RPC nodes, and low priority for validators. | <Badge variant="amber">RPC only</Badge> |
 | [v1.5.0](https://github.com/tempoxyz/tempo/releases/tag/v1.5.0) | Mar 26, 2026 | Moderato + Mainnet | Required for T2; implements compound transfer policies (TIP-1015), permit support for TIP-20 (TIP-1004), ValidatorConfig V2 (TIP-1017), and 14 audit-driven bug fixes (TIP-1036) | <Badge variant="red">Required</Badge> |
 | [v1.4.3](https://github.com/tempoxyz/tempo/releases/tag/v1.4.3) | Mar 18, 2026 | Moderato + Mainnet | Fixes gas price oracle poisoning that caused inflated fee estimates for wallet transactions | <Badge variant="yellow">Recommended</Badge> |
@@ -23,6 +24,10 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 | [v1.4.0](https://github.com/tempoxyz/tempo/releases/tag/v1.4.0) | Mar 5, 2026 | Moderato + Mainnet | Required for T1C; introduces keychain signature migration so only V2 signatures and hashes are accepted after activation | <Badge variant="red">Required</Badge> |
 | [v1.3.1](https://github.com/tempoxyz/tempo/releases/tag/v1.3.1) | Feb 22, 2026 | Testnet + Mainnet | Fixes high-load issues and finalizes T1A/T1B hardening for expiring nonce replay protection and keychain precompile gas handling | <Badge variant="red">Required</Badge> |
 | [v1.2.0](https://github.com/tempoxyz/tempo/releases/tag/v1.2.0) | Feb 13, 2026 | Mainnet only | Fixes validation bug rejecting transactions with gas limits above ~16.7M, blocking large contract deployments | <Badge variant="red">Required</Badge> |
+
+:::warning
+`--consensus.fee-recipient` is deprecated as of `v1.5.2` and will be removed in an upcoming release. Validators should migrate fee-recipient management to [Validator Config V2](/guide/node/validator-config-v2).
+:::
 
 ---
 

--- a/src/pages/guide/node/validator.mdx
+++ b/src/pages/guide/node/validator.mdx
@@ -32,6 +32,10 @@ tempo node --datadir <datadir> \
     --telemetry-url <TELEMETRY_URL>
 ```
 
+:::warning
+`--consensus.fee-recipient` is deprecated as of `v1.5.2` and will be removed in an upcoming release. Validators should migrate fee-recipient management to [Validator Config V2](/guide/node/validator-config-v2).
+:::
+
 ### Optional flags
 
 | Flag | Description |
@@ -71,7 +75,7 @@ The telemetry endpoint does **not** collect any ambient information about the ho
 
 The data is strictly limited to the node's own operational metrics and logs.
 
-The notable difference between RPC nodes and validator nodes is the omission of the `--follow` argument and the addition of the `--consensus.signing-key` and `--consensus.fee-recipient` arguments. The fee recipient is the address that will receive transaction fees in your validators' proposed blocks.
+The notable difference between RPC nodes and validator nodes is the omission of the `--follow` argument and the addition of the `--consensus.signing-key` argument. Validator fee recipients are moving to on-chain management via Validator Config V2, and the legacy `--consensus.fee-recipient` flag is deprecated.
 
 Once your node is up, it may not start syncing immediately. This is because your node might not be part of the active set. In most cases, your validator will enter the active set in under 6 hours after the on-chain addition of the validator identity.
 


### PR DESCRIPTION
Adds the v1.5.2 node-operator update entry and documents that `--consensus.fee-recipient` is deprecated in the network upgrades, validator, and CLI docs.