### PR TITLE
docs: rename feePayerUrl to feePayer, update accounts to ^0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "abitype": "^1.2.3",
-    "accounts": "^0.5.9",
+    "accounts": "^0.6.0",
     "cva": "1.0.0-beta.4",
     "mermaid": "^11.12.2",
     "monaco-editor": "^0.55.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3(typescript@5.9.3)(zod@4.3.5)
       accounts:
-        specifier: ^0.5.9
-        version: 0.5.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(@types/react@19.2.9)(@wagmi/core@3.4.0(@tanstack/query-core@5.90.19)(@types/react@19.2.9)(ox@0.14.10(typescript@5.9.3)(zod@4.3.5))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.10(typescript@5.9.3)(zod@4.3.5)))(express@5.2.1)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.47.10(typescript@5.9.3)(zod@4.3.5))
+        specifier: ^0.6.0
+        version: 0.6.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(@types/react@19.2.9)(@wagmi/core@3.4.0(@tanstack/query-core@5.90.19)(@types/react@19.2.9)(ox@0.14.10(typescript@5.9.3)(zod@4.3.5))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.10(typescript@5.9.3)(zod@4.3.5)))(express@5.2.1)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.47.10(typescript@5.9.3)(zod@4.3.5))
       cva:
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4(typescript@5.9.3)
@@ -1644,8 +1644,8 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  accounts@0.5.9:
-    resolution: {integrity: sha512-Qs5ZiV4GtqSMx1v04n9YEUbg+7fdxsA4VpzfRRCiou8QaQbiiYurDLVI6fRTXF2Bd2N5zi86H/6hQX6znMr/Gw==}
+  accounts@0.6.0:
+    resolution: {integrity: sha512-2UsnjMUTYJiGI+c60rKf5bz0uzyWlvwBK+0jn6kU/c4PD4U7SshIbvLRnI5yW6lI5GUtffkQD6o2v9hT3Sshzw==}
     peerDependencies:
       '@react-native-async-storage/async-storage': ^3.0.2
       '@wagmi/core': '>=2'
@@ -3185,6 +3185,14 @@ packages:
 
   ox@0.14.10:
     resolution: {integrity: sha512-PYsqEnSP7CrcxISS3uVBtw9yPy2gATAnWNptTI0pMnlrXLTiw0Xw/IIivJVHDFgGvKuRAtBSafhVjs+jis3CVA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.14.13:
+    resolution: {integrity: sha512-N3slDyEUq3qGw/53Xd8YZPZD7NUbbiOJDeWKvQ1ElNo2mFjjz6cV2TIbGenHw7k5ATcefDQh42dwUWoGtxU9Hg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -5627,13 +5635,13 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  accounts@0.5.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(@types/react@19.2.9)(@wagmi/core@3.4.0(@tanstack/query-core@5.90.19)(@types/react@19.2.9)(ox@0.14.10(typescript@5.9.3)(zod@4.3.5))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.10(typescript@5.9.3)(zod@4.3.5)))(express@5.2.1)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.47.10(typescript@5.9.3)(zod@4.3.5)):
+  accounts@0.6.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(@types/react@19.2.9)(@wagmi/core@3.4.0(@tanstack/query-core@5.90.19)(@types/react@19.2.9)(ox@0.14.10(typescript@5.9.3)(zod@4.3.5))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.10(typescript@5.9.3)(zod@4.3.5)))(express@5.2.1)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.47.10(typescript@5.9.3)(zod@4.3.5)):
     dependencies:
       hono: 4.12.12
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       mppx: 0.5.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.5))(express@5.2.1)(hono@4.12.12)(typescript@5.9.3)(viem@2.47.10(typescript@5.9.3)(zod@4.3.5))
-      ox: 0.14.10(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.14.13(typescript@5.9.3)(zod@4.3.6)
       webauthx: 0.1.0(typescript@5.9.3)(zod@4.3.6)
       zod: 4.3.6
       zustand: 5.0.12(@types/react@19.2.9)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -7396,7 +7404,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.14.10(typescript@5.9.3)(zod@4.3.6):
+  ox@0.14.13(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -8485,7 +8493,7 @@ snapshots:
 
   webauthx@0.1.0(typescript@5.9.3)(zod@4.3.6):
     dependencies:
-      ox: 0.14.10(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.14.13(typescript@5.9.3)(zod@4.3.6)
     transitivePeerDependencies:
       - typescript
       - zod

--- a/src/pages/accounts/api/provider.mdx
+++ b/src/pages/accounts/api/provider.mdx
@@ -106,18 +106,31 @@ const provider = Provider.create({
 })
 ```
 
-### feePayerUrl
+### feePayer
 
-- **Type:** `string`
+- **Type:** `string | { url: string; precedence?: 'fee-payer-first' | 'user-first' }`
 - **Optional**
 
-Fee payer URL for interacting with a service running [`Handler.feePayer`](/accounts/server/handler.feePayer) from `accounts/server`.
+Fee payer configuration for interacting with a service running [`Handler.feePayer`](/accounts/server/handler.feePayer) from `accounts/server`. Pass a URL string, or an object with `url` and optional `precedence` to control whether the fee payer or the user pays first.
 
 ```ts twoslash
 import { Provider } from 'accounts'
 
 const provider = Provider.create({
-  feePayerUrl: 'https://myapp.com/fee-payer', // [!code focus]
+  feePayer: 'https://myapp.com/fee-payer', // [!code focus]
+})
+```
+
+Or with precedence:
+
+```ts twoslash
+import { Provider } from 'accounts'
+
+const provider = Provider.create({
+  feePayer: { // [!code focus]
+    url: 'https://myapp.com/fee-payer', // [!code focus]
+    precedence: 'user-first', // [!code focus]
+  }, // [!code focus]
 })
 ```
 

--- a/src/pages/accounts/wagmi/tempoWallet.mdx
+++ b/src/pages/accounts/wagmi/tempoWallet.mdx
@@ -82,12 +82,12 @@ export const config = createConfig({
 })
 ```
 
-### feePayerUrl
+### feePayer
 
-- **Type:** `string`
+- **Type:** `string | { url: string; precedence?: 'fee-payer-first' | 'user-first' }`
 - **Optional**
 
-Fee payer URL for interacting with a service running [`Handler.feePayer`](/accounts/server/handler.feePayer) from `accounts/server`.
+Fee payer configuration for interacting with a service running [`Handler.feePayer`](/accounts/server/handler.feePayer) from `accounts/server`. Pass a URL string, or an object with `url` and optional `precedence`.
 
 :::info
 [See the guide](/guide/payments/sponsor-user-fees)
@@ -102,7 +102,7 @@ export const config = createConfig({
   chains: [tempo],
   connectors: [
     tempoWallet({
-      feePayerUrl: 'https://myapp.com/fee-payer', // [!code focus]
+      feePayer: 'https://myapp.com/fee-payer', // [!code focus]
     }),
   ],
   transports: { [tempo.id]: http() },

--- a/src/pages/accounts/wagmi/webAuthn.mdx
+++ b/src/pages/accounts/wagmi/webAuthn.mdx
@@ -122,12 +122,12 @@ export const config = createConfig({
 })
 ```
 
-### feePayerUrl
+### feePayer
 
-- **Type:** `string`
+- **Type:** `string | { url: string; precedence?: 'fee-payer-first' | 'user-first' }`
 - **Optional**
 
-Fee payer URL for interacting with a service running [`Handler.feePayer`](/accounts/server/handler.feePayer) from `accounts/server`.
+Fee payer configuration for interacting with a service running [`Handler.feePayer`](/accounts/server/handler.feePayer) from `accounts/server`. Pass a URL string, or an object with `url` and optional `precedence`.
 
 :::info
 [See the guide](/guide/payments/sponsor-user-fees)
@@ -143,7 +143,7 @@ export const config = createConfig({
   connectors: [
     webAuthn({
       authUrl: '/auth',
-      feePayerUrl: 'https://myapp.com/fee-payer', // [!code focus]
+      feePayer: 'https://myapp.com/fee-payer', // [!code focus]
     }),
   ],
   transports: { [tempo.id]: http() },

--- a/src/pages/guide/payments/sponsor-user-fees.mdx
+++ b/src/pages/guide/payments/sponsor-user-fees.mdx
@@ -63,7 +63,7 @@ import { createConfig, http } from 'wagmi'
 
 export const config = createConfig({
   connectors: [tempoWallet({
-    feePayerUrl: 'https://sponsor.moderato.tempo.xyz', // [!code focus]
+    feePayer: 'https://sponsor.moderato.tempo.xyz', // [!code focus]
   })],
   chains: [tempo],
   multiInjectedProviderDiscovery: false,

--- a/src/pages/guide/use-accounts/embed-tempo-wallet.mdx
+++ b/src/pages/guide/use-accounts/embed-tempo-wallet.mdx
@@ -241,7 +241,7 @@ export function Example() {
 
 ### Fee Sponsorship
 
-The `tempoWallet` connector supports fee sponsorship via a `feePayerUrl`. This allows you to sponsor transaction fees for your users.
+The `tempoWallet` connector supports fee sponsorship via a `feePayer` option. This allows you to sponsor transaction fees for your users.
 
 ```tsx twoslash [config.ts]
 // @noErrors
@@ -252,7 +252,7 @@ import { tempoWallet } from 'accounts/wagmi'
 export const config = createConfig({
   chains: [tempo],
   connectors: [tempoWallet({
-    feePayerUrl: 'https://sponsor.example.com', // [!code ++]
+    feePayer: 'https://sponsor.example.com', // [!code ++]
   })],
   transports: {
     [tempo.id]: http(),

--- a/src/snippets/wagmi.config.ts
+++ b/src/snippets/wagmi.config.ts
@@ -29,7 +29,10 @@ import { KeyManager, webAuthn } from 'wagmi/tempo'
 export const config = createConfig({
   connectors: [
     tempoWallet({
-      feePayerUrl: 'https://sponsor.moderato.tempo.xyz',
+      feePayer: {
+        precedence: 'user-first',
+        url: 'https://sponsor.moderato.tempo.xyz',
+      },
     }),
   ],
   chains: [tempo],

--- a/src/wagmi.config.ts
+++ b/src/wagmi.config.ts
@@ -59,7 +59,10 @@ export function getConfig(options: getConfig.Options = {}) {
                   { token: thetaUsd, limit: parseUnits('500', 6) },
                 ],
               }),
-              feePayerUrl: 'https://sponsor.moderato.tempo.xyz',
+              feePayer: {
+                precedence: 'user-first',
+                url: 'https://sponsor.moderato.tempo.xyz',
+              },
             }),
             webAuthn({
               grantAccessKey: {


### PR DESCRIPTION
Updates all docs references from `feePayerUrl` (string) to the new `feePayer` option which accepts `string | { url, precedence }`. Updates `accounts` SDK to `^0.6.0`.