### PR TITLE
docs: update T3 compatible SDK releases

### DIFF
--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -70,7 +70,7 @@ Tempo's broader tooling ecosystem is available in [Developer tools](/quickstart/
 |-----|-----------------------|
 | [TypeScript](https://github.com/wevm/viem) | [`viem@2.47.11`](https://github.com/wevm/viem/releases/tag/viem%402.47.11), [`ox@0.14.13`](https://github.com/wevm/ox/releases/tag/ox%400.14.13) |
 | [Rust](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) | [`tempo-alloy@1.5.1`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) |
-| [Go](https://github.com/tempoxyz/tempo-go) | [`v0.4.0`](https://github.com/tempoxyz/tempo-go/releases/tag/v0.4.0) (pending release) |
+| [Go](https://github.com/tempoxyz/tempo-go) | [`v0.4.0`](https://github.com/tempoxyz/tempo-go/releases/tag/v0.4.0) |
 | [Python](https://github.com/tempoxyz/pytempo) | [`0.5.0`](https://github.com/tempoxyz/pytempo/releases/tag/pytempo%400.5.0) |
 | [Foundry](https://github.com/tempoxyz/tempo-foundry) | [`v1.6.0-t1c1`](https://github.com/tempoxyz/tempo-foundry/releases/tag/v1.6.0-t1c1) |
 

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -72,7 +72,7 @@ Tempo's broader tooling ecosystem is available in [Developer tools](/quickstart/
 | [Rust](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) | [`tempo-alloy@1.5.1`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) |
 | [Go](https://github.com/tempoxyz/tempo-go) | [`v0.4.0`](https://github.com/tempoxyz/tempo-go/releases/tag/v0.4.0) |
 | [Python](https://github.com/tempoxyz/pytempo) | [`0.5.0`](https://github.com/tempoxyz/pytempo/releases/tag/pytempo%400.5.0) |
-| [Foundry](https://github.com/tempoxyz/tempo-foundry) | [`v1.6.0-t1c1`](https://github.com/tempoxyz/tempo-foundry/releases/tag/v1.6.0-t1c1) |
+| [Foundry](https://github.com/tempoxyz/tempo-foundry) | [`v1.6.0-t3`](https://github.com/tempoxyz/tempo-foundry/releases/tag/v1.6.0-t3) |
 
 ## Related docs
 Guides about TIPs coming soon.

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -70,7 +70,7 @@ Tempo's broader tooling ecosystem is available in [Developer tools](/quickstart/
 |-----|-----------------------|
 | [TypeScript](https://github.com/wevm/viem) | [`viem@2.47.11`](https://github.com/wevm/viem/releases/tag/viem%402.47.11), [`ox@0.14.13`](https://github.com/wevm/ox/releases/tag/ox%400.14.13) |
 | [Rust](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) | [`tempo-alloy@1.5.1`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) |
-| [Go](https://github.com/tempoxyz/tempo-go) | `TBD` |
+| [Go](https://github.com/tempoxyz/tempo-go) | [`v0.4.0`](https://github.com/tempoxyz/tempo-go/releases/tag/v0.4.0) (pending release) |
 | [Python](https://github.com/tempoxyz/pytempo) | [`0.5.0`](https://github.com/tempoxyz/pytempo/releases/tag/pytempo%400.5.0) |
 | [Foundry](https://github.com/tempoxyz/tempo-foundry) | [`v1.6.0-t1c1`](https://github.com/tempoxyz/tempo-foundry/releases/tag/v1.6.0-t1c1) |
 

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -68,7 +68,7 @@ Tempo's broader tooling ecosystem is available in [Developer tools](/quickstart/
 
 | SDK | T3-compatible release |
 |-----|-----------------------|
-| [TypeScript](https://github.com/wevm/viem) | [`viem@2.47.11`](https://github.com/wevm/viem/releases/tag/viem%402.47.11) |
+| [TypeScript](https://github.com/wevm/viem) | [`viem@2.47.11`](https://github.com/wevm/viem/releases/tag/viem%402.47.11), [`ox@0.14.13`](https://github.com/wevm/ox/releases/tag/ox%400.14.13) |
 | [Rust](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) | [`tempo-alloy@1.5.1`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) |
 | [Go](https://github.com/tempoxyz/tempo-go) | `TBD` |
 | [Python](https://github.com/tempoxyz/pytempo) | [`0.5.0`](https://github.com/tempoxyz/pytempo/releases/tag/pytempo%400.5.0) |

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -68,7 +68,7 @@ Tempo's broader tooling ecosystem is available in [Developer tools](/quickstart/
 
 | SDK | T3-compatible release |
 |-----|-----------------------|
-| [TypeScript](https://github.com/tempoxyz/tempo-ts) | [`0.14.2`](https://github.com/tempoxyz/tempo-ts/releases/tag/tempo.ts%400.14.2) |
+| [TypeScript](https://github.com/wevm/viem) | [`viem@2.47.11`](https://github.com/wevm/viem/releases/tag/viem%402.47.11) |
 | [Rust](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) | [`tempo-alloy@1.5.1`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) |
 | [Go](https://github.com/tempoxyz/tempo-go) | `TBD` |
 | [Python](https://github.com/tempoxyz/pytempo) | [`0.5.0`](https://github.com/tempoxyz/pytempo/releases/tag/pytempo%400.5.0) |

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -68,13 +68,11 @@ Tempo's broader tooling ecosystem is available in [Developer tools](/quickstart/
 
 | SDK | T3-compatible release |
 |-----|-----------------------|
-| TypeScript | `TBD` |
-| Rust | `TBD` |
-| Go | `TBD` |
-| Python | `TBD` |
-| Foundry | `TBD` |
-
-Versions will be added here once a T3-compatible release has been published for each SDK.
+| [TypeScript](https://github.com/tempoxyz/tempo-ts) | [`0.14.2`](https://github.com/tempoxyz/tempo-ts/releases/tag/tempo.ts%400.14.2) |
+| [Rust](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) | [`tempo-alloy@1.5.1`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) |
+| [Go](https://github.com/tempoxyz/tempo-go) | `TBD` |
+| [Python](https://github.com/tempoxyz/pytempo) | [`0.5.0`](https://github.com/tempoxyz/pytempo/releases/tag/pytempo%400.5.0) |
+| [Foundry](https://github.com/tempoxyz/tempo-foundry) | [`v1.6.0-t1c1`](https://github.com/tempoxyz/tempo-foundry/releases/tag/v1.6.0-t1c1) |
 
 ## Related docs
 Guides about TIPs coming soon.


### PR DESCRIPTION
Updates the Compatible SDK Releases table on the T3 upgrade page with the latest releases

Prompted by: rusowsky