### PR TITLE
docs: add 8004 contracts and link all addresses to explorer

### DIFF
--- a/src/pages/quickstart/predeployed-contracts.mdx
+++ b/src/pages/quickstart/predeployed-contracts.mdx
@@ -10,11 +10,13 @@ Core protocol contracts that power Tempo's features.
 
 | Contract | Address | Description |
 |----------|---------|-------------|
-| [**TIP-20 Factory**](/protocol/tip20/overview) | `0x20fc000000000000000000000000000000000000` | Create new TIP-20 tokens |
-| [**Fee Manager**](/protocol/fees/spec-fee-amm#2-feemanager-contract) | `0xfeec000000000000000000000000000000000000` | Handle fee payments and conversions |
-| [**Stablecoin DEX**](/protocol/exchange) | `0xdec0000000000000000000000000000000000000` | Enshrined DEX for stablecoin swaps |
-| [**TIP-403 Registry**](/protocol/tip403/spec) | `0x403c000000000000000000000000000000000000` | Transfer policy registry |
-| [**pathUSD**](/protocol/exchange/quote-tokens#pathusd) | `0x20c0000000000000000000000000000000000000` | First stablecoin deployed |
+| [**TIP-20 Factory**](/protocol/tip20/overview) | [`0x20fc000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x20fc000000000000000000000000000000000000) | Create new TIP-20 tokens |
+| [**Fee Manager**](/protocol/fees/spec-fee-amm#2-feemanager-contract) | [`0xfeec000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0xfeec000000000000000000000000000000000000) | Handle fee payments and conversions |
+| [**Stablecoin DEX**](/protocol/exchange) | [`0xdec0000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0xdec0000000000000000000000000000000000000) | Enshrined DEX for stablecoin swaps |
+| [**TIP-403 Registry**](/protocol/tip403/spec) | [`0x403c000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x403c000000000000000000000000000000000000) | Transfer policy registry |
+| [**pathUSD**](/protocol/exchange/quote-tokens#pathusd) | [`0x20c0000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000000) | First stablecoin deployed |
+| **8004 Identity Registry** | [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://explore.tempo.xyz/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432) | Identity registry |
+| **8004 Reputation Registry** | [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://explore.tempo.xyz/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63) | Reputation registry |
 
 ## Standard Utilities
 
@@ -22,11 +24,11 @@ Popular Ethereum contracts deployed for convenience.
 
 | Contract | Address | Description |
 |----------|---------|-------------|
-| [**Multicall3**](https://www.multicall3.com/) | `0xcA11bde05977b3631167028862bE2a173976CA11` | Batch multiple calls in one transaction |
-| [**CreateX**](https://github.com/pcaversaccio/createx) | `0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed` | Deterministic contract deployment |
-| [**Permit2**](https://docs.uniswap.org/contracts/permit2/overview) | `0x000000000022d473030f116ddee9f6b43ac78ba3` | Token approvals and transfers |
-| [**Arachnid Create2 Factory**](https://github.com/Arachnid/deterministic-deployment-proxy) | `0x4e59b44847b379578588920cA78FbF26c0B4956C` | CREATE2 deployment proxy |
-| [**Safe Deployer**](https://github.com/safe-fndn/safe-singleton-factory) | `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7` | Safe deployer contract |
+| [**Multicall3**](https://www.multicall3.com/) | [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://explore.tempo.xyz/address/0xcA11bde05977b3631167028862bE2a173976CA11) | Batch multiple calls in one transaction |
+| [**CreateX**](https://github.com/pcaversaccio/createx) | [`0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed`](https://explore.tempo.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed) | Deterministic contract deployment |
+| [**Permit2**](https://docs.uniswap.org/contracts/permit2/overview) | [`0x000000000022d473030f116ddee9f6b43ac78ba3`](https://explore.tempo.xyz/address/0x000000000022d473030f116ddee9f6b43ac78ba3) | Token approvals and transfers |
+| [**Arachnid Create2 Factory**](https://github.com/Arachnid/deterministic-deployment-proxy) | [`0x4e59b44847b379578588920cA78FbF26c0B4956C`](https://explore.tempo.xyz/address/0x4e59b44847b379578588920cA78FbF26c0B4956C) | CREATE2 deployment proxy |
+| [**Safe Deployer**](https://github.com/safe-fndn/safe-singleton-factory) | [`0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7`](https://explore.tempo.xyz/address/0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7) | Safe deployer contract |
 
 ## Contract ABIs
 

--- a/src/pages/quickstart/predeployed-contracts.mdx
+++ b/src/pages/quickstart/predeployed-contracts.mdx
@@ -15,8 +15,6 @@ Core protocol contracts that power Tempo's features.
 | [**Stablecoin DEX**](/protocol/exchange) | [`0xdec0000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0xdec0000000000000000000000000000000000000) | Enshrined DEX for stablecoin swaps |
 | [**TIP-403 Registry**](/protocol/tip403/spec) | [`0x403c000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x403c000000000000000000000000000000000000) | Transfer policy registry |
 | [**pathUSD**](/protocol/exchange/quote-tokens#pathusd) | [`0x20c0000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000000) | First stablecoin deployed |
-| **8004 Identity Registry** | [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://explore.tempo.xyz/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432) | Identity registry |
-| **8004 Reputation Registry** | [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://explore.tempo.xyz/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63) | Reputation registry |
 
 ## Standard Utilities
 
@@ -29,6 +27,8 @@ Popular Ethereum contracts deployed for convenience.
 | [**Permit2**](https://docs.uniswap.org/contracts/permit2/overview) | [`0x000000000022d473030f116ddee9f6b43ac78ba3`](https://explore.tempo.xyz/address/0x000000000022d473030f116ddee9f6b43ac78ba3) | Token approvals and transfers |
 | [**Arachnid Create2 Factory**](https://github.com/Arachnid/deterministic-deployment-proxy) | [`0x4e59b44847b379578588920cA78FbF26c0B4956C`](https://explore.tempo.xyz/address/0x4e59b44847b379578588920cA78FbF26c0B4956C) | CREATE2 deployment proxy |
 | [**Safe Deployer**](https://github.com/safe-fndn/safe-singleton-factory) | [`0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7`](https://explore.tempo.xyz/address/0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7) | Safe deployer contract |
+| **8004 Identity Registry** | [`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`](https://explore.tempo.xyz/address/0x8004A169FB4a3325136EB29fA0ceB6D2e539a432) | Identity registry |
+| **8004 Reputation Registry** | [`0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`](https://explore.tempo.xyz/address/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63) | Reputation registry |
 
 ## Contract ABIs
 


### PR DESCRIPTION
Adds 8004 Identity Registry and 8004 Reputation Registry to the predeployed contracts page. All contract addresses now link to explore.tempo.xyz.

Prompted by: Brendan