### PR TITLE
fix(e2e): use local webauthn ceremony in E2E tests

### DIFF
--- a/src/wagmi.config.ts
+++ b/src/wagmi.config.ts
@@ -44,7 +44,6 @@ export function getConfig(options: getConfig.Options = {}) {
       ...(import.meta.env.VITE_E2E === 'true'
         ? [
             webAuthnAccounts({
-              authUrl: 'https://keys.tempo.xyz',
               rdns: 'webAuthn',
             }),
           ]


### PR DESCRIPTION
## Problem

All E2E tests on `main` have been failing since PR #259 (`accounts` 0.5.1 → 0.5.4). Every test fails at the sign-in step — clicking "Sign in"/"Sign up" never produces a "Sign out" button.

## Root Cause

In `accounts@0.5.1`, the wagmi `webAuthn()` connector had a bug where the `authUrl` option was **silently ignored** — it wasn't destructured or forwarded to the adapter. This meant the E2E config accidentally used `WebAuthnCeremony.local()` (browser-side passkey ceremonies), which worked perfectly with Playwright's CDP virtual authenticator.

In `accounts@0.5.4`, this was fixed — `authUrl` is now properly forwarded. So the E2E tests started hitting `https://keys.tempo.xyz/register/options`, `/login/options`, etc. But `keys.tempo.xyz` runs `Handler.keyManager` (from `tempo.ts`), which serves completely different routes (`GET /challenge`, `GET /:id`). All ceremony requests 404, sign-in fails silently, and tests time out.

## Fix

Remove `authUrl` from the `VITE_E2E` branch of the wagmi config. This makes the E2E connector use `WebAuthnCeremony.local()` — the correct behavior for tests with a CDP virtual authenticator. The production config is unchanged.