### PR TITLE
Use :::::steps directive for numbered steps, rename Bridging section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,26 @@ Vocs-powered documentation site for Tempo protocol.
 - **Config**: `vocs.config.tsx` sets `baseUrl`, `ogImageUrl` (with `%title` and `%description` template variables), and `titleTemplate`
 - All pages automatically get proper `<title>`, `<meta description>`, Open Graph, and Twitter Card tags from frontmatter
 
+## Numbered Steps
+
+When writing step-by-step instructions in guides, use the `:::::steps` container directive instead of manual `### Step 1`, `#### Step 2` headings. Each step is a `###` heading inside the container. The steps are auto-numbered by the renderer.
+
+```mdx
+:::::steps
+
+### Do the first thing
+
+Content for step 1.
+
+### Do the second thing
+
+Content for step 2.
+
+:::::
+```
+
+See https://mpp.dev/guides/multiple-payment-methods for a reference example.
+
 ## Project Structure
 
 - `src/pages/` - MDX documentation pages

--- a/src/pages/guide/bridge-layerzero.mdx
+++ b/src/pages/guide/bridge-layerzero.mdx
@@ -74,7 +74,9 @@ Tempo's LayerZero Endpoint ID is **`30410`**.
 
 This example bridges USDC from Base to Tempo. Replace addresses for other tokens or source chains.
 
-##### Step 1 - Get a quote
+:::::steps
+
+### Get a quote
 
 ```bash
 cast call 0x27a16dc786820B16E5c9028b75B99F6f604b5d26 \
@@ -86,7 +88,7 @@ cast call 0x27a16dc786820B16E5c9028b75B99F6f604b5d26 \
 
 Take the first returned number as `<NATIVE_FEE>`.
 
-##### Step 2 - Approve token on source chain
+### Approve token on source chain
 
 ```bash
 cast send 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
@@ -97,7 +99,7 @@ cast send 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
   --private-key $PRIVATE_KEY
 ```
 
-##### Step 3 - Send bridge transaction
+### Send bridge transaction
 
 ```bash
 cast send 0x27a16dc786820B16E5c9028b75B99F6f604b5d26 \
@@ -110,11 +112,13 @@ cast send 0x27a16dc786820B16E5c9028b75B99F6f604b5d26 \
   --private-key $PRIVATE_KEY
 ```
 
-##### Step 4 - Verify transaction status
+### Verify transaction status
 
 ```text
 https://scan.layerzero-api.com/v1/messages/tx/<SOURCE_TX_HASH>
 ```
+
+:::::
 
 #### Using TypeScript (viem)
 
@@ -262,7 +266,9 @@ To bridge from Tempo back to another chain, call `sendToken` on the Stargate OFT
 
 This example bridges USDC.e from Tempo to Base.
 
-##### Step 1 - Quote the fee
+:::::steps
+
+### Quote the fee
 
 ```bash
 cast call 0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
@@ -274,7 +280,7 @@ cast call 0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
 
 Take the first returned number as `<NATIVE_FEE>` (in stablecoin units, not ETH).
 
-##### Step 2 - Approve token on Tempo
+### Approve token on Tempo
 
 ```bash
 cast send 0x20C000000000000000000000b9537d11c60E8b50 \
@@ -285,7 +291,7 @@ cast send 0x20C000000000000000000000b9537d11c60E8b50 \
   --private-key $PRIVATE_KEY
 ```
 
-##### Step 3 - Send bridge transaction
+### Send bridge transaction
 
 No `--value` is needed on Tempo - the messaging fee is paid in a TIP-20 stablecoin via [EndpointDollar](#endpointdollar).
 
@@ -299,11 +305,13 @@ cast send 0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
   --private-key $PRIVATE_KEY
 ```
 
-##### Step 4 - Verify transaction status
+### Verify transaction status
 
 ```text
 https://scan.layerzero-api.com/v1/messages/tx/<SOURCE_TX_HASH>
 ```
+
+:::::
 
 #### Using TypeScript (viem)
 

--- a/src/pages/guide/bridge-relay.mdx
+++ b/src/pages/guide/bridge-relay.mdx
@@ -49,7 +49,9 @@ For ERC-20 tokens, the quote response includes any required approval steps autom
 
 This example bridges USDC.e (Bridged USDC) from Base to Tempo. Replace the currency addresses and chain IDs for other tokens or routes.
 
-#### Step 1 - Get a quote
+:::::steps
+
+### Get a quote
 
 Replace `<YOUR_ADDRESS>` with your wallet address and `<AMOUNT>` with the amount in base units (e.g. `1000000` for 1 USDC.e with 6 decimals).
 
@@ -69,7 +71,7 @@ curl -X POST "https://api.relay.link/quote/v2" \
 
 The response contains a `steps` array with transaction data. Save the `requestId` from the step for tracking.
 
-#### Step 2 - Approve token (if required)
+### Approve token (if required)
 
 If the quote response includes an approval step, approve the Relay contract to spend your tokens. The approval target address is provided in the quote response's step data.
 
@@ -82,7 +84,7 @@ cast send <TOKEN_ADDRESS> \
   --private-key $PRIVATE_KEY
 ```
 
-#### Step 3 - Submit the deposit transaction
+### Submit the deposit transaction
 
 Use the `to`, `data`, and `value` fields from the quote response's transaction step:
 
@@ -94,7 +96,7 @@ cast send <TO> \
   --private-key $PRIVATE_KEY
 ```
 
-#### Step 4 - Track status
+### Track status
 
 Poll the status endpoint with the `requestId` from the quote response:
 
@@ -109,6 +111,8 @@ Once complete, view the destination transaction on Tempo:
 ```text
 https://explore.tempo.xyz/tx/<DESTINATION_TX_HASH>
 ```
+
+:::::
 
 ### Using TypeScript (viem)
 
@@ -194,7 +198,9 @@ To bridge tokens from Tempo to another chain, swap the origin and destination in
 
 ### Using curl + cast (Foundry)
 
-#### Step 1 - Get a quote
+:::::steps
+
+### Get a quote
 
 ```bash
 curl -X POST "https://api.relay.link/quote/v2" \
@@ -210,7 +216,7 @@ curl -X POST "https://api.relay.link/quote/v2" \
   }'
 ```
 
-#### Step 2 - Approve token (if required)
+### Approve token (if required)
 
 If the quote includes an approval step, approve the Relay contract to spend your tokens on Tempo.
 
@@ -223,7 +229,7 @@ cast send <TOKEN_ADDRESS> \
   --private-key $PRIVATE_KEY
 ```
 
-#### Step 3 - Submit the deposit transaction
+### Submit the deposit transaction
 
 Use the `to`, `data`, and `value` fields from the quote response:
 
@@ -238,11 +244,13 @@ cast send <TO> \
 Tempo has no native gas token, so no `--value` flag is needed. Transaction fees on Tempo are paid in a TIP-20 stablecoin automatically.
 :::
 
-#### Step 4 - Track status
+### Track status
 
 ```bash
 curl "https://api.relay.link/intents/status/v3?requestId=<REQUEST_ID>"
 ```
+
+:::::
 
 ### Using TypeScript (viem)
 

--- a/src/pages/learn/use-cases/global-payouts.mdx
+++ b/src/pages/learn/use-cases/global-payouts.mdx
@@ -99,21 +99,25 @@ If the answer to these questions is yes, you should be evaluating the stablecoin
 
 Payouts are one of the cleanest entry points for stablecoins because you can pilot quickly and measure impact.
 
-### Step 1: Clarify the business case
+:::::steps
+
+### Clarify the business case
 
 Pick your highest-friction corridor (e.g., U.S. to Brazil, Philippines, or Nigeria). Identify where fees, failed payments, or delays create real pain.
 
-### Step 2: Choose an integration approach
+### Choose an integration approach
 
 Decide whether to **buy** (provider abstracts custody, liquidity, compliance) or **build** (you assemble wallets, custody, bank rails, and potentially licensing).
 
-### Step 3: Run a pilot
+### Run a pilot
 
 Run stablecoin payouts alongside your existing system for approximately 60 days. Track delivery time, net recipient received, support tickets, and reconciliation effort.
 
-### Step 4: Operationalize
+### Operationalize
 
 Define SLAs, exception handling, reconciliation processes, and support playbooks, then expand corridors and automate what was manual.
+
+:::::
 
 ## Building with Tempo
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -344,7 +344,7 @@ export default defineConfig({
             link: '/quickstart/verify-contracts',
           },
           {
-            text: 'Bridging Guides',
+            text: 'Bridging',
             collapsed: true,
             items: [
               {


### PR DESCRIPTION
Converts all manual `Step N` headings to the `:::::steps` container directive (matching the pattern used in [mpp.dev guides](https://mpp.dev/guides/multiple-payment-methods)).

## Changes

- **bridge-layerzero.mdx** — 2 sets of `##### Step N` → `:::::steps`
- **bridge-relay.mdx** — 2 sets of `#### Step N` → `:::::steps`
- **global-payouts.mdx** — `### Step N:` → `:::::steps`
- **vocs.config.ts** — Sidebar: "Bridging Guides" → "Bridging"
- **AGENTS.md** — Added convention rule to always use `:::::steps` for numbered instructions