### PR TITLE
chore(ci): harden GitHub Actions workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: verify-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -19,16 +21,18 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           run_install: false
           version: 10.28.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.12.0
           cache: pnpm
@@ -54,6 +58,7 @@ jobs:
     if: always()
     needs: [check, e2e]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: |
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
@@ -77,16 +82,18 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           run_install: false
           version: 10.28.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.12.0
           cache: pnpm
@@ -99,7 +106,7 @@ jobs:
         run: pnpm run test:e2e --shard=${{ matrix.shard }}/3
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-${{ matrix.shard }}


### PR DESCRIPTION
Pin all GitHub Actions to SHA hashes and apply least-privilege permissions.

## Changes
- Pin `actions/checkout@v6` → `@de0fac2e…` (`v6.0.2`)
- Pin `pnpm/action-setup@v5` → `@fc06bc12…` (`v5.0.0`)
- Pin `actions/setup-node@v6` → `@53b83947…` (`v6.3.0`)
- Pin `actions/upload-artifact@v4` → `@ea165f8d…` (`v4.6.2`)
- Add top-level `permissions: {}` (default deny)
- Add `permissions: {}` to `ci-gate` job (was inheriting default)
- Add `persist-credentials: false` to both `actions/checkout` steps

## Why
Supply chain hardening flagged by dependency scan. Tag-based action refs (`@v6`) can be silently retagged — SHA pinning prevents that. Default-deny permissions + disabled credential persistence reduce blast radius.

Prompted by: horsefacts