### PR TITLE
chore: remove mainnet is live banner

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -12,6 +12,13 @@ const baseUrl = (() => {
 })()
 
 export default defineConfig({
+  // banner: {
+  //   dismissable: false,
+  //   backgroundColor: '#5B4CDB',
+  //   content: 'Your announcement here. [Learn more.](https://tempo.xyz) →',
+  //   height: '40px',
+  //   textColor: 'white',
+  // },
   changelog: Changelog.github({ prereleases: true, repo: 'tempoxyz/tempo' }),
   // TODO: Set back to true once tempoxyz/tempo#tip-1011 dead link is fixed
   checkDeadlinks: 'warn',

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -12,13 +12,6 @@ const baseUrl = (() => {
 })()
 
 export default defineConfig({
-  banner: {
-    dismissable: false,
-    backgroundColor: '#5B4CDB',
-    content: 'Tempo Mainnet is live. [Read our announcement.](https://tempo.xyz/blog/mainnet) →',
-    height: '40px',
-    textColor: 'white',
-  },
   changelog: Changelog.github({ prereleases: true, repo: 'tempoxyz/tempo' }),
   // TODO: Set back to true once tempoxyz/tempo#tip-1011 dead link is fixed
   checkDeadlinks: 'warn',


### PR DESCRIPTION
Removes the "Tempo Mainnet is live" announcement banner from the docs site. The mainnet launch is no longer news — time to clean it up.