### PR TITLE
docs: deprecate Handler.feePayer in favor of Handler.relay

### DIFF
--- a/src/components/guides/steps/payments/SponsorUserFees.tsx
+++ b/src/components/guides/steps/payments/SponsorUserFees.tsx
@@ -44,7 +44,6 @@ export function SendRelayerSponsoredPayment(props: DemoStepProps) {
       to: recipient as `0x${string}`,
       token: alphaUsd,
       memo: memo ? pad(stringToHex(memo), { size: 32 }) : undefined,
-      // feePayer is automatic when relay has feePayer configured
     })
   }
 

--- a/src/components/guides/steps/payments/SponsorUserFees.tsx
+++ b/src/components/guides/steps/payments/SponsorUserFees.tsx
@@ -44,7 +44,7 @@ export function SendRelayerSponsoredPayment(props: DemoStepProps) {
       to: recipient as `0x${string}`,
       token: alphaUsd,
       memo: memo ? pad(stringToHex(memo), { size: 32 }) : undefined,
-      feePayer: true,
+      // feePayer is automatic when relay has feePayer configured
     })
   }
 

--- a/src/pages/accounts/api/provider.mdx
+++ b/src/pages/accounts/api/provider.mdx
@@ -111,7 +111,7 @@ const provider = Provider.create({
 - **Type:** `string | { url: string; precedence?: 'fee-payer-first' | 'user-first' }`
 - **Optional**
 
-Fee payer configuration for interacting with a service running [`Handler.feePayer`](/accounts/server/handler.feePayer) from `accounts/server`. Pass a URL string, or an object with `url` and optional `precedence` to control whether the fee payer or the user pays first.
+Fee payer configuration for interacting with a service running [`Handler.relay`](/accounts/server/handler.relay) from `accounts/server`. Pass a URL string, or an object with `url` and optional `precedence` to control whether the fee payer or the user pays first.
 
 ```ts twoslash
 import { Provider } from 'accounts'

--- a/src/pages/accounts/rpc/eth_fillTransaction.mdx
+++ b/src/pages/accounts/rpc/eth_fillTransaction.mdx
@@ -242,7 +242,7 @@ result.capabilities.fee
 
 ### With Sponsorship
 
-When the relay is configured with a [`feePayer`](/accounts/server/handler.relay#feepayer), all transactions are automatically sponsored. The response includes `sponsored: true` and `sponsor` details. Clients can opt out per-transaction by passing `feePayer: false`.
+When the relay is configured with a [`feePayer`](/accounts/server/handler.relay#feepayer), validated transactions are sponsored. The response includes `sponsored: true` and `sponsor` details.
 
 ```ts twoslash
 // @noErrors

--- a/src/pages/accounts/rpc/eth_fillTransaction.mdx
+++ b/src/pages/accounts/rpc/eth_fillTransaction.mdx
@@ -242,7 +242,7 @@ result.capabilities.fee
 
 ### With Sponsorship
 
-When the relay is configured with a [`feePayer`](/accounts/server/handler.relay#feepayer) and the request is sponsorable, the response includes `sponsored: true` and `sponsor` details.
+When the relay is configured with a [`feePayer`](/accounts/server/handler.relay#feepayer), all transactions are automatically sponsored. The response includes `sponsored: true` and `sponsor` details. Clients can opt out per-transaction by passing `feePayer: false`.
 
 ```ts twoslash
 // @noErrors

--- a/src/pages/accounts/server/handler.compose.mdx
+++ b/src/pages/accounts/server/handler.compose.mdx
@@ -13,8 +13,8 @@ Composes multiple handlers into a single handler, routing requests to the handle
 import { Handler } from 'accounts/server'
 
 const handler = Handler.compose([
-  Handler.feePayer({ 
-    account: privateKeyToAccount('0x...') 
+  Handler.relay({ 
+    feePayer: { account: privateKeyToAccount('0x...') },
   }),
   Handler.webAuthn({ 
     kv: Kv.memory(), 

--- a/src/pages/accounts/server/handler.feePayer.mdx
+++ b/src/pages/accounts/server/handler.feePayer.mdx
@@ -1,149 +1,42 @@
 ---
-title: Handler.feePayer
-description: Server handler that sponsors transaction fees for users.
+title: Handler.feePayer (Deprecated)
+description: Deprecated — use Handler.relay with feePayer option instead.
 ---
 
-# `Handler.feePayer`
+# `Handler.feePayer` (Deprecated)
 
-Creates a server handler that acts as a fee payer for transactions, enabling you to subsidize gas costs for users by signing transactions with a dedicated fee payer account on your backend.
-
-:::info
-[See the guide](/guide/payments/sponsor-user-fees)
+:::warning
+`Handler.feePayer` has been deprecated. Use [`Handler.relay`](/accounts/server/handler.relay) with the [`feePayer`](/accounts/server/handler.relay#feepayer) option instead.
 :::
 
-## Usage
+## Migration
 
-```ts
-import { privateKeyToAccount } from 'viem/accounts'
-import { Handler } from 'accounts/server'
+Replace `Handler.feePayer` calls with `Handler.relay` and nest the `account` under `feePayer`:
 
-const handler = Handler.feePayer({
-  account: privateKeyToAccount('0x...'),
-})
+```diff
+- const handler = Handler.feePayer({
+-   account: privateKeyToAccount('0x...'),
+- })
++ const handler = Handler.relay({
++   feePayer: {
++     account: privateKeyToAccount('0x...'),
++   },
++ })
 ```
 
-Then plug `handler` into your server framework of choice:
+All other options (`chains`, `transports`, `path`, `onRequest`) remain the same — `validate` moves inside `feePayer`:
 
-```ts
-createServer(handler.listener) // Node.js
-Bun.serve(handler) // Bun
-Deno.serve(handler) // Deno
-app.all('*', c => handler.fetch(c.request)) // Elysia
-app.use(handler.listener) // Express
-app.use(c => handler.fetch(c.req.raw)) // Hono
-export const GET = handler.fetch // Next.js
-export const POST = handler.fetch // Next.js
+```diff
+- const handler = Handler.feePayer({
+-   account: privateKeyToAccount('0x...'),
+-   validate: (request) => request.from !== blocked,
+- })
++ const handler = Handler.relay({
++   feePayer: {
++     account: privateKeyToAccount('0x...'),
++     validate: (request) => request.from !== blocked,
++   },
++ })
 ```
 
-## Parameters
-
-### account
-
-- **Type:** `LocalAccount`
-- **Required**
-
-The account to use as the fee payer. This account will sign all transactions and pay the gas fees.
-
-```ts twoslash
-import { privateKeyToAccount } from 'viem/accounts'
-import { Handler } from 'accounts/server'
-
-const handler = Handler.feePayer({
-  account: privateKeyToAccount('0x...'), // [!code focus]
-})
-```
-
-### chains
-
-- **Type:** `readonly [Chain, ...Chain[]]`
-- **Default:** `[tempo, tempoModerato]`
-
-Supported chains. The handler resolves the client based on the `chainId` in the incoming transaction.
-
-```ts twoslash
-import { privateKeyToAccount } from 'viem/accounts'
-import { tempo } from 'viem/chains'
-import { Handler } from 'accounts/server'
-
-const handler = Handler.feePayer({
-  account: privateKeyToAccount('0x...'),
-  chains: [tempo], // [!code focus]
-})
-```
-
-### onRequest
-
-- **Type:** `(request: RpcRequest) => Promise<void>`
-- **Optional**
-
-Callback called before processing each request. Useful for logging, rate limiting, or custom validation.
-
-```ts twoslash
-import { privateKeyToAccount } from 'viem/accounts'
-import { Handler } from 'accounts/server'
-
-const handler = Handler.feePayer({
-  account: privateKeyToAccount('0x...'),
-  onRequest: async (request) => { // [!code focus]
-    console.log('Processing request:', request.method) // [!code focus]
-  }, // [!code focus]
-})
-```
-
-### path
-
-- **Type:** `string`
-- **Default:** `'/'`
-
-Path where the handler listens for requests.
-
-```ts twoslash
-import { privateKeyToAccount } from 'viem/accounts'
-import { Handler } from 'accounts/server'
-
-const handler = Handler.feePayer({
-  account: privateKeyToAccount('0x...'),
-  path: '/fee-payer', // [!code focus]
-})
-```
-
-### transports
-
-- **Type:** `Record<number, Transport>`
-- **Default:** `http()` for each chain
-
-Transports keyed by chain ID.
-
-```ts twoslash
-import { http } from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
-import { tempo } from 'viem/chains'
-import { Handler } from 'accounts/server'
-
-const handler = Handler.feePayer({
-  account: privateKeyToAccount('0x...'),
-  transports: { // [!code focus]
-    [tempo.id]: http('https://rpc.tempo.xyz'), // [!code focus]
-  }, // [!code focus]
-})
-```
-
-
-### validate
-
-- **Type:** `(request: TransactionRequest) => boolean | Promise<boolean>`
-- **Optional**
-
-Validates whether to sponsor a transaction. When omitted, all transactions are sponsored. Return `false` to reject sponsorship — the handler will re-fill without `feePayer` so gas/nonce are correct for self-payment.
-
-```ts twoslash
-import { privateKeyToAccount } from 'viem/accounts'
-import { Handler } from 'accounts/server'
-
-const blocked = '0x...'
-
-const handler = Handler.feePayer({
-  account: privateKeyToAccount('0x...'),
-  validate: (request) => request.from !== blocked, // [!code focus]
-})
-```
+See [`Handler.relay`](/accounts/server/handler.relay) for the full API reference.

--- a/src/pages/accounts/server/handler.relay.mdx
+++ b/src/pages/accounts/server/handler.relay.mdx
@@ -77,7 +77,7 @@ export const POST = handler.fetch // Next.js
 
 ### Sponsorship
 
-Configure a [`feePayer`](#feepayer) to sponsor transactions. The relay signs `feePayerSignature` on the filled transaction and returns sponsor details in the response metadata. Use a [`validate`](#feepayervalidate) callback for conditional sponsorship — rejected transactions are re-filled for self-payment.
+Configure a [`feePayer`](#feepayer) to sponsor transactions. When a fee payer is configured, **all transactions are sponsored by default** — clients do not need to opt in. A client can opt out of sponsorship for a specific transaction by passing `feePayer: false`. Use a [`validate`](#feepayervalidate) callback for conditional sponsorship — rejected transactions are re-filled for self-payment.
 
 :::code-group
 
@@ -435,7 +435,7 @@ const handler = Handler.relay({
 - **Type:** `object`
 - **Optional**
 
-Fee payer configuration. When provided, the relay will sign `feePayerSignature` on the filled transaction.
+Fee payer configuration. When provided, the relay automatically sponsors all transactions by signing `feePayerSignature` on the filled transaction. Clients can opt out per-transaction by passing `feePayer: false`.
 
 ```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'

--- a/src/pages/accounts/server/handler.relay.mdx
+++ b/src/pages/accounts/server/handler.relay.mdx
@@ -77,7 +77,7 @@ export const POST = handler.fetch // Next.js
 
 ### Sponsorship
 
-Configure a [`feePayer`](#feepayer) to sponsor transactions. When a fee payer is configured, **all transactions are sponsored by default** — clients do not need to opt in. A client can opt out of sponsorship for a specific transaction by passing `feePayer: false`. Use a [`validate`](#feepayervalidate) callback for conditional sponsorship — rejected transactions are re-filled for self-payment.
+Configure a [`feePayer`](#feepayer) to sponsor transactions. The relay signs `feePayerSignature` on the filled transaction and returns sponsor details in the response metadata. Use a [`validate`](#feepayervalidate) callback for conditional sponsorship — rejected transactions are re-filled for self-payment.
 
 :::code-group
 
@@ -435,7 +435,7 @@ const handler = Handler.relay({
 - **Type:** `object`
 - **Optional**
 
-Fee payer configuration. When provided, the relay automatically sponsors all transactions by signing `feePayerSignature` on the filled transaction. Clients can opt out per-transaction by passing `feePayer: false`.
+Fee payer configuration. When provided, the relay will sign `feePayerSignature` on the filled transaction.
 
 ```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'

--- a/src/pages/accounts/server/index.mdx
+++ b/src/pages/accounts/server/index.mdx
@@ -17,8 +17,8 @@ Handlers are compatible with any server framework that supports the:
 import { Handler } from 'accounts/server'
 import { privateKeyToAccount } from 'viem/accounts'
 
-const handler = Handler.feePayer({
-  account: privateKeyToAccount('0x...'),
+const handler = Handler.relay({
+  feePayer: { account: privateKeyToAccount('0x...') },
 })
 
 createServer(handler.listener) // Node.js
@@ -39,7 +39,13 @@ export const POST = handler.fetch // Next.js
     title="Handler.compose"
   />
   <Card
-    description="Handle transactions that require a fee payer"
+    description="Proxy RPC requests with sponsorship, auto-swap, and balance diffs"
+    icon="lucide:radio"
+    to="/accounts/server/relay"
+    title="Handler.relay"
+  />
+  <Card
+    description="Handle transactions that require a fee payer (deprecated)"
     icon="lucide:credit-card"
     to="/accounts/server/feePayer"
     title="Handler.feePayer"

--- a/src/pages/accounts/server/index.mdx
+++ b/src/pages/accounts/server/index.mdx
@@ -45,12 +45,6 @@ export const POST = handler.fetch // Next.js
     title="Handler.relay"
   />
   <Card
-    description="Handle transactions that require a fee payer (deprecated)"
-    icon="lucide:credit-card"
-    to="/accounts/server/feePayer"
-    title="Handler.feePayer"
-  />
-  <Card
     description="Handle WebAuthn credential registration and authentication"
     icon="lucide:fingerprint"
     to="/accounts/server/webAuthn"

--- a/src/pages/accounts/wagmi/tempoWallet.mdx
+++ b/src/pages/accounts/wagmi/tempoWallet.mdx
@@ -87,7 +87,7 @@ export const config = createConfig({
 - **Type:** `string | { url: string; precedence?: 'fee-payer-first' | 'user-first' }`
 - **Optional**
 
-Fee payer configuration for interacting with a service running [`Handler.feePayer`](/accounts/server/handler.feePayer) from `accounts/server`. Pass a URL string, or an object with `url` and optional `precedence`.
+Fee payer configuration for interacting with a service running [`Handler.relay`](/accounts/server/handler.relay) from `accounts/server`. Pass a URL string, or an object with `url` and optional `precedence`.
 
 :::info
 [See the guide](/guide/payments/sponsor-user-fees)

--- a/src/pages/accounts/wagmi/webAuthn.mdx
+++ b/src/pages/accounts/wagmi/webAuthn.mdx
@@ -127,7 +127,7 @@ export const config = createConfig({
 - **Type:** `string | { url: string; precedence?: 'fee-payer-first' | 'user-first' }`
 - **Optional**
 
-Fee payer configuration for interacting with a service running [`Handler.feePayer`](/accounts/server/handler.feePayer) from `accounts/server`. Pass a URL string, or an object with `url` and optional `precedence`.
+Fee payer configuration for interacting with a service running [`Handler.relay`](/accounts/server/handler.relay) from `accounts/server`. Pass a URL string, or an object with `url` and optional `precedence`.
 
 :::info
 [See the guide](/guide/payments/sponsor-user-fees)

--- a/src/pages/guide/payments/sponsor-user-fees.mdx
+++ b/src/pages/guide/payments/sponsor-user-fees.mdx
@@ -30,7 +30,7 @@ Enable gasless transactions by sponsoring transaction fees for your users. Tempo
 Tempo provides a public testnet fee payer service at `https://sponsor.moderato.tempo.xyz` that you can use for development and testing. If you want to run your own, follow the instructions below.
 :::
 
-You can stand up a minimal fee payer service using the [`Handler.feePayer`](/accounts/server/handler.feePayer) handler provided by the [Tempo Accounts SDK](/accounts). To sponsor transactions, you need a funded account that will act as the fee payer.
+You can stand up a minimal fee payer service using the [`Handler.relay`](/accounts/server/handler.relay) handler provided by the [Tempo Accounts SDK](/accounts). To sponsor transactions, you need a funded account that will act as the fee payer.
 
 ```ts twoslash [server.ts]
 // @noErrors
@@ -78,7 +78,7 @@ export const config = createConfig({
 // @noErrors
 import { webAuthn } from 'accounts/wagmi'
 import { tempo } from 'viem/chains'
-import { withFeePayer } from 'viem/tempo'
+import { withRelay } from 'viem/tempo'
 import { createConfig, http } from 'wagmi'
 
 export const config = createConfig({
@@ -86,7 +86,7 @@ export const config = createConfig({
   chains: [tempo],
   multiInjectedProviderDiscovery: false,
   transports: {
-    [tempo.id]: withFeePayer( // [!code focus]
+    [tempo.id]: withRelay( // [!code focus]
       http(), // [!code focus]
       http('https://sponsor.moderato.tempo.xyz'), // [!code focus]
     ), // [!code focus]
@@ -211,7 +211,7 @@ The SDKs handle this automatically. Here's how each SDK manages the dual-signing
     ```
 
     :::info
-    Alternatively, use `feePayer: true` with the [`withFeePayer`](https://viem.sh/tempo/transports/withFeePayer) transport to delegate signing to a remote fee payer service. See the [Steps section above](#configure-your-client-to-use-the-fee-payer-service) for setup.
+    Alternatively, use `feePayer: true` with the [`withRelay`](https://viem.sh/tempo/transports/withRelay) transport to delegate signing to a remote fee payer service. See the [Steps section above](#configure-your-client-to-use-the-fee-payer-service) for setup.
     :::
 
   </Tab>

--- a/src/pages/guide/payments/sponsor-user-fees.mdx
+++ b/src/pages/guide/payments/sponsor-user-fees.mdx
@@ -98,7 +98,7 @@ export const config = createConfig({
 
 ### Sponsor your user's transactions
 
-All transactions are now automatically sponsored when a relay with a fee payer is configured — no client-side opt-in is needed. To opt out of sponsorship for a specific transaction, pass `feePayer: false`. For more details on how to send a transaction, see the [Send a payment](/guide/payments/send-a-payment) guide.
+Now transactions will be sponsored by your relay. For more details on how to send a transaction, see the [Send a payment](/guide/payments/send-a-payment) guide.
 
 :::info
 You can also build your own fee paying service. See [Build your own fee paying service](#build-your-own-fee-paying-service) below.
@@ -132,7 +132,7 @@ function SendSponsoredPayment() {
 
         sendPayment.mutate({ // [!code hl]
           amount: parseUnits('100', metadata.data.decimals), // [!code hl]
-          // feePayer: false, // uncomment to opt out of sponsorship // [!code focus]
+          feePayer: sponsorAccount, // [!code focus]
           to: recipient, // [!code hl]
           token: alphaUsd, // [!code hl]
         }) // [!code hl]
@@ -211,7 +211,7 @@ The SDKs handle this automatically. Here's how each SDK manages the dual-signing
     ```
 
     :::info
-    Alternatively, use the [`withRelay`](https://viem.sh/tempo/transports/withRelay) transport to delegate signing to a remote fee payer service — sponsorship is automatic. See the [Steps section above](#configure-your-client-to-use-the-fee-payer-service) for setup.
+    Alternatively, use the [`withRelay`](https://viem.sh/tempo/transports/withRelay) transport to delegate signing to a remote fee payer service. See the [Steps section above](#configure-your-client-to-use-the-fee-payer-service) for setup.
     :::
 
   </Tab>

--- a/src/pages/guide/payments/sponsor-user-fees.mdx
+++ b/src/pages/guide/payments/sponsor-user-fees.mdx
@@ -98,7 +98,7 @@ export const config = createConfig({
 
 ### Sponsor your user's transactions
 
-Now you can sponsor transactions by passing `feePayer: true` in the transaction parameters. For more details on how to send a transaction, see the [Send a payment](/guide/payments/send-a-payment) guide.
+All transactions are now automatically sponsored when a relay with a fee payer is configured — no client-side opt-in is needed. To opt out of sponsorship for a specific transaction, pass `feePayer: false`. For more details on how to send a transaction, see the [Send a payment](/guide/payments/send-a-payment) guide.
 
 :::info
 You can also build your own fee paying service. See [Build your own fee paying service](#build-your-own-fee-paying-service) below.
@@ -132,7 +132,7 @@ function SendSponsoredPayment() {
 
         sendPayment.mutate({ // [!code hl]
           amount: parseUnits('100', metadata.data.decimals), // [!code hl]
-          feePayer: true, // [!code focus]
+          // feePayer: false, // uncomment to opt out of sponsorship // [!code focus]
           to: recipient, // [!code hl]
           token: alphaUsd, // [!code hl]
         }) // [!code hl]
@@ -211,7 +211,7 @@ The SDKs handle this automatically. Here's how each SDK manages the dual-signing
     ```
 
     :::info
-    Alternatively, use `feePayer: true` with the [`withRelay`](https://viem.sh/tempo/transports/withRelay) transport to delegate signing to a remote fee payer service. See the [Steps section above](#configure-your-client-to-use-the-fee-payer-service) for setup.
+    Alternatively, use the [`withRelay`](https://viem.sh/tempo/transports/withRelay) transport to delegate signing to a remote fee payer service — sponsorship is automatic. See the [Steps section above](#configure-your-client-to-use-the-fee-payer-service) for setup.
     :::
 
   </Tab>

--- a/src/snippets/unformatted/withFeePayer.ts
+++ b/src/snippets/unformatted/withFeePayer.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
 // [!region client]
 import { walletActions } from 'viem'
-import { withFeePayer } from 'viem/tempo'
+import { withRelay } from 'viem/tempo'
 
 const _client = createClient({
   account: privateKeyToAccount('0x...'),
   chain: tempo,
-  transport: withFeePayer(
+  transport: withRelay(
     // [!code hl]
     http(), // [!code hl]
     http('http://localhost:3000'), // [!code hl]
@@ -34,9 +34,9 @@ const _receipt2 = await client.sendTransactionSync({
 import { Handler } from 'accounts/server'
 import { privateKeyToAccount } from 'viem/accounts'
 
-const handler = Handler.feePayer({
+const handler = Handler.relay({
   // [!code hl]
-  account: privateKeyToAccount('0x...'), // [!code hl]
+  feePayer: { account: privateKeyToAccount('0x...') }, // [!code hl]
 }) // [!code hl]
 
 const server = createServer(handler.listener)

--- a/src/snippets/unformatted/withFeePayer.ts
+++ b/src/snippets/unformatted/withFeePayer.ts
@@ -16,15 +16,15 @@ const _client = createClient({
 // [!endregion client]
 
 // [!region usage]
-// Regular transaction
+// Sponsored transaction (automatic when relay has feePayer configured)
 const _receipt1 = await client.sendTransactionSync({
   to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
 })
 
-// Sponsored transaction // [!code hl]
+// Opt out of sponsorship // [!code hl]
 const _receipt2 = await client.sendTransactionSync({
   // [!code hl]
-  feePayer: true, // [!code hl]
+  feePayer: false, // [!code hl]
   to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb', // [!code hl]
 }) // [!code hl]
 

--- a/src/snippets/wagmi.config.ts
+++ b/src/snippets/wagmi.config.ts
@@ -22,7 +22,7 @@ export const config = createConfig({
 // [!region withFeePayer]
 import { tempoWallet } from 'accounts/wagmi'
 import { tempo } from 'viem/chains'
-import { withFeePayer } from 'viem/tempo'
+import { withRelay } from 'viem/tempo'
 import { createConfig, http } from 'wagmi'
 import { KeyManager, webAuthn } from 'wagmi/tempo'
 

--- a/src/wagmi.config.ts
+++ b/src/wagmi.config.ts
@@ -4,7 +4,7 @@ import { tempoWallet, webAuthn as webAuthnAccounts } from 'accounts/wagmi'
 import * as React from 'react'
 import { parseUnits } from 'viem'
 import { tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
-import { withFeePayer } from 'viem/tempo'
+import { withRelay } from 'viem/tempo'
 import {
   type CreateConfigParameters,
   createConfig,
@@ -79,7 +79,7 @@ export function getConfig(options: getConfig.Options = {}) {
       key: 'tempo-docs',
     }),
     transports: {
-      [tempoModerato.id]: withFeePayer(
+      [tempoModerato.id]: withRelay(
         fallback([
           http('https://rpc.moderato.tempo.xyz'),
           webSocket('wss://rpc.moderato.tempo.xyz', {
@@ -89,7 +89,7 @@ export function getConfig(options: getConfig.Options = {}) {
         http('https://sponsor.moderato.tempo.xyz'),
         { policy: 'sign-only' },
       ),
-      [tempoDevnet.id]: withFeePayer(
+      [tempoDevnet.id]: withRelay(
         fallback([
           http(tempoDevnet.rpcUrls.default.http[0]),
           webSocket(tempoDevnet.rpcUrls.default.webSocket[0], {

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1188,7 +1188,7 @@ export default defineConfig({
     },
     {
       source: '/sdk/typescript/server/handler.feePayer',
-      destination: '/accounts/server/handler.feePayer',
+      destination: '/accounts/server/handler.relay',
       status: 301,
     },
     {


### PR DESCRIPTION
Reflects the deprecation of `Handler.feePayer` in [`tempoxyz/accounts@84a36ab`](https://github.com/tempoxyz/accounts/commit/84a36ab). Fee payer functionality is now accessed via `Handler.relay({ feePayer: { ... } })`.

### Changes

- **`handler.feePayer.mdx`** → replaced with deprecation notice + migration guide
- **Code examples** → updated from `Handler.feePayer({ account })` to `Handler.relay({ feePayer: { account } })`
- **Transport** → `withFeePayer` → `withRelay` across snippets and `wagmi.config.ts`
- **Links** → all `Handler.feePayer` references now point to `Handler.relay`
- **Redirect** → old SDK path now redirects to `handler.relay`