### PR TITLE
docs: point to upstream foundry

### DIFF
--- a/src/pages/guide/tempo-transaction/index.mdx
+++ b/src/pages/guide/tempo-transaction/index.mdx
@@ -78,7 +78,7 @@ Integrating Tempo Transactions is easy and can be done quickly by a developer in
 | **Python**       | [pytempo](https://github.com/tempoxyz/pytempo)                                | < 1 hour         |
 | **Other Languages** | Reach out to us! The specification is [here](/protocol/transactions/spec-tempo-transaction) and easy to build against.                                                                  | 1-3 days         |
 
-If you are an EVM smart contract developer, see the [Tempo extension for Foundry](/sdk/foundry).
+If you are an EVM smart contract developer, see the [Foundry guide for Tempo](/sdk/foundry).
 
 
 ## Properties

--- a/src/pages/protocol/transactions/index.mdx
+++ b/src/pages/protocol/transactions/index.mdx
@@ -62,7 +62,7 @@ Integrating Tempo Transactions is easy and can be done quickly by a developer in
 | **Python**       | [pytempo](https://github.com/tempoxyz/pytempo)                                | < 1 hour         |
 | **Other Languages** | Reach out to us! The specification is [here](/protocol/transactions/spec-tempo-transaction) and easy to build against.                                                                  | 1-3 days         |
 
-If you are an EVM smart contract developer, see the [Tempo extension for Foundry](/sdk/foundry).
+If you are an EVM smart contract developer, see the [Foundry guide for Tempo](/sdk/foundry).
 
 
 ## Properties

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -72,7 +72,7 @@ Tempo's broader tooling ecosystem is available in [Developer tools](/quickstart/
 | [Rust](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) | [`tempo-alloy@1.5.1`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) |
 | [Go](https://github.com/tempoxyz/tempo-go) | [`v0.4.0`](https://github.com/tempoxyz/tempo-go/releases/tag/v0.4.0) |
 | [Python](https://github.com/tempoxyz/pytempo) | [`0.5.0`](https://github.com/tempoxyz/pytempo/releases/tag/pytempo%400.5.0) |
-| [Foundry](https://github.com/tempoxyz/tempo-foundry) | [`v1.6.0-t3`](https://github.com/tempoxyz/tempo-foundry/releases/tag/v1.6.0-t3) |
+| [Foundry](https://github.com/foundry-rs/foundry) | [`nightly`](https://github.com/foundry-rs/foundry/releases/tag/nightly) |
 
 ## Related docs
 Guides about TIPs coming soon.

--- a/src/pages/quickstart/verify-contracts.mdx
+++ b/src/pages/quickstart/verify-contracts.mdx
@@ -233,7 +233,7 @@ View the full API documentation at [contracts.tempo.xyz/docs](https://contracts.
 ## Troubleshooting
 
 :::tip
-If you encounter unexpected failures, you might be running an older version of Foundry/Forge, or you might not be running Tempo's Foundry fork. See the [Foundry setup guide](/sdk/foundry) for installation instructions.
+If you encounter unexpected failures, you might be running an older version of Foundry/Forge. See the [Foundry setup guide](/sdk/foundry) for installation instructions.
 :::
 
 ### Verification Failed

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -4,7 +4,7 @@ description: Build, test, and deploy smart contracts on Tempo using Foundry. Acc
 
 # Foundry for Tempo
 
-Tempo is a supported as a first-class citizen in [Foundry](https://github.com/foundry-rs/foundry): the leading Ethereum development toolkit.
+Tempo is supported as a first-class citizen in [Foundry](https://github.com/foundry-rs/foundry): the leading Ethereum development toolkit.
 
 Install the latest nightly to access Tempo's [protocol-level features](/protocol/) in `forge`, `cast`, `anvil`, and `chisel`, and to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
 

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -4,7 +4,7 @@ description: Build, test, and deploy smart contracts on Tempo using Foundry. Acc
 
 # Foundry for Tempo
 
-Tempo support now lives in upstream [Foundry](https://github.com/foundry-rs/foundry) nightly.
+Tempo is a supported as a first-class citizen in [Foundry](https://github.com/foundry-rs/foundry): the leading Ethereum development toolkit.
 
 Install the latest nightly to access Tempo's [protocol-level features](/protocol/) in `forge`, `cast`, `anvil`, and `chisel`, and to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
 

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -1,22 +1,26 @@
 ---
-description: Build, test, and deploy smart contracts on Tempo using the Foundry fork. Access protocol-level features with forge and cast tools.
+description: Build, test, and deploy smart contracts on Tempo using Foundry. Access Tempo protocol features with forge, cast, anvil, and chisel.
 ---
 
 # Foundry for Tempo
 
-Tempo builds on top of [Foundry](https://github.com/foundry-rs/foundry): the leading Ethereum development toolkit, through a custom fork that adds first-class support for Tempo.
+Tempo support now lives in upstream [Foundry](https://github.com/foundry-rs/foundry) nightly.
 
-This fork extends Foundry with Tempo's [protocol-level features](/protocol/), enabling developers to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
+Install the latest nightly to access Tempo's [protocol-level features](/protocol/) in `forge`, `cast`, `anvil`, and `chisel`, and to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
+
+:::warning[`tempo-foundry` is deprecated]
+`tempo-foundry` and `foundryup -n tempo` are deprecated. Switch to upstream Foundry nightly with `foundryup --install nightly`.
+:::
 
 For general information about Foundry, see the [Foundry documentation](https://getfoundry.sh/).
 
 ## Get started with Foundry
 
-Tempo's Foundry fork is installed through the standard upstream `foundryup` using the `-n tempo` flag, no separate installer is required.
+Install the latest Foundry nightly to get Tempo support.
 
-::::steps
+:::::steps
 
-## Install `foundryup`
+### Install `foundryup`
 
 If you don't have `foundryup` installed yet:
 
@@ -24,50 +28,85 @@ If you don't have `foundryup` installed yet:
 curl -L https://foundry.paradigm.xyz | bash
 ```
 
-Or if you already have `foundryup` installed:
+### Install the latest Foundry nightly
 
 ```bash
-foundryup --update
+foundryup --install nightly
 ```
 
-## Install Tempo's Foundry fork
+This installs the latest `nightly` release of [`forge`](https://getfoundry.sh/forge/overview#forge), [`cast`](https://getfoundry.sh/cast/overview#cast), [`anvil`](https://getfoundry.sh/anvil/overview#anvil), and [`chisel`](https://getfoundry.sh/chisel/overview#chisel).
 
-```bash
-foundryup -n tempo
-```
-
-This will automatically install the latest `nightly` release of all precompiled binaries: [`forge`](https://getfoundry.sh/forge/overview#forge), [`cast`](https://getfoundry.sh/cast/overview#cast), [`anvil`](https://getfoundry.sh/anvil/overview#anvil), and [`chisel`](https://getfoundry.sh/chisel/overview#chisel).
 
 :::tip
 To install a specific version, replace `<TAG_NAME>` with the desired release tag:
+
 ```bash
-foundryup -n tempo -i <TAG_NAME>
+foundryup --install <TAG_NAME>
 ```
 :::
 
-## Verify Installation
+### Create a new Foundry project
 
-```bash
-forge -V
-```
-
-You should see version information include `-tempo`, indicating you are using the Tempo fork.
-
-```bash
-# forge <version>-tempo (<commit> <timestamp>)
-```
-
-## Create a new Foundry project
-
-Initialize a new project with Tempo support:
+Initialize a new Foundry project with the Tempo template:
 
 ```bash
 forge init -n tempo my-project && cd my-project
 ```
 
-Each new project is configured for Tempo out of the box, with [`tempo-std`](https://github.com/tempoxyz/tempo-std), the Tempo standard library installed, containing helpers for Tempo's protocol-level features.
+This gives you a Tempo-ready starter project, including the Tempo `Mail` example template.
 
-::::
+If you're adding Tempo support to an existing Foundry project, install [`tempo-std`](https://github.com/tempoxyz/tempo-std) manually:
+
+```bash
+forge install tempoxyz/tempo-std
+```
+
+:::::
+
+## Configure `foundry.toml`
+
+The Tempo template gives you a working starting point, but it is often useful to make Tempo explicit in `foundry.toml`.
+
+### Configure RPC aliases
+
+Set a default Tempo RPC alias and keep a separate alias for Moderato testnet:
+
+```toml
+[profile.default]
+eth_rpc_url = "tempo"
+
+[rpc_endpoints]
+tempo = "${TEMPO_RPC_URL}"
+moderato = "${TEMPO_TESTNET_RPC_URL}"
+```
+
+With this config, commands that use the default RPC pick up `tempo` automatically, and you can still switch explicitly with `--rpc-url moderato`.
+
+### Activate Tempo features explicitly
+
+For most projects, the most flexible option is to enable Tempo network features directly:
+
+```toml
+[profile.default]
+tempo = true
+```
+
+This network flag, enables Tempo-specific network behavior while still letting Foundry resolve the right semantics from the chain you are targeting.
+
+If you need advanced testing against a specific Tempo hardfork, pin it explicitly in `foundry.toml` or via inline-config:
+
+```toml
+[profile.default]
+hardfork = "tempo:T3"
+```
+
+This is the advanced option when you want local simulation, tests, or scripts to run against a specific Tempo hardfork such as T3. It also infers the Tempo network in Foundry's config layer.
+
+### Verification config
+
+Tempo's contract verifier is Sourcify-compatible. Configure verification with `VERIFIER_URL=https://contracts.tempo.xyz` or `--verifier-url https://contracts.tempo.xyz`.
+
+The `[etherscan]` table in `foundry.toml` is for Etherscan-style verifiers, not Tempo's verifier.
 
 ## Use Foundry for your workflows
 
@@ -385,4 +424,3 @@ cast keychain key-info <ACCOUNT> <KEY_ID> \
 cast keychain remaining-limit <ACCOUNT> <KEY_ID> <TOKEN_ADDRESS> \
   --rpc-url $TEMPO_RPC_URL
 ```
-

--- a/src/pages/sdk/foundry/mpp.mdx
+++ b/src/pages/sdk/foundry/mpp.mdx
@@ -7,7 +7,7 @@ import { Card, Cards } from 'vocs'
 
 # Use MPP with Foundry
 
-Foundry nightly includes native MPP support on Tempo. When an RPC endpoint returns `402 Payment Required`, Foundry automatically handles the payment challenge with no wrapper scripts, middleware, or code changes.
+Foundry includes native MPP support on Tempo. When an RPC endpoint returns `402 Payment Required`, Foundry automatically handles the payment challenge with no wrapper scripts, middleware, or code changes.
 
 :::warning[`tempo-foundry` is deprecated]
 `tempo-foundry` and `foundryup -n tempo` are deprecated. Install upstream Foundry nightly with `foundryup --install nightly`.

--- a/src/pages/sdk/foundry/mpp.mdx
+++ b/src/pages/sdk/foundry/mpp.mdx
@@ -10,7 +10,7 @@ import { Card, Cards } from 'vocs'
 Foundry includes native MPP support on Tempo. When an RPC endpoint returns `402 Payment Required`, Foundry automatically handles the payment challenge with no wrapper scripts, middleware, or code changes.
 
 :::warning[`tempo-foundry` is deprecated]
-`tempo-foundry` and `foundryup -n tempo` are deprecated. Install upstream Foundry nightly with `foundryup --install nightly`.
+`tempo-foundry` and `foundryup -n tempo` are deprecated. Install upstream Foundry nightly with `foundryup -i nightly`.
 :::
 
 Every Foundry tool works transparently with MPP-gated endpoints:

--- a/src/pages/sdk/foundry/mpp.mdx
+++ b/src/pages/sdk/foundry/mpp.mdx
@@ -54,7 +54,7 @@ curl -fsSL https://tempo.xyz/install | bash
 Tempo support now ships in Foundry's nightly:
 
 ```bash
-foundryup --install nightly
+foundryup -i nightly
 ```
 
 All standard Foundry commands work as before — MPP activates only when an endpoint returns `402`.

--- a/src/pages/sdk/foundry/mpp.mdx
+++ b/src/pages/sdk/foundry/mpp.mdx
@@ -7,7 +7,11 @@ import { Card, Cards } from 'vocs'
 
 # Use MPP with Foundry
 
-[Tempo Foundry](https://github.com/tempoxyz/tempo-foundry) extends Foundry with native MPP support. When an RPC endpoint returns `402 Payment Required`, Foundry automatically handles the payment challenge — no wrapper scripts, no middleware, no code changes.
+Foundry nightly includes native MPP support on Tempo. When an RPC endpoint returns `402 Payment Required`, Foundry automatically handles the payment challenge with no wrapper scripts, middleware, or code changes.
+
+:::warning[`tempo-foundry` is deprecated]
+`tempo-foundry` and `foundryup -n tempo` are deprecated. Install upstream Foundry nightly with `foundryup --install nightly`.
+:::
 
 Every Foundry tool works transparently with MPP-gated endpoints:
 
@@ -26,19 +30,18 @@ When you point any Foundry tool at an MPP-gated RPC URL, the built-in transport 
 4. **Channel open** — If no payment channel exists, Foundry opens one on-chain with a deposit (default: `100,000` base units). This is a one-time on-chain lockup — unused balance remains in the channel.
 5. **Voucher payment** — Foundry signs an off-chain voucher against the open channel and retries the request with an `Authorization: Payment` header.
 6. **Auto top-up** — When a channel's deposit is exhausted, Foundry sends a top-up transaction. The server accepts it with `204 No Content`, then Foundry signs a fresh voucher and retries automatically.
-6. **Channel reuse** — Subsequent requests reuse the same channel. Channel state is persisted to `$TEMPO_HOME/foundry/channels.json` (default `~/.tempo/foundry/channels.json`) across process invocations.
+7. **Channel reuse** — Subsequent requests reuse the same channel. Channel state is persisted to `$TEMPO_HOME/foundry/channels.json` (default `~/.tempo/foundry/channels.json`) across process invocations.
 
 :::tip
 Channel reuse means the first call to an MPP endpoint has roughly one confirmation of overhead (~500ms on Tempo), but all subsequent calls add near-zero latency.
 :::
 
 ## Setup
-:::
 
 :::note
 Some endpoints use a one-shot `charge` intent instead of session-based channels. Foundry handles both — charge payments sign a single TIP-20 transfer without opening a channel.
 :::
-::::steps
+:::::steps
 
 ### Install the Tempo CLI
 
@@ -46,12 +49,12 @@ Some endpoints use a one-shot `charge` intent instead of session-based channels.
 curl -fsSL https://tempo.xyz/install | bash
 ```
 
-### Install Tempo Foundry
+### Install Foundry
 
-Tempo's fork is installed through the standard `foundryup` using the `-n tempo` flag:
+Tempo support now ships in Foundry's nightly:
 
 ```bash
-foundryup -n tempo
+foundryup --install nightly
 ```
 
 All standard Foundry commands work as before — MPP activates only when an endpoint returns `402`.
@@ -78,7 +81,7 @@ Point any Foundry tool at an MPP-gated RPC URL. No additional flags or config ne
 cast block-number --rpc-url https://rpc.mpp.tempo.xyz
 ```
 
-::::
+:::::
 
 ## Examples
 
@@ -206,15 +209,6 @@ Channels are automatically evicted when fully spent or closed. If the server res
 Use the Moderato testnet MPP endpoint for development:
 
 ```bash
-### Channel persistence
-
-Open channels are saved to `$TEMPO_HOME/foundry/channels.json` (default `~/.tempo/foundry/channels.json`). This allows channel reuse across process invocations — you won't re-open a channel every time you run `cast` or `forge`.
-
-Channels are automatically evicted when fully spent or closed. If the server restarts and returns `410 Gone`, Foundry clears stale local state and opens a fresh channel on the next request.
-
-### Gas sponsorship
-
-Some MPP endpoints sponsor gas fees on behalf of the caller. When the server's challenge includes a `feePayer` flag, Foundry delegates gas payment to the server — no TEMPO balance needed for gas.
 cast block-number --rpc-url https://rpc.mpp.moderato.tempo.xyz
 
 # Mainnet
@@ -222,6 +216,10 @@ cast block-number --rpc-url https://rpc.mpp.tempo.xyz
 ```
 
 Fund your testnet wallet with `tempo wallet fund` before making requests.
+
+### Gas sponsorship
+
+Some MPP endpoints sponsor gas fees on behalf of the caller. When the server's challenge includes a `feePayer` flag, Foundry delegates gas payment to the server, so no TEMPO balance is needed for gas.
 
 ## Troubleshooting
 

--- a/src/pages/sdk/foundry/mpp.mdx
+++ b/src/pages/sdk/foundry/mpp.mdx
@@ -219,7 +219,7 @@ Fund your testnet wallet with `tempo wallet fund` before making requests.
 
 ### Gas sponsorship
 
-Some MPP endpoints sponsor gas fees on behalf of the caller. When the server's challenge includes a `feePayer` flag, Foundry delegates gas payment to the server, so no TEMPO balance is needed for gas.
+Some MPP endpoints sponsor gas fees on behalf of the caller. When the server's challenge includes a `feePayer` flag, Foundry delegates gas payment to the server, so no native balance is needed for gas.
 
 ## Troubleshooting
 


### PR DESCRIPTION
this PR migrates off `tempo-foundry` and points users to using upstream `foundry` instead