### PR TITLE
fix: update broken bridge links on getting-funds page

### DIFF
--- a/src/pages/guide/getting-funds.mdx
+++ b/src/pages/guide/getting-funds.mdx
@@ -51,7 +51,7 @@ codex exec "Read https://tempo.xyz/SKILL.md and fund my Tempo Wallet"
 
 Use one of these supported bridges to move assets to Tempo:
 
-- **[LayerZero (Stargate)](/guide/bridge-usdc-stargate)**: Bridge USDC to and from Tempo via Stargate. See the [full bridging guide](/guide/bridge-usdc-stargate) for contract addresses, code examples, and EndpointDollar details.
+- **[LayerZero (Stargate)](/guide/bridge-layerzero)**: Bridge USDC to and from Tempo via Stargate. See the [full bridging guide](/guide/bridge-layerzero) for contract addresses, code examples, and EndpointDollar details.
 - **[Squid](https://app.squidrouter.com/)**: Swap and bridge assets to Tempo in one flow.
 - **[Relay](https://relay.link/)**: Bridge assets to Tempo with low fees.
 - **[Across](https://app.across.to/)**: Bridge assets to Tempo quickly with competitive fees.


### PR DESCRIPTION
The `bridge-usdc-stargate` page was renamed to `bridge-layerzero` in PR #300 but the two links in `getting-funds.mdx` weren't updated, causing broken links at [docs.tempo.xyz/guide/getting-funds#bridge](https://docs.tempo.xyz/guide/getting-funds#bridge).

Updates both `/guide/bridge-usdc-stargate` → `/guide/bridge-layerzero`.

Prompted by: Max