### PR TITLE
docs: improve zones overview copy

### DIFF
--- a/src/pages/protocol/zones/index.mdx
+++ b/src/pages/protocol/zones/index.mdx
@@ -8,7 +8,7 @@ import { Cards, Card } from 'vocs'
 # Tempo Zones
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones are still in early development and available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
 :::
 
 A Tempo Zone is a private execution environment attached to Tempo Mainnet. Inside a Tempo Zone, balances, transfers, and transaction history are invisible to block explorers, indexers, and other users on Tempo Mainnet. Each Tempo Zone runs its own sequencer and executes transactions independently.
@@ -43,7 +43,11 @@ Validity proofs guarantee correct state transitions. Sequencers order transactio
 
 Tempo Zones are interoperable with Tempo Mainnet and with each other. Deposits and withdrawals settle in seconds. A Tempo Zone can withdraw tokens, swap them on the Stablecoin DEX, and deposit the result into another Tempo Zone in a single operation. The [bridging specification](/protocol/zones/bridging) covers deposits, withdrawals, encrypted deposits for private on-ramps, and composable withdrawal callbacks for cross-zone transfers.
 
-## Specifications
+### Github and Specifications
+
+The zones repository is available on [github](https://github.com/tempoxyz/zones), which also includes the full Tempo Zones [specifications](https://github.com/tempoxyz/zones/blob/main/docs/specs/zone_spec.md).
+
+## Reference
 
 <Cards>
   <Card


### PR DESCRIPTION
## Summary
- clarify the Tempo Zones availability notice on the overview page
- add direct links to the `tempoxyz/zones` repository and canonical spec
- relabel the card section from `Specifications` to `Reference`

## Test plan
- [ ] Open `/protocol/zones` and confirm the updated notice text reads naturally.
- [ ] Verify the new GitHub and spec links resolve to the expected repository pages.


Made with [Cursor](https://cursor.com)