### PR TITLE
Replace dead zones email with contact page

### DIFF
--- a/src/pages/guide/private-zones/connect-to-a-zone.mdx
+++ b/src/pages/guide/private-zones/connect-to-a-zone.mdx
@@ -6,7 +6,7 @@ description: Connect to Tempo Zones on testnet using Zone A and Zone B RPC URLs,
 # Connect to a Zone
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 Use this page when you need the RPC endpoint and chain metadata for `Zone A` or `Zone B`.

--- a/src/pages/guide/private-zones/deposit-to-a-zone.mdx
+++ b/src/pages/guide/private-zones/deposit-to-a-zone.mdx
@@ -13,7 +13,7 @@ export const depositZoneBalances = [{ label: 'Zone A', token: Demo.pathUsd, zone
 # Deposit to a Zone
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 Use this guide when you want to move `pathUSD` from your public Tempo balance into `Zone A`. You will submit a public-chain deposit first, then wait for `Zone A` to credit the net amount after fees.

--- a/src/pages/guide/private-zones/index.mdx
+++ b/src/pages/guide/private-zones/index.mdx
@@ -8,7 +8,7 @@ import { Card, Cards } from 'vocs'
 # Connect to Tempo Zones
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 Tempo Zones let you keep balances and transfers inside a private execution environment while still using the public Tempo chain when funds enter or leave. The important thing to remember is that most zone flows settle in stages: a public or zone transaction lands first, then the private balance update appears shortly after.

--- a/src/pages/guide/private-zones/send-tokens-across-zones.mdx
+++ b/src/pages/guide/private-zones/send-tokens-across-zones.mdx
@@ -15,7 +15,7 @@ export const crossZoneBalances = [
 # Send tokens across zones
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 Use this guide when you want to move `pathUSD` from `Zone A` into `Zone B` without changing the token. The route still touches the public chain, so the confirmation happens in stages rather than as a single balance update.

--- a/src/pages/guide/private-zones/send-tokens-within-a-zone.mdx
+++ b/src/pages/guide/private-zones/send-tokens-within-a-zone.mdx
@@ -12,7 +12,7 @@ export const inZoneBalances = [{ label: 'Zone A', token: Demo.pathUsd, zone: 6 }
 # Send tokens within a zone
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 Use this guide when you want to send `pathUSD` from one private `Zone A` balance to another without moving funds back through the public chain.

--- a/src/pages/guide/private-zones/swap-across-zones.mdx
+++ b/src/pages/guide/private-zones/swap-across-zones.mdx
@@ -15,7 +15,7 @@ export const swapZoneBalances = [
 # Swap across zones
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 Use this guide when you want to leave `Zone A` with `pathUSD` and arrive in `Zone B` with `betaUSD` in one routed flow. The trade briefly touches the public chain, so the confirmation happens in stages rather than as a single balance update.

--- a/src/pages/guide/private-zones/withdraw-from-a-zone.mdx
+++ b/src/pages/guide/private-zones/withdraw-from-a-zone.mdx
@@ -13,7 +13,7 @@ export const withdrawalZoneBalances = [{ label: 'Zone A', token: Demo.pathUsd, z
 # Withdraw from a Zone
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 Use this guide when you want to move `pathUSD` out of `Zone A` and back to your public Tempo balance.

--- a/src/pages/protocol/zones/accounts.mdx
+++ b/src/pages/protocol/zones/accounts.mdx
@@ -6,7 +6,7 @@ description: Account-scoped access control on Tempo Zones, including private bal
 # Accounts
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 Tempo Zones enforce account privacy at two complementary layers: the EVM execution level and the [RPC access control](/protocol/zones/rpc) level. Neither is sufficient alone.

--- a/src/pages/protocol/zones/architecture.mdx
+++ b/src/pages/protocol/zones/architecture.mdx
@@ -8,7 +8,7 @@ import { StaticMermaidDiagram } from '../../../components/StaticMermaidDiagram'
 # Tempo Zone Architecture
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 A Tempo Zone is a dedicated blockchain rooted to Tempo Mainnet where one sequencer controls block production and visibility. No zone data is published on Tempo Mainnet. Instead, the sequencer publishes commitments to the current zone state along with proofs of correct execution. These proofs allow funds to move in and out of the Tempo Zone. This scaling approach is known as a validium.

--- a/src/pages/protocol/zones/bridging.mdx
+++ b/src/pages/protocol/zones/bridging.mdx
@@ -6,7 +6,7 @@ description: Deposit and withdraw TIP-20 tokens between Tempo Mainnet and Tempo 
 # Zone Bridging
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 Tempo Zones use Tempo-centric bridging for cross-chain operations: deposits flow from Tempo into a zone, and withdrawals flow from a zone back to Tempo with optional callbacks for composability.

--- a/src/pages/protocol/zones/execution.mdx
+++ b/src/pages/protocol/zones/execution.mdx
@@ -6,7 +6,7 @@ description: Specification for gas accounting, fee tokens, fixed TIP-20 gas cost
 # Execution & Gas
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 This page specifies how Tempo Zones handle gas accounting, fee collection, and token management. For deposit and withdrawal flows, see the [bridging specification](/protocol/zones/bridging). For balance visibility and access control rules, see the [accounts specification](/protocol/zones/accounts).

--- a/src/pages/protocol/zones/index.mdx
+++ b/src/pages/protocol/zones/index.mdx
@@ -8,7 +8,7 @@ import { Cards, Card } from 'vocs'
 # Tempo Zones
 
 :::info
-Tempo Zones are still in early development and available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones are still in early development and available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 A Tempo Zone is a private execution environment attached to Tempo Mainnet. Inside a Tempo Zone, balances, transfers, and transaction history are invisible to block explorers, indexers, and other users on Tempo Mainnet. Each Tempo Zone runs its own sequencer and executes transactions independently.

--- a/src/pages/protocol/zones/proving.mdx
+++ b/src/pages/protocol/zones/proving.mdx
@@ -8,7 +8,7 @@ import { StaticMermaidDiagram } from '../../../components/StaticMermaidDiagram'
 # Zone Proving
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 :::warning

--- a/src/pages/protocol/zones/rpc.mdx
+++ b/src/pages/protocol/zones/rpc.mdx
@@ -6,7 +6,7 @@ description: Authenticated JSON-RPC interface for Tempo Zones with per-account s
 # Zone RPC
 
 :::info
-Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, reach out to us at [zones@tempo.xyz](mailto:zones@tempo.xyz).
+Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).
 :::
 
 The zone RPC starts from the standard Ethereum JSON-RPC and restricts it to enforce privacy guarantees. Every RPC request must include an authorization token that proves the caller controls a Tempo account and scopes all responses to that account.


### PR DESCRIPTION
## Summary
- replace the dead `zones@tempo.xyz` mailto link with the public contact page
- update the link text to `tempo.xyz/contact` across the Tempo Zones docs

## Verification
- `bun run check` (passes with existing `scripts/lighthouse.ts` warnings)