### PR TITLE
docs(ecosystem): add Pellet to Data & Analytics

### DIFF
--- a/src/pages/ecosystem/data-analytics.mdx
+++ b/src/pages/ecosystem/data-analytics.mdx
@@ -59,6 +59,18 @@ Get started with the [CoinGecko API](https://docs.coingecko.com/reference/introd
 
 Start indexing Tempo [here](https://goldsky.com/chains/tempo).
 
+## Pellet
+
+[Pellet](https://pelletfi.com) delivers Open-Ledger Intelligence (OLI) for every TIP-20 stablecoin on Tempo — direct on-chain measurement of peg spread vs pathUSD, TIP-403 policy state (allowlist / blocklist / pause), reserve composition with attestation provenance, TIP-20 reward attribution and effective APY, fee-token economics, DEX flow topology, cross-stable flow anomalies, peg-break events, and composite risk scores with explainable sub-scores. Every numeric value is a direct measurement; null means unmeasured and is never inferred as zero.
+
+Fifteen endpoints — fourteen free + one MPP-paid deep briefing — are consumable directly over HTTP, via the [@pelletfi/sdk](https://www.npmjs.com/package/@pelletfi/sdk) TypeScript client, the [@pelletfi/mcp](https://www.npmjs.com/package/@pelletfi/mcp) MCP server, or the [Pellet entry in MPPScan](https://mppscan.com). All stablecoin-scoped endpoints support historical snapshots via `?as_of=<ISO8601 | epoch | relative>`.
+
+Review the [Pellet API documentation](https://pelletfi.com/docs/api) and the [OLI methodology](https://pelletfi.com/docs/oli).
+
+:::tip
+Pellet ships the first pre-trade TIP-403 compliance oracle on Tempo. Agents call `GET /api/v1/tip403/simulate?from=…&to=…&token=…&amount=…` before submitting a transfer to predict whether it would revert under the token's policy — without spending gas on the attempt. Returns a tri-state `willSucceed` (`true` | `false` | `null`) plus policy id, policy type, per-party authorization, and balance verification.
+:::
+
 ## Range
 
 [Range](https://www.range.org) powers the Stablecoin Explorer, which provides a unified view of major stablecoins across 100+ chains. Tempo is fully supported, allowing developers and users to trace stablecoin flows in a way traditional explorers cannot.


### PR DESCRIPTION
## Summary

Adds a Pellet entry to the [Data & Analytics ecosystem page](https://docs.tempo.xyz/ecosystem/data-analytics), placed alphabetically between **Goldsky** and **Range**.

## What Pellet is

[Pellet](https://pelletfi.com) is Open-Ledger Intelligence (OLI) for Tempo — direct on-chain measurement for every TIP-20 stablecoin:

- Peg spread vs pathUSD (measured on-chain via the enshrined DEX, not oracle-aggregated)
- TIP-403 policy state + enforcement (allowlist / blocklist / pause, supply cap + headroom)
- Reserve composition with attestation provenance
- TIP-20 reward attribution + effective APY (reads the reward precompile)
- Fee-token economics (reads the fee manager precompile)
- DEX flow topology + ≥3σ cross-stable flow anomalies
- Composite risk scores with explainable sub-scores (peg / peg-break / supply / policy)
- Historical time-travel via `?as_of=` on every stablecoin-scoped endpoint

Discipline note: null means unmeasured and is never inferred as zero.

## Access surfaces

- HTTP: [pelletfi.com/docs/api](https://pelletfi.com/docs/api)
- TypeScript SDK: [@pelletfi/sdk](https://www.npmjs.com/package/@pelletfi/sdk)
- MCP server: [@pelletfi/mcp](https://www.npmjs.com/package/@pelletfi/mcp)
- MPP directory: [Pellet on MPPScan](https://mppscan.com)

## Highlight worth calling out

Pellet ships the first pre-trade TIP-403 compliance oracle on Tempo at `GET /api/v1/tip403/simulate`. Agents call it before submitting a transfer to predict whether it would revert under the token's policy — avoiding wasted gas on `Unauthorized()` reverts. Returns a tri-state `willSucceed` (`true` | `false` | `null`) plus policy id, policy type, per-party authorization, and optional balance verification. The tri-state is deliberate: `null` signals a measurement gap, not inferred denial.

## Changes

- `src/pages/ecosystem/data-analytics.mdx` — one new `## Pellet` section (12 lines added)

No other files touched. No dependency changes.