### PR TITLE
fix: clarify `TransferWithMemo` event description

### DIFF
--- a/src/pages/guide/payments/send-a-payment.mdx
+++ b/src/pages/guide/payments/send-a-payment.mdx
@@ -1001,7 +1001,7 @@ Send multiple payments in a single transaction using batch transactions:
 When you send a payment, the token contract emits events:
 
 - **Transfer**: Standard ERC-20 transfer event
-- **TransferWithMemo**: Additional event with memo (if using `transferWithMemo`)
+- **TransferWithMemo**: Additional event emitted automatically when a `memo` is passed to `token.transfer`
 
 You can filter these events to track payments in your off-chain systems.
 


### PR DESCRIPTION
The previous note implied developers call `transferWithMemo` directly. 

Looking at the SDK source in `wevm/viem` (`src/tempo/actions/token.ts`), `transferWithMemo` is called internally by `token.transfer` when a `memo` param is passed — developers never call it directly.

Updated the note to reflect the actual developer experience.