### PR TITLE
docs(rpc-node): add --tempo.bootnodes-endpoint to example commands

### DIFF
--- a/src/pages/guide/node/rpc.mdx
+++ b/src/pages/guide/node/rpc.mdx
@@ -17,6 +17,7 @@ tempo download --archive
 # Run node
 tempo node \
   --follow \
+  --tempo.bootnodes-endpoint https://peers.tempo.xyz \
   --http --http.port 8545 \
   --http.api eth,net,web3,txpool,trace
 ```
@@ -43,6 +44,7 @@ WorkingDirectory=$HOME/tempo
 ExecStart=/usr/local/bin/tempo node \\
   --datadir <datadir> \\
   --follow \\
+  --tempo.bootnodes-endpoint https://peers.tempo.xyz \\
   --http \\
   --http.addr 0.0.0.0 \\
   --http.port 8545 \\


### PR DESCRIPTION
Without this flag, nodes started from a snapshot sit at `connected_peers=0` and never backfill. It's in the v1.6.0 changelog but missing from the RPC node examples, so operators hit this silently.