### PR TITLE
fix: reorder faucet tabs to show "Fund an address" first

### DIFF
--- a/src/pages/guide/use-accounts/add-funds.mdx
+++ b/src/pages/guide/use-accounts/add-funds.mdx
@@ -18,6 +18,17 @@ import { Tabs, Tab } from 'vocs'
 Get test tokens to build on Tempo testnet.
 
 <Tabs>
+  <Tab title="Fund an address">
+
+<div className="h-4" />
+Send test stablecoins to any address.
+
+<div className="h-6"/>
+<Demo.Container name="Fund an address">
+  <AddFundsToOthers stepNumber={1} last />
+</Demo.Container>
+
+  </Tab>
   <Tab title="Fund your wallet">
 
 <div className="h-4" />
@@ -30,17 +41,6 @@ Connect your wallet to receive test stablecoins directly.
   <AddFundsToWallet stepNumber={2} />
   <AddTokensToWallet stepNumber={3} />
   <SetFeeToken stepNumber={4} last />
-</Demo.Container>
-
-  </Tab>
-  <Tab title="Fund an address">
-
-<div className="h-4" />
-Send test stablecoins to any address.
-
-<div className="h-6"/>
-<Demo.Container name="Fund an address">
-  <AddFundsToOthers stepNumber={1} last />
 </Demo.Container>
 
   </Tab>

--- a/src/pages/quickstart/faucet.mdx
+++ b/src/pages/quickstart/faucet.mdx
@@ -19,6 +19,17 @@ import { Tabs, Tab } from 'vocs'
 Get test stablecoins on Tempo testnet.
 
 <Tabs>
+  <Tab title="Fund an address">
+
+<div className="h-4" />
+Send test stablecoins to any address.
+
+<div className="h-6"/>
+<Demo.Container name="Fund an address">
+  <AddFundsToOthers stepNumber={1} last />
+</Demo.Container>
+
+  </Tab>
   <Tab title="Fund your wallet">
 
 <div className="h-4" />
@@ -31,17 +42,6 @@ Connect your wallet to receive test stablecoins directly.
   <AddFundsToWallet stepNumber={2} />
   <AddTokensToWallet stepNumber={3} />
   <SetFeeToken stepNumber={4} last />
-</Demo.Container>
-
-  </Tab>
-  <Tab title="Fund an address">
-
-<div className="h-4" />
-Send test stablecoins to any address.
-
-<div className="h-6"/>
-<Demo.Container name="Fund an address">
-  <AddFundsToOthers stepNumber={1} last />
 </Demo.Container>
 
   </Tab>


### PR DESCRIPTION
Reorders the faucet tabs on both `/quickstart/faucet` and `/guide/use-accounts/add-funds` so "Fund an address" is the default tab.

Combined with the vocs `keepMounted={false}` change (brendanjryan/vocs), this means the expensive "Fund your wallet" tab (wallet connector, MIPD provider detection) only loads when explicitly clicked, making the faucet page load significantly faster.