### PR TITLE
Add 'Get In Touch' card to Integrate Tempo page

### DIFF
--- a/src/pages/quickstart/integrate-tempo.mdx
+++ b/src/pages/quickstart/integrate-tempo.mdx
@@ -86,3 +86,12 @@ If you're interested in learning more about how Tempo works under the hood, feel
 </Cards>
 
 We welcome contributions from the community to help improve and expand the project.
+
+<Cards>
+  <Card
+    description="Connect with the Tempo team to discuss partnerships, integration opportunities, or opportunities to collaborate."
+    to="mailto:partners@tempo.xyz"
+    icon="lucide:mail"
+    title="Get In Touch"
+  />
+</Cards>


### PR DESCRIPTION
Copies the 'Get In Touch' info card from the overview/home page to the Integrate Tempo (initial setup) page, excluding the link back to the integrate page itself.