### PR TITLE
fix dead link on learn/privacy page

### DIFF
--- a/src/pages/learn/tempo/privacy.mdx
+++ b/src/pages/learn/tempo/privacy.mdx
@@ -38,7 +38,7 @@ Read the full technical specification:
 <Cards>
   <Card
     description="Technical overview of Tempo Zones — native validium chains with multi-asset bridging and validity proofs."
-    to="/protocol/zones/overview"
+    to="/protocol/zones"
     icon="lucide:layers-3"
     title="Zones Overview"
   />


### PR DESCRIPTION
Fixes a dead link on the `learn/privacy` page:
<img width="762" height="520" alt="CleanShot 2026-04-20 at 14 46 42@2x" src="https://github.com/user-attachments/assets/37cfc0a3-93ca-48b0-b7dd-c86222d99e3c" /> currently 404s (check for yourself [here](https://docs.tempo.xyz/learn/tempo/privacy#zones-private-validium-chains))


