### PR TITLE
docs: add T3 activation timestamps

### DIFF
--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -39,7 +39,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 | **Scope** | Enhanced access keys with periodic limits, call scoping, and an authorization ABI update; signature verification precompile; virtual addresses for TIP-20 deposit forwarding; and security hardening and gas correctness fixes |
 | **TIPs** | [TIP-1011: Enhanced Access Key Permissions](/protocol/tips/tip-1011), [TIP-1020: Signature Verification Precompile](/protocol/tips/tip-1020), [TIP-1022: Virtual Addresses for TIP-20 Deposit Forwarding](/protocol/tips/tip-1022), TIP-1038: T3 security hardening and gas correctness fixes |
 | **Details** | [T3 network upgrade](/protocol/upgrades/t3) |
-| **Release** | T3-compatible release coming soon |
+| **Release** | [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) |
 | **Testnet** | Moderato: Apr 21, 2026 16:00 CEST (unix: 1776780000) |
 | **Mainnet** | Presto: Apr 27, 2026 16:00 CEST (unix: 1777298400) |
 | **Priority** | <Badge variant="red">Required</Badge> |

--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -40,8 +40,8 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 | **TIPs** | [TIP-1011: Enhanced Access Key Permissions](/protocol/tips/tip-1011), [TIP-1020: Signature Verification Precompile](/protocol/tips/tip-1020), [TIP-1022: Virtual Addresses for TIP-20 Deposit Forwarding](/protocol/tips/tip-1022), TIP-1038: T3 security hardening and gas correctness fixes |
 | **Details** | [T3 network upgrade](/protocol/upgrades/t3) |
 | **Release** | T3-compatible release coming soon |
-| **Testnet** | Moderato: Apr 22, 2026 16:00 CEST (unix: TBD) |
-| **Mainnet** | Presto: Apr 27, 2026 16:00 CEST (unix: TBD) |
+| **Testnet** | Moderato: Apr 21, 2026 16:00 CEST (unix: 1776780000) |
+| **Mainnet** | Presto: Apr 27, 2026 16:00 CEST (unix: 1777298400) |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
 All node operators should upgrade before the Moderato activation date, even if they do not plan to use the new T3 feature set directly.

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -15,8 +15,8 @@ The features described on this page are scheduled for T3 and are not active on M
 
 | Network | Date | Timestamp |
 |---------|------|-----------|
-| Moderato (testnet) | April 22, 2026 4pm CEST | `TBD` |
-| Presto (mainnet) | April 27, 2026 4pm CEST | `TBD` |
+| Moderato (testnet) | April 21, 2026 4pm CEST | `1776780000` |
+| Presto (mainnet) | April 27, 2026 4pm CEST | `1777298400` |
 
 Partners should upgrade nodes to the T3-compatible release before the Moderato activation timestamp.
 


### PR DESCRIPTION
Fills in T3 unix timestamps from `tempoxyz/tempo` chainspec constants (`crates/chainspec/src/constants.rs`):

- **Moderato**: `1776780000` (Apr 21, 2026 16:00 CEST)
- **Mainnet**: `1777298400` (Apr 27, 2026 16:00 CEST)

Also corrects the Moderato date from Apr 22 → Apr 21 to match the activation timestamp.

Updated pages:
- `src/pages/guide/node/network-upgrades.mdx`
- `src/pages/protocol/upgrades/t3.mdx`

Prompted by: Jen