### PR TITLE
fix: add 301 redirect for /protocol/zones/overview

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -906,6 +906,11 @@ export default defineConfig({
       destination: '/protocol/exchange/quote-tokens#pathusd',
       status: 301,
     },
+    {
+      source: '/protocol/zones/overview',
+      destination: '/protocol/zones',
+      status: 301,
+    },
   ],
   codeHighlight: {
     langAlias: {


### PR DESCRIPTION
The `overview.mdx` page was merged into `index.mdx` in #308 but no redirect was added, causing a hard 404 at https://docs.tempo.xyz/protocol/zones/overview for anyone with bookmarks or external links to the old URL.

Adds a 301 redirect: `/protocol/zones/overview` → `/protocol/zones`