### PR TITLE
docs: update T3 banner to clarify mainnet vs testnet status

### DIFF
--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -5,8 +5,8 @@ description: Details and timeline for the T3 network upgrade, including enhanced
 
 # T3 Network Upgrade
 
-:::info[T3 is not live yet]
-The features described on this page are scheduled for T3 and are not active on Moderato or Presto yet. They only become live once the T3 activation timestamps are reached.
+:::info[T3 is not yet live on Mainnet]
+The features described on this page are part of the T3 upgrade and are not yet active on Mainnet (Presto). They are currently live on Testnet (Moderato).
 :::
 
 ## Timeline

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -5,7 +5,7 @@ description: Details and timeline for the T3 network upgrade, including enhanced
 
 # T3 Network Upgrade
 
-:::info[T3 is not yet live on Mainnet]
+T3 will change this spec
 The features described on this page are part of the T3 upgrade and are not yet active on Mainnet (Presto). They are currently live on Testnet (Moderato).
 :::
 

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -6,7 +6,7 @@ description: Details and timeline for the T3 network upgrade, including enhanced
 # T3 Network Upgrade
 
 T3 will change this spec
-The features described on this page are part of the T3 upgrade and are not yet active on Mainnet (Presto). They are currently live on Testnet (Moderato).
+The [T3 network upgrade](https://docs.tempo.xyz/protocol/upgrades/t3) will update this specification. The sections below describe the currently active behavior. See [Upcoming changes](https://docs.tempo.xyz/protocol/tip20/spec#upcoming-changes) for the upcoming deltas.
 :::
 
 ## Timeline


### PR DESCRIPTION
Updates the T3 upgrade page banner to clarify that T3 is not yet live on **Mainnet (Presto)** but is currently live on **Testnet (Moderato)**.

**Before:** "T3 is not live yet" — implied it wasn't active anywhere.
**After:** "T3 is not yet live on Mainnet" — clarifies testnet is already active.