### PR TITLE
fix: use /address/ instead of /account/ in explorer links

### DIFF
--- a/src/components/guides/Demo.tsx
+++ b/src/components/guides/Demo.tsx
@@ -106,7 +106,7 @@ export function ExplorerAccountLink({
   inline = false,
 }: { address: string; inline?: boolean }) {
   const { trackExternalLinkClick } = usePostHogTracking()
-  const url = `${getExplorerHost()}/account/${address}`
+  const url = `${getExplorerHost()}/address/${address}`
 
   return (
     <div className={inline ? 'inline-flex' : 'mt-1'}>


### PR DESCRIPTION
The 'View account' explorer links in the virtual address demo were using `/account/` in the URL, but the explorer expects `/address/`. This caused broken links.