### PR TITLE
chore(foundry): add foundry-toolchain mention

### DIFF
--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -110,8 +110,8 @@ The `[etherscan]` table in `foundry.toml` is for Etherscan-style verifiers, not 
 
 ### Using `foundry-toolchain` in your CI
 
-Use the [`foundry-toolchain`](https://github.com/foundry-rs/foundry-toolchain) GitHub Action to install Foundry in CI.
-Tempo is included in upstream Foundry, so no special configuration is needed.
+Use the [`foundry-toolchain`](https://github.com/foundry-rs/foundry-toolchain) GitHub Action to install Foundry in your CI.
+Tempo support is included in Foundry, so no special configuration is needed.
 
 ```yaml
 - name: Install Foundry

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -108,6 +108,18 @@ Tempo's contract verifier is Sourcify-compatible. Configure verification with `V
 
 The `[etherscan]` table in `foundry.toml` is for Etherscan-style verifiers, not Tempo's verifier.
 
+### Using `foundry-toolchain` in your CI
+
+Use the [`foundry-toolchain`](https://github.com/foundry-rs/foundry-toolchain) GitHub Action to install Foundry in CI.
+Tempo is included in upstream Foundry, so no special configuration is needed.
+
+```yaml
+- name: Install Foundry
+  uses: foundry-rs/foundry-toolchain@v1
+  with:
+    version: nightly
+```
+
 ## Use Foundry for your workflows
 
 All standard Foundry commands are supported out of the box.


### PR DESCRIPTION
Add a mention of `foundry-toolchain` use, specifically to use nightly for now as stable does not yet support Tempo