### PR TITLE
Update Safe (remove coming soon) and RedStone blurb

### DIFF
--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -156,11 +156,11 @@ Range stands out through:
 
 Explore Tempo activity in the [Stablecoin Explorer](https://explorer.money/transactions?dn=tempo-testnet&sc=INTRACHAIN&sn=tempo-testnet).
 
-### Redstone
+### RedStone
 
-[Redstone](https://redstone.finance) delivers modular oracle infrastructure with a push and pull model for onchain price feeds. Redstone's architecture minimizes gas costs by delivering data on-demand, making it well-suited for DeFi applications, lending protocols, and stablecoin systems on Tempo.
+[RedStone](https://redstone.finance) delivers modular oracle infrastructure with a Push and Pull model for onchain price feeds. RedStone's architecture minimizes gas costs by delivering data on-demand, making it well-suited for DeFi applications, lending protocols, FX and stablecoin systems on Tempo.
 
-Explore the available data feeds and integration guides in the [Redstone docs](https://docs.redstone.finance/).
+Explore the available Push data feeds [here](https://app.redstone.finance/push-feeds?networks=tempo&testnets=true) and integration guides in the [RedStone docs](https://docs.redstone.finance/).
 
 ### SonarX
 
@@ -273,11 +273,9 @@ Access Tempo through the [Fireblocks console](https://console.fireblocks.io/) an
 
 Get started on the [Pimlico dashboard](https://dashboard.pimlico.io/) and explore the [Pimlico docs](https://docs.pimlico.io/).
 
-### Safe *(coming soon)*
+### Safe
 
-[Safe](https://safe.global) provides a modular smart account framework used across leading Web3 applications and institutions. With Safe, developers can build Tempo applications that take advantage of multi-sig controls, programmable permissions, session keys, and automated transaction policies. 
-
-Safe integration for Tempo is coming soon. Stay tuned for updates as support becomes available.
+[Safe](https://safe.global) provides a modular smart account framework used across leading Web3 applications and institutions. With Safe, developers can build Tempo applications that take advantage of multi-sig controls, programmable permissions, session keys, and automated transaction policies.
 
 ### ZeroDev
 


### PR DESCRIPTION
- Removes 'coming soon' from Safe section — it's live
- Updates RedStone blurb with proper casing (RedStone), adds FX mention, and links to push feeds page