### PR TITLE
docs: rename validator operator address

### DIFF
--- a/src/pages/guide/node/validator-setup.mdx
+++ b/src/pages/guide/node/validator-setup.mdx
@@ -72,7 +72,7 @@ Provide the following values along with the signature to the Tempo team:
 
 | Value | Format | Description |
 |-------|--------|-------------|
-| **Validator address** | Ethereum address (`0x…`) | The control address for your validator. Used to authorize on-chain operations (IP updates, rotation, ownership transfer). |
+| **Validator operator address** | Ethereum address (`0x…`) | The control address for your validator. Used to authorize on-chain operations (IP updates, rotation, ownership transfer). |
 | **Public key** | `0x`-prefixed 32-byte hex | Your ed25519 identity key (from [Step 1](#step-1-generate-a-signing-keypair)). |
 | **Ingress** | `IP:port` | The inbound address other validators use to reach your node. Must be unique across all active validators. |
 | **Egress** | `IP` | The outbound IP address your node uses to connect to other validators. |


### PR DESCRIPTION
## Summary
Rename the Step 3 registration field in the validator onboarding guide from `Validator address` to `Validator operator address`.