### PR TITLE
[codex] fix docs main ci

### DIFF
--- a/e2e/virtual-addresses.test.ts
+++ b/e2e/virtual-addresses.test.ts
@@ -31,6 +31,7 @@ test('virtual addresses guide signs in and starts master registration', async ({
     await expect(
       page.getByRole('heading', { name: 'Use virtual addresses for deposits' }),
     ).toBeVisible()
+    await page.getByRole('tab', { name: 'Real registration' }).click()
     await expect(page.getByRole('button', { name: 'Sign out' }).first()).toBeVisible({
       timeout: 30000,
     })

--- a/src/components/guides/Demo.tsx
+++ b/src/components/guides/Demo.tsx
@@ -104,7 +104,10 @@ export function ReceiptHash({ hash }: { hash: string }) {
 export function ExplorerAccountLink({
   address,
   inline = false,
-}: { address: string; inline?: boolean }) {
+}: {
+  address: string
+  inline?: boolean
+}) {
   const { trackExternalLinkClick } = usePostHogTracking()
   const url = `${getExplorerHost()}/address/${address}`
 
@@ -459,7 +462,7 @@ export function Step(
         <div className="flex items-center gap-3.5">
           <div
             className={cx(
-              'shrink-0 flex size-7 items-center justify-center rounded-full text-center text-[13px] text-black tabular-nums opacity-40 group-data-[completed=true]:opacity-100 dark:text-white',
+              'flex size-7 shrink-0 items-center justify-center rounded-full text-center text-[13px] text-black tabular-nums opacity-40 group-data-[completed=true]:opacity-100 dark:text-white',
               completed ? 'bg-green3' : 'bg-gray4',
             )}
           >
@@ -605,6 +608,7 @@ export function Button(
   const Element = render ? (p: typeof props) => React.cloneElement(render, p) : 'button'
   return (
     <Element
+      disabled={disabled ? true : undefined}
       className={buttonClassName({
         className,
         disabled,

--- a/src/components/guides/VirtualAddressesLiveDemo.tsx
+++ b/src/components/guides/VirtualAddressesLiveDemo.tsx
@@ -661,7 +661,9 @@ export function VirtualAddressesLiveDemo() {
                   <span className="break-all font-mono text-[12px] text-primary">
                     {registration.virtualAddress}
                   </span>
-                  {hasExplorerLink && <ExplorerAccountLink address={registration.virtualAddress} inline />}
+                  {hasExplorerLink && (
+                    <ExplorerAccountLink address={registration.virtualAddress} inline />
+                  )}
                 </span>
               </div>
               <div>
@@ -700,9 +702,8 @@ export function VirtualAddressesLiveDemo() {
                   <div className="space-y-1">
                     <span className="text-primary">Transfer events in this receipt</span>
                     <div>
-                      Treat the <span className="font-mono text-primary">sender → virtual</span>{' '}
-                      and <span className="font-mono text-primary">virtual → master</span> pair as
-                      one
+                      Treat the <span className="font-mono text-primary">sender → virtual</span> and{' '}
+                      <span className="font-mono text-primary">virtual → master</span> pair as one
                       logical deposit to the registered wallet. Other transfer logs in the receipt,
                       like fees, are separate.
                     </div>

--- a/src/lib/useRootWebAuthnAccount.ts
+++ b/src/lib/useRootWebAuthnAccount.ts
@@ -17,6 +17,8 @@ type RootWebAuthnAccountProvider = {
   request: (args: { method: 'eth_accounts' }) => Promise<readonly `0x${string}`[]>
 }
 
+const rootWebAuthnAccountTimeoutMs = 30_000
+
 export function useRootWebAuthnAccount() {
   const { address, connector } = useConnection()
 
@@ -29,7 +31,11 @@ export function useRootWebAuthnAccount() {
 
       const provider = await connector.getProvider()
       if (isRootWebAuthnAccountProvider(provider)) {
-        await waitForProviderAccount(provider, address as `0x${string}`)
+        await waitForProviderAccount(
+          provider,
+          address as `0x${string}`,
+          rootWebAuthnAccountTimeoutMs,
+        )
 
         return provider.getAccount({
           accessKey: false,
@@ -38,12 +44,16 @@ export function useRootWebAuthnAccount() {
         })
       }
 
-      const credential = await waitForStoredCredential(address as `0x${string}`)
+      const credential = await waitForStoredCredential(
+        address as `0x${string}`,
+        rootWebAuthnAccountTimeoutMs,
+      )
       return accountFromCredential(credential)
     },
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
-    retry: false,
+    retry: 2,
+    retryDelay: 500,
     staleTime: Number.POSITIVE_INFINITY,
   })
 }


### PR DESCRIPTION
## Summary

- Preserve the native disabled attribute on demo buttons so Playwright and users see the real disabled state.
- Make the virtual-address E2E test select the Real registration tab before asserting live registration UI.
- Let WebAuthn root account lookup tolerate passkey connector startup delays before creating zone clients.

## Root Cause

Docs main CI was failing in E2E shard 3. The shared demo Button styled disabled buttons but did not pass the disabled attribute to the DOM, so Playwright tried to click controls that were visually disabled and had pointer-events disabled. Once fixed, the withdraw test exposed a startup race where the WebAuthn root account query could fail once and never retry, leaving the zone authorization button permanently disabled. The virtual-address test also assumed the live registration demo was the default tab, but the page defaults to the Fast demo tab.