### PR TITLE
fix: update zones overview link

### DIFF
--- a/src/pages/learn/tempo/privacy.mdx
+++ b/src/pages/learn/tempo/privacy.mdx
@@ -31,14 +31,14 @@ All of this is achieved while preserving the compliance features that make stabl
 
 ## Zones: Private Validium Chains
 
-Tempo has built-in support for privacy through [zones](/protocol/zones/overview) — native validium chains anchored to Tempo. Instead of being visible to the entire world, balances and transactions on zones are only visible to the zone sequencer, the users involved, and anyone they choose to selectively disclose to.
+Tempo has built-in support for privacy through [zones](/protocol/zones) — native validium chains anchored to Tempo. Instead of being visible to the entire world, balances and transactions on zones are only visible to the zone sequencer, the users involved, and anyone they choose to selectively disclose to.
 
 Read the full technical specification:
 
 <Cards>
   <Card
     description="Technical overview of Tempo Zones — native validium chains with multi-asset bridging and validity proofs."
-    to="/protocol/zones/overview"
+    to="/protocol/zones"
     icon="lucide:layers-3"
     title="Zones Overview"
   />

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -57,7 +57,7 @@ This section provides details on the Tempo Protocol specifications, and serves a
   />
   <Card
     description="Tempo-native validium chains with multi-asset bridging, validity proofs, and privacy"
-    to="/protocol/zones/overview"
+    to="/protocol/zones"
     icon="lucide:layers-3"
     title="Zones"
   />


### PR DESCRIPTION
This PR updates the "Zones Overview" link to point to `/protocol/zones`.