### PR TITLE
docs: remove Solidity reference implementation links

### DIFF
--- a/src/pages/protocol/tip20/overview.mdx
+++ b/src/pages/protocol/tip20/overview.mdx
@@ -192,10 +192,4 @@ By using TIP-20 tokens as quote tokens, the DEX benefits from the same payment-o
     icon="lucide:rocket"
     title="Guide: Issue Stablecoins"
   />
-  <Card
-    description="Solidity reference implementation of the TIP-20 standard"
-    to="https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TIP20.sol"
-    icon="lucide:file-text"
-    title="Reference Implementation"
-  />
 </Cards>

--- a/src/pages/protocol/tip403/overview.mdx
+++ b/src/pages/protocol/tip403/overview.mdx
@@ -26,12 +26,6 @@ TIP-403 is Tempo's policy registry system that enables TIP-20 tokens to enforce 
     title="Guide: Manage Your Stablecoin"
   />
   <Card
-    description="Solidity reference implementation of the TIP-403 standard"
-    to="https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TIP403Registry.sol"
-    icon="lucide:file-text"
-    title="Reference Implementation"
-  />
-  <Card
     description="Rust implementation in the Tempo client"
     to="https://github.com/tempoxyz/tempo/tree/main/crates/precompiles/src/tip403_registry"
     icon="lucide:file-text"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -101,20 +101,16 @@ function syncTips(): Plugin {
     await Promise.all(
       tipFiles.map(async (file) => {
         let content = await fetch(file.download_url).then((r) => r.text())
-        // Fix dead links in TIPs that reference paths in the tempoxyz/tempo
-        // repo. These resolve fine on github.com but break Vocs' dead-link
-        // checker, since the files don't exist in the docs site. Rewriting
-        // them here lets us keep `checkDeadlinks: true` without forking
-        // upstream content. Add new patterns as upstream typos appear.
+        // Strip stale Solidity interface links from upstream TIPs. The linked
+        // files are no longer published, so keeping the link would surface dead
+        // references in the docs UI and fail Vocs' dead-link checker.
         content = content.replace(
-          /\(tips\/ref-impls\/src\/interfaces\/(\w+\.sol)\)/g,
-          '(https://github.com/tempoxyz/tempo-std/blob/master/src/interfaces/$1)',
+          /^- \[[^\]]+\.sol\]\(tips\/(?:ref-impls|verify)\/src\/interfaces\/[^)]+\)\n/gm,
+          '',
         )
-        // TIP-1011 references `tips/verify/src/interfaces/...` (upstream typo
-        // of `ref-impls`). Map it to the actual tempoxyz/tempo location.
         content = content.replace(
-          /\(tips\/verify\/src\/interfaces\/(\w+\.sol)\)/g,
-          '(https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/interfaces/$1)',
+          /\[([^\]]+\.sol)\]\(tips\/(?:ref-impls|verify)\/src\/interfaces\/[^)]+\)/g,
+          '$1',
         )
         // tip-0000 links to `./tip_template.md`, which lives in the tempo
         // repo but not in the docs site.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -466,10 +466,6 @@ export default defineConfig({
                 link: '/protocol/tip20/virtual-addresses',
               },
               {
-                text: 'Reference Implementation',
-                link: 'https://github.com/tempoxyz/tempo-std/blob/master/src/interfaces/ITIP20.sol',
-              },
-              {
                 text: 'Rust Implementation',
                 link: 'https://github.com/tempoxyz/tempo/tree/main/crates/precompiles/src/tip20',
               },
@@ -502,10 +498,6 @@ export default defineConfig({
                 link: '/protocol/tip403/spec',
               },
               {
-                text: 'Reference Implementation',
-                link: 'https://github.com/tempoxyz/tempo-std/blob/master/src/interfaces/ITIP403Registry.sol',
-              },
-              {
                 text: 'Rust Implementation',
                 link: 'https://github.com/tempoxyz/tempo/tree/main/crates/precompiles/src/tip403_registry',
               },
@@ -534,10 +526,6 @@ export default defineConfig({
                   {
                     text: 'Specification',
                     link: '/protocol/fees/spec-fee-amm',
-                  },
-                  {
-                    text: 'Reference Implementation',
-                    link: 'https://github.com/tempoxyz/tempo-std/blob/master/src/interfaces/IFeeManager.sol',
                   },
                   {
                     text: 'Rust Implementation',
@@ -622,10 +610,6 @@ export default defineConfig({
               {
                 text: 'DEX Balance',
                 link: '/protocol/exchange/exchange-balance',
-              },
-              {
-                text: 'Reference Implementation',
-                link: 'https://github.com/tempoxyz/tempo-std/blob/master/src/interfaces/IStablecoinDEX.sol',
               },
               {
                 text: 'Rust Implementation',


### PR DESCRIPTION
Removes stale Solidity reference implementation links from the protocol docs.

- drops the reference implementation entries from protocol navigation
- removes the reference implementation cards from TIP-20 and TIP-403 overview pages
- strips stale upstream TIP interface links during sync so dead links stop resurfacing

Validation:
- corepack pnpm check:types
- corepack pnpm check (passes for this change; repo still reports 3 existing Biome warnings in scripts/lighthouse.ts)