### PR TITLE
docs: switch Foundry setup to latest v1.7.0

### DIFF
--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -73,7 +73,7 @@ Tempo's broader tooling ecosystem is available in [Developer tools](/quickstart/
 | [Rust](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) | [`tempo-alloy@1.5.1`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.5.1) |
 | [Go](https://github.com/tempoxyz/tempo-go) | [`v0.4.0`](https://github.com/tempoxyz/tempo-go/releases/tag/v0.4.0) |
 | [Python](https://github.com/tempoxyz/pytempo) | [`0.5.0`](https://github.com/tempoxyz/pytempo/releases/tag/pytempo%400.5.0) |
-| [Foundry](https://github.com/foundry-rs/foundry) | [`nightly`](https://github.com/foundry-rs/foundry/releases/tag/nightly) |
+| [Foundry](https://github.com/foundry-rs/foundry) | [`v1.7.0`](https://github.com/foundry-rs/foundry/releases/tag/v1.7.0) |
 
 :::note[Current SDK caveat]
 The Accounts SDK and `wallet_authorizeAccessKey` docs still describe the legacy pre-T3 access-key shape. Until their T3 support lands, use the protocol specs and the T3-compatible SDK releases above for the post-T3 `authorizeKey(...)` ABI.

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -6,17 +6,17 @@ description: Build, test, and deploy smart contracts on Tempo using Foundry. Acc
 
 Tempo is supported as a first-class citizen in [Foundry](https://github.com/foundry-rs/foundry): the leading Ethereum development toolkit.
 
-Install the latest stable Foundry release to access Tempo's [protocol-level features](/protocol/) in `forge`, `cast`, `anvil`, and `chisel`, and to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
+Install the latest Foundry release to access Tempo's [protocol-level features](/protocol/) in `forge`, `cast`, `anvil`, and `chisel`, and to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
 
 :::warning[`tempo-foundry` is deprecated]
-`tempo-foundry` and `foundryup -n tempo` are deprecated. Switch to upstream Foundry stable with `foundryup`.
+`tempo-foundry` and `foundryup -n tempo` are deprecated. Switch to the latest upstream Foundry release with `foundryup`.
 :::
 
 For general information about Foundry, see the [Foundry documentation](https://getfoundry.sh/).
 
 ## Get started with Foundry
 
-Install the latest stable Foundry release to get Tempo support.
+Install the latest Foundry release to get Tempo support.
 
 :::::steps
 
@@ -34,7 +34,7 @@ curl -L https://foundry.paradigm.xyz | bash
 foundryup
 ```
 
-This installs the latest stable release of [`forge`](https://getfoundry.sh/forge/overview#forge), [`cast`](https://getfoundry.sh/cast/overview#cast), [`anvil`](https://getfoundry.sh/anvil/overview#anvil), and [`chisel`](https://getfoundry.sh/chisel/overview#chisel). At the time of writing, that is `v1.7.0`.
+This installs the latest release of [`forge`](https://getfoundry.sh/forge/overview#forge), [`cast`](https://getfoundry.sh/cast/overview#cast), [`anvil`](https://getfoundry.sh/anvil/overview#anvil), and [`chisel`](https://getfoundry.sh/chisel/overview#chisel). At the time of writing, that is `v1.7.0`.
 
 
 :::tip
@@ -111,7 +111,7 @@ The `[etherscan]` table in `foundry.toml` is for Etherscan-style verifiers, not 
 ### Using `foundry-toolchain` in your CI
 
 Use the [`foundry-toolchain`](https://github.com/foundry-rs/foundry-toolchain) GitHub Action to install Foundry in your CI.
-Tempo support is included in stable Foundry releases, so no special configuration is needed. The action installs the latest stable release by default, which is currently `v1.7.0`.
+Tempo support is included in the latest Foundry releases, so no special configuration is needed. The action installs the latest release by default, which is currently `v1.7.0`.
 
 ```yaml
 - name: Install Foundry

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -34,7 +34,7 @@ curl -L https://foundry.paradigm.xyz | bash
 foundryup
 ```
 
-This installs the latest release of [`forge`](https://getfoundry.sh/forge/overview#forge), [`cast`](https://getfoundry.sh/cast/overview#cast), [`anvil`](https://getfoundry.sh/anvil/overview#anvil), and [`chisel`](https://getfoundry.sh/chisel/overview#chisel). At the time of writing, that is `v1.7.0`.
+This installs the latest versioned release of [`forge`](https://getfoundry.sh/forge/overview#forge), [`cast`](https://getfoundry.sh/cast/overview#cast), [`anvil`](https://getfoundry.sh/anvil/overview#anvil), and [`chisel`](https://getfoundry.sh/chisel/overview#chisel).
 
 
 :::tip

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -6,17 +6,17 @@ description: Build, test, and deploy smart contracts on Tempo using Foundry. Acc
 
 Tempo is supported as a first-class citizen in [Foundry](https://github.com/foundry-rs/foundry): the leading Ethereum development toolkit.
 
-Install the latest nightly to access Tempo's [protocol-level features](/protocol/) in `forge`, `cast`, `anvil`, and `chisel`, and to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
+Install the latest stable Foundry release to access Tempo's [protocol-level features](/protocol/) in `forge`, `cast`, `anvil`, and `chisel`, and to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
 
 :::warning[`tempo-foundry` is deprecated]
-`tempo-foundry` and `foundryup -n tempo` are deprecated. Switch to upstream Foundry nightly with `foundryup --install nightly`.
+`tempo-foundry` and `foundryup -n tempo` are deprecated. Switch to upstream Foundry stable with `foundryup`.
 :::
 
 For general information about Foundry, see the [Foundry documentation](https://getfoundry.sh/).
 
 ## Get started with Foundry
 
-Install the latest Foundry nightly to get Tempo support.
+Install the latest stable Foundry release to get Tempo support.
 
 :::::steps
 
@@ -28,13 +28,13 @@ If you don't have `foundryup` installed yet:
 curl -L https://foundry.paradigm.xyz | bash
 ```
 
-### Install the latest Foundry nightly
+### Install or update Foundry
 
 ```bash
-foundryup --install nightly
+foundryup
 ```
 
-This installs the latest `nightly` release of [`forge`](https://getfoundry.sh/forge/overview#forge), [`cast`](https://getfoundry.sh/cast/overview#cast), [`anvil`](https://getfoundry.sh/anvil/overview#anvil), and [`chisel`](https://getfoundry.sh/chisel/overview#chisel).
+This installs the latest stable release of [`forge`](https://getfoundry.sh/forge/overview#forge), [`cast`](https://getfoundry.sh/cast/overview#cast), [`anvil`](https://getfoundry.sh/anvil/overview#anvil), and [`chisel`](https://getfoundry.sh/chisel/overview#chisel). At the time of writing, that is `v1.7.0`.
 
 
 :::tip
@@ -111,13 +111,11 @@ The `[etherscan]` table in `foundry.toml` is for Etherscan-style verifiers, not 
 ### Using `foundry-toolchain` in your CI
 
 Use the [`foundry-toolchain`](https://github.com/foundry-rs/foundry-toolchain) GitHub Action to install Foundry in your CI.
-Tempo support is included in Foundry, so no special configuration is needed.
+Tempo support is included in stable Foundry releases, so no special configuration is needed. The action installs the latest stable release by default, which is currently `v1.7.0`.
 
 ```yaml
 - name: Install Foundry
   uses: foundry-rs/foundry-toolchain@v1
-  with:
-    version: nightly
 ```
 
 ## Use Foundry for your workflows

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -111,7 +111,7 @@ The `[etherscan]` table in `foundry.toml` is for Etherscan-style verifiers, not 
 ### Using `foundry-toolchain` in your CI
 
 Use the [`foundry-toolchain`](https://github.com/foundry-rs/foundry-toolchain) GitHub Action to install Foundry in your CI.
-Tempo support is included in the latest Foundry releases, so no special configuration is needed. The action installs the latest release by default, which is currently `v1.7.0`.
+Tempo support is included in the latest Foundry release, so no special configuration is needed.
 
 ```yaml
 - name: Install Foundry

--- a/src/pages/sdk/foundry/mpp.mdx
+++ b/src/pages/sdk/foundry/mpp.mdx
@@ -10,7 +10,7 @@ import { Card, Cards } from 'vocs'
 Foundry includes native MPP support on Tempo. When an RPC endpoint returns `402 Payment Required`, Foundry automatically handles the payment challenge with no wrapper scripts, middleware, or code changes.
 
 :::warning[`tempo-foundry` is deprecated]
-`tempo-foundry` and `foundryup -n tempo` are deprecated. Install upstream Foundry stable with `foundryup`.
+`tempo-foundry` and `foundryup -n tempo` are deprecated. Install the latest upstream Foundry release with `foundryup`.
 :::
 
 Every Foundry tool works transparently with MPP-gated endpoints:
@@ -51,7 +51,7 @@ curl -fsSL https://tempo.xyz/install | bash
 
 ### Install Foundry
 
-Tempo support now ships in Foundry's stable release stream:
+Tempo support now ships in the latest Foundry releases:
 
 ```bash
 foundryup

--- a/src/pages/sdk/foundry/mpp.mdx
+++ b/src/pages/sdk/foundry/mpp.mdx
@@ -10,7 +10,7 @@ import { Card, Cards } from 'vocs'
 Foundry includes native MPP support on Tempo. When an RPC endpoint returns `402 Payment Required`, Foundry automatically handles the payment challenge with no wrapper scripts, middleware, or code changes.
 
 :::warning[`tempo-foundry` is deprecated]
-`tempo-foundry` and `foundryup -n tempo` are deprecated. Install upstream Foundry nightly with `foundryup -i nightly`.
+`tempo-foundry` and `foundryup -n tempo` are deprecated. Install upstream Foundry stable with `foundryup`.
 :::
 
 Every Foundry tool works transparently with MPP-gated endpoints:
@@ -51,13 +51,13 @@ curl -fsSL https://tempo.xyz/install | bash
 
 ### Install Foundry
 
-Tempo support now ships in Foundry's nightly:
+Tempo support now ships in Foundry's stable release stream:
 
 ```bash
-foundryup -i nightly
+foundryup
 ```
 
-All standard Foundry commands work as before — MPP activates only when an endpoint returns `402`.
+All standard Foundry commands work as before — MPP activates only when an endpoint returns `402`. At the time of writing, `foundryup` installs `v1.7.0`.
 
 ### Configure your wallet
 

--- a/src/pages/sdk/foundry/mpp.mdx
+++ b/src/pages/sdk/foundry/mpp.mdx
@@ -57,7 +57,7 @@ Tempo support now ships in the latest Foundry releases:
 foundryup
 ```
 
-All standard Foundry commands work as before — MPP activates only when an endpoint returns `402`. At the time of writing, `foundryup` installs `v1.7.0`.
+All standard Foundry commands work as before — MPP activates only when an endpoint returns `402`.
 
 ### Configure your wallet
 

--- a/src/pages/sdk/foundry/mpp.mdx
+++ b/src/pages/sdk/foundry/mpp.mdx
@@ -10,7 +10,7 @@ import { Card, Cards } from 'vocs'
 Foundry includes native MPP support on Tempo. When an RPC endpoint returns `402 Payment Required`, Foundry automatically handles the payment challenge with no wrapper scripts, middleware, or code changes.
 
 :::warning[`tempo-foundry` is deprecated]
-`tempo-foundry` and `foundryup -n tempo` are deprecated. Install the latest upstream Foundry release with `foundryup`.
+`tempo-foundry` and `foundryup -n tempo` are deprecated. Install the latest Foundry release with `foundryup`.
 :::
 
 Every Foundry tool works transparently with MPP-gated endpoints:


### PR DESCRIPTION
## Summary
- switch Tempo's Foundry SDK docs from nightly-only install guidance to the latest `foundryup` flow
- update the `foundry-toolchain` CI example to use its default latest-install behavior
- update the T3 compatibility table to point to Foundry `v1.7.0`
- use `latest` terminology instead of `stable` for versioned Foundry releases

## Verification
- confirmed upstream docs say `foundryup` installs the latest Foundry release
- confirmed `foundry-toolchain` installs the latest Foundry release by default
- could not run `bun run check` in this container because `bun` is not installed

cc @zerosnacks
