### PR TITLE
feat(wagmi): set webAuthn authUrl from VITE_WEBAUTHN_AUTH_URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ VITE_GA_MEASUREMENT_ID=
 VITE_POSTHOG_HOST=
 VITE_POSTHOG_KEY=
 VITE_TEMPO_ENV=             # testnet|devnet|localnet
+VITE_WEBAUTHN_AUTH_URL=     # e.g. https://wallet.tempo.xyz/api/webauthn

--- a/env.d.ts
+++ b/env.d.ts
@@ -5,6 +5,7 @@ interface EnvironmentVariables {
   readonly VITE_POSTHOG_KEY: string
   readonly VITE_POSTHOG_HOST: string
   readonly VITE_TEMPO_ENV: 'localnet' | 'devnet' | 'moderato'
+  readonly VITE_WEBAUTHN_AUTH_URL?: string
 
   readonly INDEXSUPPLY_API_KEY: string
   readonly SLACK_FEEDBACK_WEBHOOK: string

--- a/src/wagmi.config.ts
+++ b/src/wagmi.config.ts
@@ -50,27 +50,29 @@ export function getConfig(options: getConfig.Options = {}) {
     chains: [chain],
     connectors: [
       ...(import.meta.env.VITE_E2E === 'true'
-       ? [
-           webAuthn(),
-         ]
-       : [
-           tempoWallet({
-             authorizeAccessKey: () => ({
-               expiry: Expiry.days(1),
-               limits: [
-                 { token: pathUsd, limit: parseUnits('500', 6) },
-                 { token: alphaUsd, limit: parseUnits('500', 6) },
-                 { token: betaUsd, limit: parseUnits('500', 6) },
-                 { token: thetaUsd, limit: parseUnits('500', 6) },
-               ],
-             }),
-             feePayer: {
-               precedence: 'user-first',
-               url: 'https://sponsor.moderato.tempo.xyz',
-             },
-           }),
-           webAuthn(),
-         ]),
+        ? [webAuthn()]
+        : [
+            tempoWallet({
+              authorizeAccessKey: () => ({
+                expiry: Expiry.days(1),
+                limits: [
+                  { token: pathUsd, limit: parseUnits('500', 6) },
+                  { token: alphaUsd, limit: parseUnits('500', 6) },
+                  { token: betaUsd, limit: parseUnits('500', 6) },
+                  { token: thetaUsd, limit: parseUnits('500', 6) },
+                ],
+              }),
+              feePayer: {
+                precedence: 'user-first',
+                url: 'https://sponsor.moderato.tempo.xyz',
+              },
+            }),
+            webAuthn(
+             import.meta.env.VITE_WEBAUTHN_AUTH_URL
+               ? { authUrl: import.meta.env.VITE_WEBAUTHN_AUTH_URL }
+               : undefined,
+           ),
+          ]),
     ],
     multiInjectedProviderDiscovery,
     storage: createStorage({


### PR DESCRIPTION
Configures the `webAuthn` Wagmi connector's `authUrl` from the `VITE_WEBAUTHN_AUTH_URL` environment variable. If unset, no `authUrl` is passed to the connector.

Set `VITE_WEBAUTHN_AUTH_URL=https://wallet-next.tempo.xyz/api/webauthn` in Vercel to enable a remote WebAuthn handler.