### PR TITLE
fix(EmbedPasskeys): use method: 'register' capability and simplify sign-in

### DIFF
--- a/src/components/guides/EmbedPasskeys.tsx
+++ b/src/components/guides/EmbedPasskeys.tsx
@@ -75,7 +75,7 @@ export function SignInButtons() {
               : {
                   capabilities: {
                     label: 'Tempo Docs',
-                    type: 'sign-up',
+                    method: 'register'
                   } as never,
                 }),
           })
@@ -88,17 +88,7 @@ export function SignInButtons() {
         variant="default"
         onClick={async () => {
           await disconnect.disconnectAsync().catch(() => {})
-          connect.connect(
-            isE2E
-              ? { connector }
-              : {
-                  connector,
-                  capabilities: {
-                    label: 'Tempo Docs',
-                    type: 'sign-in',
-                  } as never,
-                },
-          )
+          connect.connect({ connector })
         }}
         type="button"
       >

--- a/src/pages/guide/use-accounts/embed-passkeys.mdx
+++ b/src/pages/guide/use-accounts/embed-passkeys.mdx
@@ -133,14 +133,14 @@ export function Example() {
         onClick={() =>
           connect.connect({
             connector,
-            capabilities: { type: 'sign-up' },
+            capabilities: { method: 'register' },
           })
         }
       >
         Sign up
       </button>
 
-      <button onClick={() => connect.connect({ connector, capabilities: { type: 'sign-in' } })}>
+      <button onClick={() => connect.connect({ connector })}>
         Sign in
       </button>
     </div>
@@ -209,14 +209,14 @@ export function Example() {
         onClick={() =>
           connect.connect({
             connector,
-            capabilities: { type: 'sign-up' },
+            capabilities: { method: 'register' },
           })
         }
       >
         Sign up
       </button>
 
-      <button onClick={() => connect.connect({ connector, capabilities: { type: 'sign-in' } })}>
+      <button onClick={() => connect.connect({ connector })}>
         Sign in
       </button>
     </div>


### PR DESCRIPTION
Updates the embed passkeys demo:
- Changes `type: 'sign-up'` to `method: 'register'` for the registration capability
- Simplifies the sign-in connect call to use `{ connector }` directly without capabilities