### PR TITLE
chore(wagmi): fix indentation in webAuthn connector config

### DIFF
--- a/src/wagmi.config.ts
+++ b/src/wagmi.config.ts
@@ -68,10 +68,10 @@ export function getConfig(options: getConfig.Options = {}) {
               },
             }),
             webAuthn(
-             import.meta.env.VITE_WEBAUTHN_AUTH_URL
-               ? { authUrl: import.meta.env.VITE_WEBAUTHN_AUTH_URL }
-               : undefined,
-           ),
+              import.meta.env.VITE_WEBAUTHN_AUTH_URL
+                ? { authUrl: import.meta.env.VITE_WEBAUTHN_AUTH_URL }
+                : undefined,
+            ),
           ]),
     ],
     multiInjectedProviderDiscovery,


### PR DESCRIPTION
Formatter cleanup for the `webAuthn(...)` connector arguments in `src/wagmi.config.ts`.