### PR TITLE
fix(EmbedPasskeys): rename register capability label -> name

### DIFF
--- a/src/components/guides/EmbedPasskeys.tsx
+++ b/src/components/guides/EmbedPasskeys.tsx
@@ -74,8 +74,8 @@ export function SignInButtons() {
               ? ({ capabilities: { method: 'register', name: 'Tempo Docs' } } as const)
               : {
                   capabilities: {
-                    label: 'Tempo Docs',
-                    method: 'register'
+                    method: 'register',
+                    name: 'Tempo Docs',
                   } as never,
                 }),
           })


### PR DESCRIPTION
The webAuthn register capability key was renamed from `label` to `name`. Update the non-E2E branch in [`EmbedPasskeys.tsx`](https://github.com/tempoxyz/docs/blob/fix-webauthn-register-name/src/components/guides/EmbedPasskeys.tsx) to match the E2E branch (and the new interface).