### PR TITLE
Update RedStone blurb in data analytics page

### DIFF
--- a/src/pages/ecosystem/data-analytics.mdx
+++ b/src/pages/ecosystem/data-analytics.mdx
@@ -70,11 +70,11 @@ Range stands out through:
 
 Explore Tempo activity in the [Stablecoin Explorer](https://explorer.money/transactions?dn=tempo-testnet&sc=INTRACHAIN&sn=tempo-testnet).
 
-## Redstone
+## RedStone
 
-[Redstone](https://redstone.finance) delivers modular oracle infrastructure with a push and pull model for onchain price feeds. Redstone's architecture minimizes gas costs by delivering data on-demand, making it well-suited for DeFi applications, lending protocols, and stablecoin systems on Tempo.
+[RedStone](https://redstone.finance) delivers modular oracle infrastructure with a Push and Pull model for onchain price feeds. RedStone's architecture minimizes gas costs by delivering data on-demand, making it well-suited for DeFi applications, lending protocols, FX and stablecoin systems on Tempo.
 
-Explore the available data feeds and integration guides in the [Redstone docs](https://docs.redstone.finance/).
+Explore the available Push data feeds [here](https://app.redstone.finance/push-feeds?networks=tempo&testnets=true) and integration guides in the [RedStone docs](https://docs.redstone.finance/).
 
 ## SonarX
 


### PR DESCRIPTION
Applies the same RedStone updates from #342 to the correct page (`/ecosystem/data-analytics`). The previous PR landed on `/quickstart/developer-tools`, which contains a duplicate section.

- Use proper RedStone casing
- Capitalize Push and Pull
- Add FX to use cases
- Link to push feeds page (`app.redstone.finance/push-feeds?networks=tempo&testnets=true`)

Co-Authored-By: joshitzko <82132285+joshitzko@users.noreply.github.com>

Prompted by: josh