### PR TITLE
Add Safe to ecosystem wallets page

### DIFF
--- a/src/pages/ecosystem/wallets.mdx
+++ b/src/pages/ecosystem/wallets.mdx
@@ -110,6 +110,12 @@ Get started at [OKX Wallet](https://www.okx.com/web3).
 
 Get started at [Rabby](https://rabby.io).
 
+### Safe
+
+[Safe](https://safe.global) provides a modular smart account framework used across leading Web3 applications and institutions. With Safe, developers can build Tempo applications that take advantage of multi-sig controls, programmable permissions, session keys, and automated transaction policies.
+
+Get started at [Safe](https://safe.global).
+
 ## Agentic
 
 ### Enact


### PR DESCRIPTION
Adds Safe to `/ecosystem/wallets` under the **Self-Custodial** section, using the existing blurb from the developer tools page.

Follow-up to #342 — instead of fixing the existing entry under Smart Contract Libraries on the developer tools page, Safe should live in the wallets ecosystem page.

Co-Authored-By: joshitzko <82132285+joshitzko@users.noreply.github.com>

Prompted by: josh