### PR TITLE
fix: rewrite inter-TIP .md links during sync to fix dead-link build failure

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -118,6 +118,9 @@ function syncTips(): Plugin {
           /\(\.\/tip_template\.md\)/g,
           '(https://github.com/tempoxyz/tempo/blob/main/tips/tip_template.md)',
         )
+        // Rewrite inter-TIP links from ./tip-NNNN.md to ./tip-NNNN (synced as .mdx,
+        // Vocs resolves extensionless paths).
+        content = content.replace(/\(\.\/tip-(\d+)\.md\)/g, '(./tip-$1)')
         // Escape angle brackets outside of code blocks/inline code so MDX doesn't
         // treat them as JSX (e.g. `Mapping<B256, bool>` in prose).
         content = escapeAngleBrackets(content)


### PR DESCRIPTION
The TIP sync plugin converts `.md` → `.mdx` but wasn't rewriting internal cross-TIP links (`./tip-1011.md` in `tip-1046.md`). Vocs dead-link checker catches these as broken links and fails the build.

Adds a regex rewrite that strips the `.md` extension from inter-TIP links so Vocs resolves them correctly against the synced `.mdx` files.