### PR TITLE
fix: rewrite relative inter-TIP links to absolute routes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -118,6 +118,12 @@ function syncTips(): Plugin {
           /\(\.\/tip_template\.md\)/g,
           '(https://github.com/tempoxyz/tempo/blob/main/tips/tip_template.md)',
         )
+        // Rewrite relative inter-TIP links (`./tip-NNNN.md`) to absolute
+        // docs routes so the Vocs dead-link checker resolves them correctly.
+        content = content.replace(
+          /\(\.\/tip-(\d+)\.md\)/g,
+          '(/protocol/tips/tip-$1)',
+        )
         // Escape angle brackets outside of code blocks/inline code so MDX doesn't
         // treat them as JSX (e.g. `Mapping<B256, bool>` in prose).
         content = escapeAngleBrackets(content)


### PR DESCRIPTION
## Problem

[PR #188](https://github.com/tempoxyz/docs/pull/188) merged but failed to deploy because TIP-1046 contains relative links (`./tip-1011.md`) that the Vocs dead-link checker can't resolve — synced TIPs become `.mdx` route pages, not `.md` files.

## Fix

Adds a rewrite rule in the TIP sync plugin (`vite.config.ts`) that converts all `./tip-NNNN.md` relative links to absolute `/protocol/tips/tip-NNNN` routes during sync. This matches the existing pattern for `./tip_template.md` and will handle any future inter-TIP cross-references.