### PR TITLE
feat: add SEO title and description frontmatter to 84 docs pages

### DIFF
--- a/src/pages/guide/issuance/create-a-stablecoin.mdx
+++ b/src/pages/guide/issuance/create-a-stablecoin.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Create a Stablecoin"
 description: Create your own stablecoin on Tempo using the TIP-20 token standard. Deploy tokens with built-in compliance features and role-based permissions.
 interactive: true
 ---

--- a/src/pages/guide/issuance/distribute-rewards.mdx
+++ b/src/pages/guide/issuance/distribute-rewards.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Distribute Rewards"
 description: Distribute rewards to token holders using TIP-20's built-in reward mechanism. Allocate tokens proportionally based on holder balances.
 interactive: true
 ---

--- a/src/pages/guide/issuance/index.mdx
+++ b/src/pages/guide/issuance/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Stablecoin Issuance"
 description: Create and manage your own stablecoin on Tempo. Issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
 ---
 

--- a/src/pages/guide/issuance/manage-stablecoin.mdx
+++ b/src/pages/guide/issuance/manage-stablecoin.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Manage Your Stablecoin"
 description: Configure stablecoin permissions, supply limits, and compliance policies. Grant roles, set transfer policies, and control pause/unpause functionality.
 interactive: true
 ---

--- a/src/pages/guide/issuance/mint-stablecoins.mdx
+++ b/src/pages/guide/issuance/mint-stablecoins.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Mint Stablecoins"
 description: Mint new tokens to increase your stablecoin's total supply. Grant the issuer role and create tokens with optional memos for tracking.
 interactive: true
 ---

--- a/src/pages/guide/issuance/use-for-fees.mdx
+++ b/src/pages/guide/issuance/use-for-fees.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Use Your Stablecoin for Fees"
 description: Enable users to pay transaction fees using your stablecoin. Add fee pool liquidity and integrate with Tempo's flexible fee payment system.
 interactive: true
 ---

--- a/src/pages/guide/node/index.mdx
+++ b/src/pages/guide/node/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Tempo Node"
 description: Run your own Tempo node for direct network access. Set up RPC nodes for API access or validator nodes to participate in consensus.
 ---
 

--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Node Installation"
 description: Install Tempo node using pre-built binaries, build from source with Rust, or run with Docker. Get started in minutes with tempoup.
 ---
 

--- a/src/pages/guide/node/rpc.mdx
+++ b/src/pages/guide/node/rpc.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Running an RPC Node"
 description: Set up and run a Tempo RPC node for API access. Download snapshots, configure systemd services, and monitor node health and sync status.
 ---
 

--- a/src/pages/guide/node/system-requirements.mdx
+++ b/src/pages/guide/node/system-requirements.mdx
@@ -1,4 +1,5 @@
 ---
+title: "System Requirements"
 description: Minimum and recommended hardware specs for running Tempo RPC and validator nodes. CPU, RAM, storage, network, and port requirements.
 ---
 

--- a/src/pages/guide/node/validator.mdx
+++ b/src/pages/guide/node/validator.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Running a Validator Node"
 description: Overview of running a Tempo validator node.
 ---
 

--- a/src/pages/guide/payments/accept-a-payment.mdx
+++ b/src/pages/guide/payments/accept-a-payment.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Accept a Payment"
 description: Accept stablecoin payments in your application. Verify transactions, listen for transfer events, and reconcile payments using memos.
 interactive: true
 ---

--- a/src/pages/guide/payments/index.mdx
+++ b/src/pages/guide/payments/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Stablecoin Payments"
 description: Send and receive stablecoin payments on Tempo. Integrate payments with flexible fee options, sponsorship capabilities, and parallel transactions.
 ---
 

--- a/src/pages/guide/payments/pay-fees-in-any-stablecoin.mdx
+++ b/src/pages/guide/payments/pay-fees-in-any-stablecoin.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Pay Fees in Any Stablecoin"
 description: Configure users to pay transaction fees in any supported stablecoin. Eliminate the need for a separate gas token with Tempo's flexible fee system.
 showOutline: 1
 interactive: true

--- a/src/pages/guide/payments/send-a-payment.mdx
+++ b/src/pages/guide/payments/send-a-payment.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Send a Payment"
 description: Send stablecoin payments between accounts on Tempo. Include optional memos for reconciliation and tracking with TypeScript, Rust, or Solidity.
 interactive: true
 ---

--- a/src/pages/guide/payments/send-parallel-transactions.mdx
+++ b/src/pages/guide/payments/send-parallel-transactions.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Send Parallel Transactions"
 description: Submit multiple transactions concurrently using Tempo's expiring nonce system under-the-hood.
 interactive: true
 ---

--- a/src/pages/guide/payments/sponsor-user-fees.mdx
+++ b/src/pages/guide/payments/sponsor-user-fees.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Sponsor User Fees"
 description: Enable gasless transactions by sponsoring fees for your users. Set up a fee payer service and improve UX by removing friction from payment flows.
 interactive: true
 ---

--- a/src/pages/guide/payments/transfer-memos.mdx
+++ b/src/pages/guide/payments/transfer-memos.mdx
@@ -1,4 +1,6 @@
 ---
+title: "Attach a Transfer Memo"
+description: "Attach 32-byte references to TIP-20 transfers for payment reconciliation using memos for customer IDs and invoices."
 interactive: true
 ---
 

--- a/src/pages/guide/stablecoin-dex/executing-swaps.mdx
+++ b/src/pages/guide/stablecoin-dex/executing-swaps.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Executing Swaps"
 description: Learn to execute instant stablecoin swaps on Tempo's DEX. Get price quotes, set slippage protection, and batch approvals with swaps.
 interactive: true
 ---

--- a/src/pages/guide/stablecoin-dex/index.mdx
+++ b/src/pages/guide/stablecoin-dex/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Exchange Stablecoins"
 description: Trade between stablecoins on Tempo's enshrined DEX. Execute swaps, provide liquidity, and query the onchain orderbook for optimal pricing.
 ---
 

--- a/src/pages/guide/stablecoin-dex/managing-fee-liquidity.mdx
+++ b/src/pages/guide/stablecoin-dex/managing-fee-liquidity.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Managing Fee Liquidity"
 description: Add and remove liquidity in the Fee AMM to enable stablecoin fee conversions. Monitor pools, check LP balances, and rebalance reserves.
 interactive: true
 ---

--- a/src/pages/guide/stablecoin-dex/providing-liquidity.mdx
+++ b/src/pages/guide/stablecoin-dex/providing-liquidity.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Providing Liquidity"
 description: Place limit and flip orders to provide liquidity on the Stablecoin DEX orderbook. Learn to manage orders and set prices using ticks.
 interactive: true
 ---

--- a/src/pages/guide/stablecoin-dex/view-the-orderbook.mdx
+++ b/src/pages/guide/stablecoin-dex/view-the-orderbook.mdx
@@ -1,4 +1,5 @@
 ---
+title: "View the Orderbook"
 description: Inspect Tempo's onchain orderbook using SQL queries. View spreads, order depth, individual orders, and recent trade prices with indexed data.
 ---
 

--- a/src/pages/guide/tempo-transaction/index.mdx
+++ b/src/pages/guide/tempo-transaction/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Use Tempo Transactions"
 description: Learn how to use Tempo Transactions for configurable fee tokens, fee sponsorship, batch calls, access keys, and concurrent execution.
 ---
 

--- a/src/pages/guide/use-accounts/add-funds.mdx
+++ b/src/pages/guide/use-accounts/add-funds.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Add Funds"
 description: Get test stablecoins on Tempo Testnet using the faucet. Request pathUSD, AlphaUSD, BetaUSD, and ThetaUSD tokens for development and testing.
 mipd: true
 interactive: true

--- a/src/pages/guide/use-accounts/batch-transactions.mdx
+++ b/src/pages/guide/use-accounts/batch-transactions.mdx
@@ -1,3 +1,8 @@
+---
+title: "Batch Transactions"
+description: "Combine multiple operations into a single atomic Tempo transaction to reduce gas costs and prevent partial failures."
+---
+
 # Batch Transactions
 
 One of the most powerful features of the [Tempo Transaction](/protocol/transactions/spec-tempo-transaction) type is batching multiple operations into a single transaction. This allows you to execute several actions atomically (i.e., they all succeed or all fail together). This helps reduce gas costs, prevents partial failures, and creates better user experiences by combining multiple steps into one transaction.

--- a/src/pages/guide/use-accounts/connect-to-wallets.mdx
+++ b/src/pages/guide/use-accounts/connect-to-wallets.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Connect to Wallets"
 description: Connect your application to EVM-compatible wallets like MetaMask on Tempo. Set up Wagmi connectors and add the Tempo network to user wallets.
 mipd: true
 interactive: true

--- a/src/pages/guide/use-accounts/embed-passkeys.mdx
+++ b/src/pages/guide/use-accounts/embed-passkeys.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Embed Passkey Accounts"
 description: Create domain-bound passkey accounts on Tempo using WebAuthn for secure, passwordless authentication with biometrics like Face ID and Touch ID.
 interactive: true
 ---

--- a/src/pages/guide/use-accounts/embed-tempo-wallet.mdx
+++ b/src/pages/guide/use-accounts/embed-tempo-wallet.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Embed Tempo Wallet"
 description: Embed the Tempo Wallet dialog into your application for a universal wallet experience with account management, passkeys, and fee sponsorship.
 interactive: true
 ---

--- a/src/pages/guide/use-accounts/index.mdx
+++ b/src/pages/guide/use-accounts/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Create and Use Accounts"
 description: Create and integrate Tempo accounts with the universal Tempo Wallet or domain-bound passkeys.
 ---
 

--- a/src/pages/guide/use-accounts/scheduled-transactions.mdx
+++ b/src/pages/guide/use-accounts/scheduled-transactions.mdx
@@ -1,3 +1,8 @@
+---
+title: "Scheduled Transactions"
+description: "Execute transactions within specific time windows using validAfter and validBefore timestamps on Tempo transactions."
+---
+
 # Scheduled Transactions
 
 Execute transactions only within a specific time window using `validAfter` and `validBefore` timestamps.

--- a/src/pages/guide/use-accounts/webauthn-p256-signatures.mdx
+++ b/src/pages/guide/use-accounts/webauthn-p256-signatures.mdx
@@ -1,3 +1,8 @@
+---
+title: "WebAuthn and P256 Signatures"
+description: "Sign Tempo transactions with WebAuthn passkeys, P256 keys, or standard secp256k1 wallets for flexible authentication."
+---
+
 # WebAuthn & P256 Signatures
 
 Tempo EOA addresses can be derived from multiple signature types. Allowing you to sign transactions with standard Ethereum wallets, hardware security keys, biometric authentication like Face ID and Touch ID, or even using [passkeys](https://passkeys.dev/).

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Tempo Documentation"
 description: Explore Tempo's blockchain documentation, integration guides, and protocol specs. Build low-cost, high-throughput payment applications.
 ---
 

--- a/src/pages/learn/index.mdx
+++ b/src/pages/learn/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Learn"
 description: Explore stablecoin use cases and Tempo's payments-optimized blockchain architecture for remittances, payouts, and embedded finance.
 ---
 

--- a/src/pages/learn/partners.mdx
+++ b/src/pages/learn/partners.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Partners"
 description: Discover Tempo's ecosystem of stablecoin issuers, wallets, custody providers, compliance tools, and ramps.
 ---
 

--- a/src/pages/learn/tempo/fx.mdx
+++ b/src/pages/learn/tempo/fx.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Onchain FX"
 description: Access foreign exchange liquidity directly onchain with regulated non-USD stablecoin issuers and multi-currency fee payments on Tempo.
 ---
 

--- a/src/pages/learn/tempo/index.mdx
+++ b/src/pages/learn/tempo/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Tempo Overview"
 description: Discover Tempo, the payments-first blockchain with instant settlement, predictably low fees, and native stablecoin support.
 ---
 

--- a/src/pages/learn/tempo/machine-payments.mdx
+++ b/src/pages/learn/tempo/machine-payments.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Agentic Payments"
 description: The Machine Payments Protocol (MPP) is an open standard for machine-to-machine payments, co-authored by Stripe and Tempo.
 ---
 

--- a/src/pages/learn/tempo/modern-transactions.mdx
+++ b/src/pages/learn/tempo/modern-transactions.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Modern Transactions"
 description: Native support for gas sponsorship, batch transactions, scheduled payments, and passkey authentication built into Tempo's protocol.
 ---
 

--- a/src/pages/learn/tempo/native-stablecoins.mdx
+++ b/src/pages/learn/tempo/native-stablecoins.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Native Stablecoins"
 description: Tempo's stablecoin token standard with payment lanes, stable fees, reconciliation memos, and built-in compliance for regulated issuers.
 ---
 

--- a/src/pages/learn/tempo/performance.mdx
+++ b/src/pages/learn/tempo/performance.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Performance"
 description: High throughput and sub-second finality built on Reth SDK and Simplex Consensus for payment applications requiring instant settlement.
 ---
 

--- a/src/pages/learn/tempo/privacy.mdx
+++ b/src/pages/learn/tempo/privacy.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Privacy"
 description: Explore Tempo's opt-in privacy features enabling private balances and confidential transfers while maintaining issuer compliance.
 ---
 

--- a/src/pages/learn/use-cases/agentic-commerce.mdx
+++ b/src/pages/learn/use-cases/agentic-commerce.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Agentic Commerce"
 description: Power autonomous AI agents with programmable stablecoin payments for goods, services, and digital resources in real time.
 ---
 

--- a/src/pages/learn/use-cases/embedded-finance.mdx
+++ b/src/pages/learn/use-cases/embedded-finance.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Embedded Finance"
 description: Enable platforms and marketplaces to streamline partner payouts, lower payment costs, and launch rewarding loyalty programs.
 ---
 

--- a/src/pages/learn/use-cases/global-payouts.mdx
+++ b/src/pages/learn/use-cases/global-payouts.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Global Payouts"
 description: Deliver instant, low-cost payouts to contractors, merchants, and partners worldwide with stablecoins, bypassing slow banking rails.
 ---
 

--- a/src/pages/learn/use-cases/microtransactions.mdx
+++ b/src/pages/learn/use-cases/microtransactions.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Microtransactions"
 description: Enable true pay-per-use pricing with sub-cent payments for APIs, content, IoT services, and machine-to-machine commerce.
 ---
 

--- a/src/pages/learn/use-cases/remittances.mdx
+++ b/src/pages/learn/use-cases/remittances.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Remittances"
 description: Send cross-border payments faster and cheaper with stablecoins, eliminating correspondent banks and reducing transfer costs.
 ---
 

--- a/src/pages/learn/use-cases/tokenized-deposits.mdx
+++ b/src/pages/learn/use-cases/tokenized-deposits.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Tokenized Deposits"
 description: Move treasury liquidity instantly across borders with real-time visibility into global cash positions using tokenized deposits.
 ---
 

--- a/src/pages/protocol/blockspace/overview.mdx
+++ b/src/pages/protocol/blockspace/overview.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Blockspace Overview"
 description: Technical specification for Tempo block structure including header fields, payment lanes, and system transaction ordering.
 ---
 

--- a/src/pages/protocol/blockspace/payment-lane-specification.mdx
+++ b/src/pages/protocol/blockspace/payment-lane-specification.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Payment Lane Specification"
 description: Technical specification for Tempo payment lanes ensuring dedicated blockspace for payment transactions with predictable fees during congestion.
 ---
 

--- a/src/pages/protocol/exchange/exchange-balance.mdx
+++ b/src/pages/protocol/exchange/exchange-balance.mdx
@@ -1,4 +1,5 @@
 ---
+title: "DEX Balance"
 description: Hold token balances directly on the Stablecoin DEX to save gas costs on trades, receive maker proceeds automatically, and trade more efficiently.
 ---
 

--- a/src/pages/protocol/exchange/executing-swaps.mdx
+++ b/src/pages/protocol/exchange/executing-swaps.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Executing Swaps"
 description: Learn how to execute swaps and quote prices on Tempo's Stablecoin DEX with exact-in and exact-out swap functions and slippage protection.
 ---
 

--- a/src/pages/protocol/exchange/index.mdx
+++ b/src/pages/protocol/exchange/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Stablecoin DEX"
 description: Tempo's enshrined decentralized exchange for trading between stablecoins with optimal pricing, limit orders, and flip orders for liquidity provision.
 ---
 

--- a/src/pages/protocol/exchange/providing-liquidity.mdx
+++ b/src/pages/protocol/exchange/providing-liquidity.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Providing Liquidity"
 description: Provide liquidity on Tempo's DEX using limit orders and flip orders. Earn spreads while facilitating stablecoin trades with price-time priority.
 ---
 

--- a/src/pages/protocol/exchange/quote-tokens.mdx
+++ b/src/pages/protocol/exchange/quote-tokens.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Quote Tokens"
 description: Quote tokens determine trading pairs on Tempo's DEX. Each TIP-20 specifies a quote token, with pathUSD available as an optional neutral choice.
 ---
 

--- a/src/pages/protocol/exchange/spec.mdx
+++ b/src/pages/protocol/exchange/spec.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Stablecoin DEX Specification"
 description: Technical specification for Tempo's enshrined DEX with price-time priority orderbook, flip orders, and multi-hop routing for stablecoin trading.
 ---
 

--- a/src/pages/protocol/fees/fee-amm/index.mdx
+++ b/src/pages/protocol/fees/fee-amm/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Fee AMM Overview"
 description: Understand how the Fee AMM automatically converts transaction fees between stablecoins, enabling users to pay in any supported token.
 ---
 

--- a/src/pages/protocol/fees/index.mdx
+++ b/src/pages/protocol/fees/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Transaction Fees"
 description: Pay transaction fees in any USD stablecoin on Tempo. No native token required—fees are paid directly in TIP-20 stablecoins with automatic conversion.
 ---
 

--- a/src/pages/protocol/fees/spec-fee-amm.mdx
+++ b/src/pages/protocol/fees/spec-fee-amm.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Fee AMM Specification"
 description: Technical specification for the Fee AMM enabling automatic stablecoin conversion for transaction fees with fixed-rate swaps and MEV protection.
 ---
 

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Tempo Protocol"
 description: Technical specifications and reference documentation for the Tempo blockchain protocol, purpose-built for global payments at scale.
 ---
 

--- a/src/pages/protocol/tip20-rewards/overview.mdx
+++ b/src/pages/protocol/tip20-rewards/overview.mdx
@@ -1,4 +1,5 @@
 ---
+title: "TIP-20 Rewards"
 description: Built-in reward distribution mechanism for TIP-20 tokens enabling efficient, opt-in proportional rewards to token holders at scale.
 ---
 

--- a/src/pages/protocol/tip20-rewards/spec.mdx
+++ b/src/pages/protocol/tip20-rewards/spec.mdx
@@ -1,4 +1,5 @@
 ---
+title: "TIP-20 Rewards Specification"
 description: Technical specification for the TIP-20 reward distribution system using reward-per-token accumulator pattern for scalable pro-rata rewards.
 ---
 

--- a/src/pages/protocol/tip20/overview.mdx
+++ b/src/pages/protocol/tip20/overview.mdx
@@ -1,4 +1,5 @@
 ---
+title: "TIP-20 Token Standard"
 description: TIP-20 is Tempo's native token standard for stablecoins with built-in fee payment, payment lanes, transfer memos, and compliance policies.
 ---
 

--- a/src/pages/protocol/tip20/spec.mdx
+++ b/src/pages/protocol/tip20/spec.mdx
@@ -1,4 +1,5 @@
 ---
+title: "TIP-20 Specification"
 description: Technical specification for TIP-20, the optimized token standard extending ERC-20 with memos, rewards distribution, and policy integration.
 ---
 

--- a/src/pages/protocol/tip403/overview.mdx
+++ b/src/pages/protocol/tip403/overview.mdx
@@ -1,4 +1,5 @@
 ---
+title: "TIP-403 Policy Registry"
 description: Learn how TIP-403 enables TIP-20 tokens to enforce access control through a shared policy registry with whitelist and blacklist support.
 ---
 

--- a/src/pages/protocol/tip403/spec.mdx
+++ b/src/pages/protocol/tip403/spec.mdx
@@ -1,4 +1,5 @@
 ---
+title: "TIP-403 Specification"
 description: Technical specification for TIP-403, the policy registry system enabling whitelist and blacklist access control for TIP-20 tokens on Tempo.
 ---
 

--- a/src/pages/protocol/tips/index.mdx
+++ b/src/pages/protocol/tips/index.mdx
@@ -1,3 +1,8 @@
+---
+title: "Tempo Improvement Proposals"
+description: "Browse Tempo Improvement Proposals (TIPs), the design documents that specify changes to the Tempo protocol."
+---
+
 import { TipsList } from '../../../components/TipsList'
 
 # Tempo Improvement Proposals (TIPs)

--- a/src/pages/protocol/transactions/AccountKeychain.mdx
+++ b/src/pages/protocol/transactions/AccountKeychain.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Account Keychain"
 description: Technical specification for the Account Keychain precompile managing access keys with expiry timestamps, spending limits, and call-scope restrictions.
 ---
 

--- a/src/pages/protocol/transactions/index.mdx
+++ b/src/pages/protocol/transactions/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Tempo Transactions"
 description: Learn about Tempo Transactions, a new EIP-2718 transaction type with passkey support, fee sponsorship, batching, and concurrent execution.
 ---
 

--- a/src/pages/protocol/transactions/spec-tempo-transaction.mdx
+++ b/src/pages/protocol/transactions/spec-tempo-transaction.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Tempo Transaction Specification"
 description: Technical specification for the Tempo transaction type (EIP-2718) with WebAuthn signatures, parallelizable nonces, gas sponsorship, and batching.
 ---
 

--- a/src/pages/quickstart/connection-details.mdx
+++ b/src/pages/quickstart/connection-details.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Connect to the Network"
 description: Connect to Tempo using browser wallets, CLI tools, or direct RPC endpoints. Get chain ID, URLs, and configuration details.
 mipd: true
 interactive: true

--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Developer Tools"
 description: Explore Tempo's developer ecosystem with indexers, embedded wallets, node infrastructure, and analytics partners for building payment apps.
 ---
 

--- a/src/pages/quickstart/evm-compatibility.mdx
+++ b/src/pages/quickstart/evm-compatibility.mdx
@@ -1,4 +1,5 @@
 ---
+title: "EVM Differences"
 description: Learn how Tempo differs from Ethereum. Understand wallet behavior, fee token selection, VM layer changes, and fast finality consensus.
 ---
 

--- a/src/pages/quickstart/faucet.mdx
+++ b/src/pages/quickstart/faucet.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Faucet"
 description: Get free test stablecoins on Tempo Testnet. Connect your wallet or enter any address to receive pathUSD, AlphaUSD, BetaUSD, and ThetaUSD.
 mipd: true
 interactive: true

--- a/src/pages/quickstart/integrate-tempo.mdx
+++ b/src/pages/quickstart/integrate-tempo.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Integrate Tempo"
 description: Build on Tempo Testnet. Connect to the network, explore SDKs, and follow guides for accounts, payments, and stablecoin issuance.
 interactive: true
 ---

--- a/src/pages/quickstart/predeployed-contracts.mdx
+++ b/src/pages/quickstart/predeployed-contracts.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Predeployed Contracts"
 description: Discover Tempo's predeployed system contracts including TIP-20 Factory, Fee Manager, Stablecoin DEX, and standard utilities like Multicall3.
 ---
 

--- a/src/pages/quickstart/wallet-developers.mdx
+++ b/src/pages/quickstart/wallet-developers.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Wallet Integration Guide"
 description: Integrate Tempo into your wallet. Handle fee tokens, configure gas display, and deliver enhanced stablecoin payment experiences for users.
 showOutline: 1
 ---

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Foundry SDK"
 description: Build, test, and deploy smart contracts on Tempo using Foundry. Access Tempo protocol features with forge, cast, anvil, and chisel.
 ---
 

--- a/src/pages/sdk/go/index.mdx
+++ b/src/pages/sdk/go/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Go SDK"
 description: Build blockchain apps with the Tempo Go SDK. Send transactions, batch calls, and handle fee sponsorship with idiomatic Go code.
 ---
 

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "SDKs"
 description: Integrate Tempo into your applications with SDKs for TypeScript, Go, Rust, and Foundry. Build blockchain apps in your preferred language.
 ---
 

--- a/src/pages/sdk/python/index.mdx
+++ b/src/pages/sdk/python/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Python SDK"
 description: Build blockchain apps with the Tempo Python SDK. Send transactions, batch calls, and handle fee sponsorship using web3.py.
 ---
 

--- a/src/pages/sdk/rust/index.mdx
+++ b/src/pages/sdk/rust/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Rust SDK"
 description: Build blockchain apps with the Tempo Rust SDK using Alloy. Query chains, send transactions, and manage tokens with type-safe Rust code.
 ---
 

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: "TypeScript SDKs"
 description: Build blockchain apps with Tempo using Viem and Wagmi. Send transactions, manage tokens, and integrate AMM pools with TypeScript.
 ---
 

--- a/src/pages/sdk/typescript/prool/setup.mdx
+++ b/src/pages/sdk/typescript/prool/setup.mdx
@@ -1,4 +1,5 @@
 ---
+title: "Prool Setup"
 description: Set up infinite pooled Tempo node instances in TypeScript with Prool for testing and local development of blockchain applications.
 ---
 


### PR DESCRIPTION
Adds `title` frontmatter to 84 docs pages that were missing it. The `vocs.config.ts` uses `titleTemplate: '%s ⋅ Tempo'`, so each title renders as `{title} ⋅ Tempo` in the browser tab and OG tags.

**What changed:**
- 80 files had existing frontmatter with `description` but no `title` — added `title`
- 4 files had no frontmatter at all — added full `---` block with both `title` and `description`

**Sections covered:** guide/issuance, guide/node, guide/payments, guide/stablecoin-dex, guide/tempo-transaction, guide/use-accounts, index, learn, protocol, quickstart, sdk