### PR TITLE
fix: og:image title/description not rendering

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -102,14 +102,12 @@ export default defineConfig({
           ? secondSeg.toUpperCase().replace(/-/g, ' ')
           : ''
 
-    const params = new URLSearchParams({
-      title: '%title',
-      description: '%description',
+    const extra = new URLSearchParams({
       section,
       ...(subsection ? { subsection } : {}),
-    })
+    }).toString()
 
-    return `${baseUrl}/api/og?${params.toString()}`
+    return `${baseUrl}/api/og?title=%title&description=%description&${extra}`
   },
   // TODO: Change back to file paths (`/lockup-light.svg`, `/lockup-dark.svg`) once password protection is removed
   logoUrl: {


### PR DESCRIPTION
**Problem:** OG images show literal `%title` instead of the actual page title (e.g. "Send a Payment"). This affects all non-landing pages.

**Root cause:** `URLSearchParams` in the `ogImageUrl` config function URL-encodes `%title` → `%25title`, so Vocs's `.replace('%title', ...)` substitution can't find the placeholder.

**Fix:** Build the query string manually, keeping `%title` and `%description` as bare placeholders for Vocs to substitute.