### PR TITLE
feat: add SEO descriptions to docs pages missing meta descriptions

### DIFF
--- a/src/pages/guide/payments/transfer-memos.mdx
+++ b/src/pages/guide/payments/transfer-memos.mdx
@@ -1,5 +1,6 @@
 ---
 interactive: true
+description: Attach 32-byte reference memos to TIP-20 transfers for payment reconciliation, invoice matching, and exchange deposit tracking on Tempo.
 ---
 
 import { Cards, Card } from 'vocs'

--- a/src/pages/guide/tempo-transaction/index.mdx
+++ b/src/pages/guide/tempo-transaction/index.mdx
@@ -1,11 +1,12 @@
 ---
+title: Use Tempo Transactions
 description: Learn how to use Tempo Transactions for configurable fee tokens, fee sponsorship, batch calls, access keys, and concurrent execution.
 ---
 
 import { Cards, Card } from 'vocs'
 import TempoTxProperties from '../../../snippets/tempo-tx-properties.mdx'
 
-## Use Tempo Transactions
+# Use Tempo Transactions
 
 Tempo Transactions are a new [EIP-2718](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2718.md) transaction type, exclusively available on Tempo.
 

--- a/src/pages/guide/use-accounts/batch-transactions.mdx
+++ b/src/pages/guide/use-accounts/batch-transactions.mdx
@@ -1,3 +1,7 @@
+---
+description: Execute multiple operations atomically in a single Tempo Transaction using native protocol-level batching with one signature and lower gas costs.
+---
+
 # Batch Transactions
 
 One of the most powerful features of the [Tempo Transaction](/protocol/transactions/spec-tempo-transaction) type is batching multiple operations into a single transaction. This allows you to execute several actions atomically (i.e., they all succeed or all fail together). This helps reduce gas costs, prevents partial failures, and creates better user experiences by combining multiple steps into one transaction.

--- a/src/pages/guide/use-accounts/scheduled-transactions.mdx
+++ b/src/pages/guide/use-accounts/scheduled-transactions.mdx
@@ -1,3 +1,7 @@
+---
+description: Schedule Tempo transactions to execute within a specific time window using validAfter and validBefore timestamps for vesting, offers, and delayed execution.
+---
+
 # Scheduled Transactions
 
 Execute transactions only within a specific time window using `validAfter` and `validBefore` timestamps.

--- a/src/pages/guide/use-accounts/webauthn-p256-signatures.mdx
+++ b/src/pages/guide/use-accounts/webauthn-p256-signatures.mdx
@@ -1,3 +1,7 @@
+---
+description: Sign Tempo transactions with passkeys, Face ID, Touch ID, or hardware security keys using native WebAuthn and P256 signature support on EOA accounts.
+---
+
 # WebAuthn & P256 Signatures
 
 Tempo EOA addresses can be derived from multiple signature types. Allowing you to sign transactions with standard Ethereum wallets, hardware security keys, biometric authentication like Face ID and Touch ID, or even using [passkeys](https://passkeys.dev/).

--- a/src/pages/protocol/tips/index.mdx
+++ b/src/pages/protocol/tips/index.mdx
@@ -1,3 +1,7 @@
+---
+description: Browse all Tempo Improvement Proposals (TIPs) — design documents that specify protocol changes and serve as the source of truth for implementation.
+---
+
 import { TipsList } from '../../../components/TipsList'
 
 # Tempo Improvement Proposals (TIPs)

--- a/src/pages/quickstart/tokenlist.mdx
+++ b/src/pages/quickstart/tokenlist.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tempo Token List Registry
 interactive: true
+description: Query token metadata, icons, and prices on Tempo using the Uniswap Token Lists-compatible API, and submit new tokens via PR to the registry.
 ---
 import { Callout } from 'vocs'
 


### PR DESCRIPTION
## Summary

Adds `description:` frontmatter to the 6 docs pages that were missing it, and fixes the `tempo-transaction/index.mdx` heading level.

Supersedes #370

## Why

- **Vocs auto-infers titles from H1 headings**, so explicit `title:` frontmatter is unnecessary for pages that already have an `# H1` — the previous PR (#370) added redundant titles to 84 pages.
- **79 of 84 pages already had `description:`** in their frontmatter — they were fine.
- **6 pages had no `description:`**, causing them to fall back to the generic site description in search results and social previews.
- **`guide/tempo-transaction/index.mdx` started with `##` instead of `#`**, so Vocs couldn't infer its title. This PR promotes the heading to `#` and adds an explicit `title:` in frontmatter.

## Changes

| File | Change |
|------|--------|
| `guide/payments/transfer-memos.mdx` | Add `description` |
| `guide/use-accounts/batch-transactions.mdx` | Add `description` |
| `guide/use-accounts/scheduled-transactions.mdx` | Add `description` |
| `guide/use-accounts/webauthn-p256-signatures.mdx` | Add `description` |
| `protocol/tips/index.mdx` | Add `description` |
| `quickstart/tokenlist.mdx` | Add `description` |
| `guide/tempo-transaction/index.mdx` | Add `title`, promote `##` → `#` |