### PR TITLE
docs: T4 network upgrade page + v1.6.0/v1.7.0 release entries

### DIFF
--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.7.0 (planned) | TBD | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
+| v1.7.0 (planned) | May 11, 2026 | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
 | [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) | Apr 16, 2026 | Moderato + Mainnet | Required for T3; implements enhanced access key permissions with periodic limits and call scoping (TIP-1011), the signature verification precompile (TIP-1020), and virtual addresses for TIP-20 deposit forwarding (TIP-1022). | <Badge variant="red">Required</Badge> |
 | [v1.5.3](https://github.com/tempoxyz/tempo/releases/tag/v1.5.3) | Apr 9, 2026 | Moderato + Mainnet | Patch release that restores OTLP HTTPS telemetry and fixes an epoch-transition consensus race that could incorrectly block straggling peers. Validators that skipped v1.5.2 should upgrade directly to this release. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.5.2](https://github.com/tempoxyz/tempo/releases/tag/v1.5.2) | Apr 8, 2026 | Moderato + Mainnet | Maintenance release with the latest reth update, payload builder and RPC improvements, plus transaction validation and mempool hardening. | <Badge variant="yellow">Recommended</Badge> |
@@ -41,9 +41,9 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 | **Scope** | Embed consensus context into the block header to unlock deferred verification, plus T4 bug fixes and security hardening |
 | **TIPs** | [TIP-1031: Embed Consensus Context in the Block Header](/protocol/tips/tip-1031), [TIP-1046: T4 Hardfork Meta TIP](/protocol/tips/tip-1046) |
 | **Details** | [T4 network upgrade](/protocol/upgrades/t4) |
-| **Release** | v1.7.0 (planned) |
-| **Testnet** | Moderato: TBD |
-| **Mainnet** | Presto: TBD |
+| **Release** | v1.7.0 (planned, May 11, 2026 16:00 CEST) |
+| **Testnet** | Moderato: May 14, 2026 16:00 CEST (unix: 1778767200) |
+| **Mainnet** | Presto: May 18, 2026 16:00 CEST (unix: 1779112800) |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
 ### Who is affected?

--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -15,6 +15,8 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
+| v1.7.0 (planned) | TBD | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
+| [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) | Apr 16, 2026 | Moderato + Mainnet | Required for T3; implements enhanced access key permissions with periodic limits and call scoping (TIP-1011), the signature verification precompile (TIP-1020), and virtual addresses for TIP-20 deposit forwarding (TIP-1022). | <Badge variant="red">Required</Badge> |
 | [v1.5.3](https://github.com/tempoxyz/tempo/releases/tag/v1.5.3) | Apr 9, 2026 | Moderato + Mainnet | Patch release that restores OTLP HTTPS telemetry and fixes an epoch-transition consensus race that could incorrectly block straggling peers. Validators that skipped v1.5.2 should upgrade directly to this release. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.5.2](https://github.com/tempoxyz/tempo/releases/tag/v1.5.2) | Apr 8, 2026 | Moderato + Mainnet | Maintenance release with the latest reth update, payload builder and RPC improvements, plus transaction validation and mempool hardening. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.5.1](https://github.com/tempoxyz/tempo/releases/tag/v1.5.1) | Mar 29, 2026 | Moderato + Mainnet | Security patch for RPC endpoints that accept `stateOverride`, including `eth_call` and `debug_traceCall`. This release is required for RPC providers and other public RPC nodes, and low priority for validators. | <Badge variant="amber">RPC only</Badge> |
@@ -29,6 +31,26 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 :::warning
 `--consensus.fee-recipient` is deprecated as of `v1.5.2` and will be removed in an upcoming release. Validators should migrate fee-recipient management to [update the fee recipient](/guide/node/validator-lifecycle#update-the-fee-recipient).
 :::
+
+---
+
+## T4
+
+| | |
+|---|---|
+| **Scope** | Embed consensus context into the block header to unlock deferred verification, plus T4 bug fixes and security hardening |
+| **TIPs** | [TIP-1031: Embed Consensus Context in the Block Header](/protocol/tips/tip-1031), [TIP-1046: T4 Hardfork Meta TIP](/protocol/tips/tip-1046) |
+| **Details** | [T4 network upgrade](/protocol/upgrades/t4) |
+| **Release** | v1.7.0 (planned) |
+| **Testnet** | Moderato: TBD |
+| **Mainnet** | Presto: TBD |
+| **Priority** | <Badge variant="red">Required</Badge> |
+
+### Who is affected?
+
+All node operators must upgrade before the T4 activation timestamp. TIP-1031 changes how block headers are produced and verified; non-upgraded nodes will have their proposals rejected and will fall out of consensus at activation.
+
+Smart contract developers and integrators are not directly affected by TIP-1031, but should review [TIP-1046](/protocol/tips/tip-1046) for the bundled gas accounting changes and access-key scope validation updates that may affect transaction gas usage post-T4.
 
 ---
 

--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.7.0 (planned) | May 11, 2026 | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
+| v1.7.0 (targeted) | Mon, May 11, 2026 | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
 | [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) | Apr 16, 2026 | Moderato + Mainnet | Required for T3; implements enhanced access key permissions with periodic limits and call scoping (TIP-1011), the signature verification precompile (TIP-1020), and virtual addresses for TIP-20 deposit forwarding (TIP-1022). | <Badge variant="red">Required</Badge> |
 | [v1.5.3](https://github.com/tempoxyz/tempo/releases/tag/v1.5.3) | Apr 9, 2026 | Moderato + Mainnet | Patch release that restores OTLP HTTPS telemetry and fixes an epoch-transition consensus race that could incorrectly block straggling peers. Validators that skipped v1.5.2 should upgrade directly to this release. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.5.2](https://github.com/tempoxyz/tempo/releases/tag/v1.5.2) | Apr 8, 2026 | Moderato + Mainnet | Maintenance release with the latest reth update, payload builder and RPC improvements, plus transaction validation and mempool hardening. | <Badge variant="yellow">Recommended</Badge> |
@@ -41,7 +41,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 | **Scope** | Embed consensus context into the block header to unlock deferred verification, plus T4 bug fixes and security hardening |
 | **TIPs** | [TIP-1031: Embed Consensus Context in the Block Header](/protocol/tips/tip-1031), [TIP-1046: T4 Hardfork Meta TIP](/protocol/tips/tip-1046) |
 | **Details** | [T4 network upgrade](/protocol/upgrades/t4) |
-| **Release** | v1.7.0 (planned, May 11, 2026 16:00 CEST) |
+| **Release** | v1.7.0 (targeted for Mon, May 11, 2026 16:00 CEST) |
 | **Testnet** | Moderato: May 14, 2026 16:00 CEST (unix: 1778767200) |
 | **Mainnet** | Presto: May 18, 2026 16:00 CEST (unix: 1779112800) |
 | **Priority** | <Badge variant="red">Required</Badge> |

--- a/src/pages/protocol/upgrades/t4.mdx
+++ b/src/pages/protocol/upgrades/t4.mdx
@@ -15,10 +15,10 @@ The features described on this page are scheduled for T4 and are not active on M
 
 | Network | Date | Timestamp |
 |---------|------|-----------|
-| Moderato (testnet) | TBD | `TBD` |
-| Presto (mainnet) | TBD | `TBD` |
+| Moderato (testnet) | May 14, 2026 4pm CEST | `1778767200` |
+| Presto (mainnet) | May 18, 2026 4pm CEST | `1779112800` |
 
-Node operators must upgrade to the T4-compatible release (v1.7.0) before the Moderato activation timestamp.
+Node operators must upgrade to the T4-compatible release (v1.7.0, targeted for May 11, 2026 4pm CEST) before the Moderato activation timestamp.
 
 ## Overview
 
@@ -66,4 +66,4 @@ T4-compatible SDK releases will be listed here as they ship.
 
 ### TIP-1046: T4 Hardfork Meta TIP
 
-[TIP-1046](/protocol/tips/tip-1046) bundles bug fixes and security hardening gated behind T4, including a `cancel_stale_order` recipient authorization check, correct out-of-gas propagation in TIP-20 dispatch, an intrinsic gas surcharge for access-key scope persistence, paused-token enforcement on internal-balance DEX debit paths, pre-charging the static gas portion before cold loads, and pre-validating the full call-scope batch before any storage writes.
+[TIP-1046](/protocol/tips/tip-1046) bundles T4 bug fixes and security hardening. The notable changes for partners are an intrinsic gas surcharge for access-key scope persistence, pre-charging the static gas portion before cold account/storage loads, and the subblock metadata system transaction change covered above. See the TIP for the full list.

--- a/src/pages/protocol/upgrades/t4.mdx
+++ b/src/pages/protocol/upgrades/t4.mdx
@@ -1,0 +1,69 @@
+---
+title: T4 Network Upgrade
+description: Details and timeline for the T4 network upgrade, including consensus context in the block header and bundled bug fixes.
+---
+
+# T4 Network Upgrade
+
+This page summarizes T4 scope, partner impact, and breaking changes.
+
+:::info[T4 is not live yet]
+The features described on this page are scheduled for T4 and are not active on Moderato or Presto yet. They only become live once the T4 activation timestamps are reached.
+:::
+
+## Timeline
+
+| Network | Date | Timestamp |
+|---------|------|-----------|
+| Moderato (testnet) | TBD | `TBD` |
+| Presto (mainnet) | TBD | `TBD` |
+
+Node operators must upgrade to the T4-compatible release (v1.7.0) before the Moderato activation timestamp.
+
+## Overview
+
+T4 is Tempo's next network upgrade. It introduces the following changes:
+- Embedding consensus context into the block header to unlock deferred verification and reduce finalization latency ([TIP-1031](/protocol/tips/tip-1031))
+- A bundle of T4 bug fixes and security hardening covering AccountKeychain scope handling, gas accounting, TIP-20 paused-token enforcement, and subblock metadata system transactions ([TIP-1046](/protocol/tips/tip-1046))
+
+**Action required for node operators:** Upgrade to v1.7.0 before the Moderato activation timestamp. Non-upgraded nodes will fall out of consensus.
+
+## Who is affected?
+
+- All node operators (validators and RPC nodes) must upgrade. TIP-1031 is a breaking change to block header encoding — non-upgraded nodes will have their proposals rejected and fall out of consensus at activation.
+- Tools and indexers that decode `TempoHeader` from raw RLP must handle the new trailing optional `Context` field.
+- Most other integrators do not need code changes.
+
+## Breaking changes
+
+### Block header encoding (TIP-1031)
+
+`TempoHeader` adds an `Option<Context>` field as the **last** field, following Ethereum's trailing-optional pattern (e.g. `base_fee_per_gas`, `blob_gas_used`):
+
+- **Pre-activation:** the field is `None` and is omitted from the RLP stream entirely. Existing block hashes are preserved.
+- **Post-activation:** the field MUST be set on every block beyond genesis and MUST exactly match the context provided by the consensus engine. Mismatched or missing context causes the block to be rejected.
+
+Tools that decode `TempoHeader` from raw RLP outside of Tempo SDKs must update their decoders. Tempo SDKs handle this transparently.
+
+### Subblock metadata (TIP-1046)
+
+Blocks with no subblocks may now omit the metadata system transaction. Builders that explicitly emit an empty subblocks/metadata system transaction will have their blocks rejected post-T4.
+
+## Compatible SDK releases
+
+T4-compatible SDK releases will be listed here as they ship.
+
+## Related docs
+- [Network upgrades and releases](/guide/node/network-upgrades)
+- [TIP-1031: Embed Consensus Context in the Block Header](/protocol/tips/tip-1031)
+- [TIP-1046: T4 Hardfork Meta TIP](/protocol/tips/tip-1046)
+
+## Feature TIPs
+
+### TIP-1031: Embed Consensus Context in the Block Header
+
+[TIP-1031](/protocol/tips/tip-1031) adds an optional `Context` field (epoch, view, parent view, leader) as the last field of `TempoHeader`. This commits consensus metadata to the block hash so Tempo blocks implement Commonware's `CertifiableBlock` trait, enabling deferred verification (optimistic notarization with async background verification) and reduced finalization latency. Pre-activation headers are unchanged; post-activation headers require the field and validators reject mismatched context.
+
+### TIP-1046: T4 Hardfork Meta TIP
+
+[TIP-1046](/protocol/tips/tip-1046) bundles bug fixes and security hardening gated behind T4, including a `cancel_stale_order` recipient authorization check, correct out-of-gas propagation in TIP-20 dispatch, an intrinsic gas surcharge for access-key scope persistence, paused-token enforcement on internal-balance DEX debit paths, pre-charging the static gas portion before cold loads, and pre-validating the full call-scope batch before any storage writes.

--- a/src/pages/protocol/upgrades/t4.mdx
+++ b/src/pages/protocol/upgrades/t4.mdx
@@ -5,7 +5,7 @@ description: Details and timeline for the T4 network upgrade, including consensu
 
 # T4 Network Upgrade
 
-This page summarizes T4 scope, partner impact, and breaking changes.
+This page summarizes T4 scope.
 
 :::info[T4 is not live yet]
 The features described on this page are scheduled for T4 and are not active on Moderato or Presto yet. They only become live once the T4 activation timestamps are reached.
@@ -24,30 +24,9 @@ Node operators must upgrade to the T4-compatible release (v1.7.0, targeted for M
 
 T4 is Tempo's next network upgrade. It introduces the following changes:
 - Embedding consensus context into the block header to unlock deferred verification and reduce finalization latency ([TIP-1031](/protocol/tips/tip-1031))
-- A bundle of T4 bug fixes and security hardening covering AccountKeychain scope handling, gas accounting, TIP-20 paused-token enforcement, and subblock metadata system transactions ([TIP-1046](/protocol/tips/tip-1046))
+- A bundle of T4 bug fixes and security hardening (https://tips.sh/1046)
 
 **Action required for node operators:** Upgrade to v1.7.0 before the Moderato activation timestamp. Non-upgraded nodes will fall out of consensus.
-
-## Who is affected?
-
-- All node operators (validators and RPC nodes) must upgrade. TIP-1031 is a breaking change to block header encoding — non-upgraded nodes will have their proposals rejected and fall out of consensus at activation.
-- Tools and indexers that decode `TempoHeader` from raw RLP must handle the new trailing optional `Context` field.
-- Most other integrators do not need code changes.
-
-## Breaking changes
-
-### Block header encoding (TIP-1031)
-
-`TempoHeader` adds an `Option<Context>` field as the **last** field, following Ethereum's trailing-optional pattern (e.g. `base_fee_per_gas`, `blob_gas_used`):
-
-- **Pre-activation:** the field is `None` and is omitted from the RLP stream entirely. Existing block hashes are preserved.
-- **Post-activation:** the field MUST be set on every block beyond genesis and MUST exactly match the context provided by the consensus engine. Mismatched or missing context causes the block to be rejected.
-
-Tools that decode `TempoHeader` from raw RLP outside of Tempo SDKs must update their decoders. Tempo SDKs handle this transparently.
-
-### Subblock metadata (TIP-1046)
-
-Blocks with no subblocks may now omit the metadata system transaction. Builders that explicitly emit an empty subblocks/metadata system transaction will have their blocks rejected post-T4.
 
 ## Compatible SDK releases
 
@@ -63,7 +42,3 @@ T4-compatible SDK releases will be listed here as they ship.
 ### TIP-1031: Embed Consensus Context in the Block Header
 
 [TIP-1031](/protocol/tips/tip-1031) adds an optional `Context` field (epoch, view, parent view, leader) as the last field of `TempoHeader`. This commits consensus metadata to the block hash so Tempo blocks implement Commonware's `CertifiableBlock` trait, enabling deferred verification (optimistic notarization with async background verification) and reduced finalization latency. Pre-activation headers are unchanged; post-activation headers require the field and validators reject mismatched context.
-
-### TIP-1046: T4 Hardfork Meta TIP
-
-[TIP-1046](/protocol/tips/tip-1046) bundles T4 bug fixes and security hardening. The notable changes for partners are an intrinsic gas surcharge for access-key scope persistence, pre-charging the static gas portion before cold account/storage loads, and the subblock metadata system transaction change covered above. See the TIP for the full list.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -725,11 +725,15 @@ export default defineConfig({
             collapsed: true,
             items: [
               {
-                text: 'T3',
+                text: 'T4',
+                link: '/protocol/upgrades/t4',
+              },
+              {
+                text: 'T3 (Active)',
                 link: '/protocol/upgrades/t3',
               },
               {
-                text: 'T2 (Active)',
+                text: 'T2',
                 link: '/protocol/upgrades/t2',
               },
             ],


### PR DESCRIPTION
Adds documentation for the T4 network upgrade and backfills missing release entries.

## Changes

- **New page** [`/protocol/upgrades/t4`](https://docs.tempo.xyz/protocol/upgrades/t4) covering [TIP-1031](https://docs.tempo.xyz/protocol/tips/tip-1031) (consensus context in block header) and [TIP-1046](https://docs.tempo.xyz/protocol/tips/tip-1046) (T4 hardfork meta TIP / bug fixes & hardening). Mirrors the structure of the existing T3 upgrade page.
- **T4 summary block** added to the [network upgrades page](https://docs.tempo.xyz/guide/node/network-upgrades).
- **v1.7.0 (planned)** row added to the Node Operator Updates table for the T4 release.
- **v1.6.0** row added to the Node Operator Updates table for the T3 release (was missing).
- **T3 row** updated with the actual release (v1.6.0) and confirmed activation timestamps (`1776780000` Moderato / `1777298400` Presto).
- **Sidebar** updated under Protocol → Network Upgrades to include T4 and mark T3 as Active.

## Notes

- T4 timestamps and v1.7.0 release date are TBD and will be filled in once scheduled.
- T4 scope per [T4 spec doc](https://docs.google.com/document/d/15GPTZlLXWKJUAqFeOq-0CGus-k_MjEA6KhDKAIZmYtU/edit?tab=t.0): TIP-1031 + TIP-1046 only.