### PR TITLE
docs: add peering guide for execution layer peer discovery

### DIFF
--- a/src/pages/guide/node/peering.mdx
+++ b/src/pages/guide/node/peering.mdx
@@ -1,0 +1,78 @@
+---
+description: Improve peer discovery and connection reliability for your Tempo node using the bootnodes endpoint, p2p-proxy infrastructure, and dedicated partner nodes.
+---
+
+# Peering
+
+Tempo provides infrastructure to make execution-layer peer discovery fast and reliable. This page covers how to use the dynamic bootnodes endpoint, the p2p-proxy scaling layer, and how partners can request dedicated peering nodes.
+
+## Bootnodes Endpoint
+
+Tempo publishes a curated list of high-quality peers — validators, RPC nodes, and their direct neighbors — through a dynamic HTTP endpoint:
+
+| **Network** | **Endpoint** |
+|-------------|-------------|
+| Mainnet | `https://peers.tempo.xyz` |
+| Testnet | `https://testnet-peers.tempo.xyz` |
+
+To use it, pass the `--tempo.bootnodes-endpoint` flag when starting your node:
+
+```bash
+tempo node \
+  --follow \
+  --tempo.bootnodes-endpoint https://peers.tempo.xyz \
+  --http --http.port 8545 \
+  --http.api eth,net,web3,txpool,trace
+```
+
+For testnet:
+
+```bash
+tempo node \
+  --follow \
+  --chain moderato \
+  --tempo.bootnodes-endpoint https://testnet-peers.tempo.xyz \
+  --http --http.port 8545 \
+  --http.api eth,net,web3,txpool,trace
+```
+
+The endpoint dynamically discovers validators and RPC nodes on the Tempo network, queries their immediate neighbors via `operator_peers`, and returns a synthesized list of up-to-date, high-quality peers. This means you don't need to rely on hardcoded bootnode definitions — as the network grows, the endpoint scales with it.
+
+## P2P Proxy Nodes
+
+To scale the number of available peers in the network, Tempo runs **p2p-proxy** nodes. These are lightweight, stateless nodes that attach 1:1 to existing RPC nodes and can handle a large number of peer connections for syncing. Because they are stateless, they are easy to scale horizontally.
+
+P2p-proxy nodes are included in the bootnodes endpoint automatically — no additional configuration is needed on your end.
+
+## Filtering Irrelevant Peers
+
+Tempo nodes enforce ENR fork ID filtering by default (`--enforce-enr-forkid`). This prevents your node from spending time dialing peers that aren't on the Tempo chain, improving initial sync times and connection quality.
+
+## Dedicated Partner Nodes
+
+For partners who need guaranteed peering reliability — even during periods of high network saturation — Tempo offers dedicated p2p-proxy nodes with discovery disabled, reserved exclusively for partner use.
+
+To request access to dedicated peering nodes, reach out to the Tempo team. Once provided, add the enodes to your node configuration using the `--trusted-peers` flag:
+
+```bash
+tempo node \
+  --follow \
+  --tempo.bootnodes-endpoint https://peers.tempo.xyz \
+  --trusted-peers <enode://...@host:port>,<enode://...@host:port> \
+  --http --http.port 8545 \
+  --http.api eth,net,web3,txpool,trace
+```
+
+## Verifying Peer Connections
+
+After starting your node, verify that it has connected to peers:
+
+```bash
+# Check peer count (should be non-zero)
+cast rpc net_peerCount --rpc-url http://localhost:8545
+```
+
+If your node consistently shows zero peers, ensure that:
+1. The `--tempo.bootnodes-endpoint` flag is set correctly
+2. Your firewall allows outbound TCP connections on the P2P port (default: `30303`)
+3. You are running a recent version of the Tempo node software

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -867,6 +867,10 @@ export default defineConfig({
             link: '/guide/node/rpc',
           },
           {
+            text: 'Peering',
+            link: '/guide/node/peering',
+          },
+          {
             text: 'Running a validator',
             items: [
               {


### PR DESCRIPTION
Adds a new **Peering** page under Run a Tempo Node → covering:

- Dynamic bootnodes endpoint (`--tempo.bootnodes-endpoint`) pointing to `peers.tempo.xyz` / `testnet-peers.tempo.xyz`
- P2P proxy scaling infrastructure
- ENR fork ID filtering (`--enforce-enr-forkid`)
- Dedicated partner peering nodes (via `--trusted-peers`)
- Peer connection verification

Based on the scaling execution layer peering design from [this thread](https://tempoxyz.slack.com/archives/C09KGTZ4S01/p1776336908323409?thread_ts=1776335455.753479&cid=C09KGTZ4S01).

> Note: the original Slack post included an architecture diagram image. It should be added to `public/` and referenced from the page if desired.