### PR TITLE
fix(handler.relay): update resolveTokens example to match new Token[] signature

### DIFF
--- a/src/pages/accounts/server/handler.relay.mdx
+++ b/src/pages/accounts/server/handler.relay.mdx
@@ -526,18 +526,28 @@ const handler = Handler.relay({
 
 ### resolveTokens
 
-- **Type:** `(chainId?: number) => readonly Address[]`
-- **Optional**
+- **Type:** `(chainId: number) => readonly Token[] | Promise<readonly Token[]>`
+- **Default:** Fetches `https://tokenlist.tempo.xyz/list/:chainId`
 
-Returns token addresses to check balances for during fee token resolution. The relay checks `balanceOf` for each token and picks the one with the highest balance.
+Resolves the list of tokens to check balances for during fee token resolution. The relay checks `balanceOf` for each token and picks the one with the highest balance.
 
 ```ts twoslash
 import { Handler } from 'accounts/server'
 
 const handler = Handler.relay({
   resolveTokens: (chainId) => [ // [!code focus]
-    '0x20c0000000000000000000000000000000000000', // pathUSD // [!code focus]
-    '0x20c000000000000000000000b9537d11c60e8b50', // USDC.e // [!code focus]
+    { // [!code focus]
+      address: '0x20c0000000000000000000000000000000000000', // [!code focus]
+      decimals: 6, // [!code focus]
+      name: 'pathUSD', // [!code focus]
+      symbol: 'pathUSD', // [!code focus]
+    }, // [!code focus]
+    { // [!code focus]
+      address: '0x20c000000000000000000000b9537d11c60e8b50', // [!code focus]
+      decimals: 6, // [!code focus]
+      name: 'USDC.e', // [!code focus]
+      symbol: 'USDC.e', // [!code focus]
+    }, // [!code focus]
   ], // [!code focus]
 })
 ```


### PR DESCRIPTION
Fixes the failing main build at https://github.com/tempoxyz/docs/actions/runs/25368647374/job/74386033538.

`Handler.relay`'s `resolveTokens` now expects `readonly Token[]` (with `address`, `decimals`, `name`, `symbol`) instead of `readonly Address[]`. Updates the type/default in [handler.relay.mdx](https://github.com/tempoxyz/docs/blob/fix-handler-relay-resolveTokens/src/pages/accounts/server/handler.relay.mdx) and the twoslash code sample to compile against the current accounts version.