### PR TITLE
docs: clarify that apps run their own fee payer service in production

### DIFF
--- a/src/pages/guide/payments/sponsor-user-fees.mdx
+++ b/src/pages/guide/payments/sponsor-user-fees.mdx
@@ -28,11 +28,11 @@ Enable gasless transactions by sponsoring transaction fees for your users. Tempo
 
 ### Set up the fee payer service
 
-:::tip
-Tempo provides a public testnet fee payer service at `https://sponsor.moderato.tempo.xyz` that you can use for development and testing. If you want to run your own, follow the instructions below.
-:::
+For production use, applications run their own fee payer service. You can stand up a minimal one using the [`Handler.relay`](/accounts/server/handler.relay) handler provided by the [Tempo Accounts SDK](/accounts). To sponsor transactions, you need a funded account that will act as the fee payer.
 
-You can stand up a minimal fee payer service using the [`Handler.relay`](/accounts/server/handler.relay) handler provided by the [Tempo Accounts SDK](/accounts). To sponsor transactions, you need a funded account that will act as the fee payer.
+:::tip
+For development and testing, Tempo provides a public testnet fee payer service at `https://sponsor.moderato.tempo.xyz`.
+:::
 
 ```ts twoslash [server.ts]
 // @noErrors

--- a/src/snippets/public-testnet-sponsor-tip.mdx
+++ b/src/snippets/public-testnet-sponsor-tip.mdx
@@ -1,3 +1,3 @@
 :::tip
-Tempo provides a public testnet fee payer service at `https://sponsor.moderato.tempo.xyz` that you can use for development and testing. If you want to run your own, follow the instructions below.
+For development and testing, Tempo provides a public testnet fee payer service at `https://sponsor.moderato.tempo.xyz`. For production, run your own fee payer service.
 :::


### PR DESCRIPTION
Clarifies the fee payer docs to lead with the production expectation (run your own service) and positions the testnet endpoint as a dev/testing convenience.

Two files changed:
- `src/pages/guide/payments/sponsor-user-fees.mdx` — reorders the section so the production guidance comes first
- `src/snippets/public-testnet-sponsor-tip.mdx` — updates the shared tip snippet used across docs

cc @U0AANH5QHEF for review