### PR TITLE
fix: scale mermaid diagrams to fit container width

### DIFF
--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -950,7 +950,9 @@ export function MermaidDiagram({ chart }: { chart: string }) {
       el.innerHTML = render(lo, th)
       const svg = el.querySelector('svg')
       if (!svg) return
-      svg.style.maxWidth = '100%'
+      svg.removeAttribute('width')
+      svg.removeAttribute('height')
+      svg.style.width = '100%'
       svg.style.height = 'auto'
       svg.style.display = 'block'
       svg.style.margin = '0 auto'

--- a/src/components/StaticMermaidDiagram.tsx
+++ b/src/components/StaticMermaidDiagram.tsx
@@ -79,7 +79,9 @@ export function StaticMermaidDiagram({ chart }: { chart: string }) {
         el.innerHTML = svg
         const svgEl = el.querySelector('svg')
         if (svgEl) {
-          svgEl.style.maxWidth = '100%'
+          svgEl.removeAttribute('width')
+          svgEl.removeAttribute('height')
+          svgEl.style.width = '100%'
           svgEl.style.height = 'auto'
           svgEl.style.display = 'block'
           svgEl.style.margin = '0 auto'


### PR DESCRIPTION
## Summary

- Mermaid renders SVGs with explicit `width`/`height` HTML attributes that override CSS `max-width`, causing diagrams to render at full native size (huge and illegible)
- Fix: remove those attributes after render and set `width: 100%` via style so the SVG scales to its container
- Applies to both `StaticMermaidDiagram` and `MermaidDiagram` components

## Affected pages

- `guide/node/validator-status` (state diagram — the reported issue)
- `protocol/zones/architecture` (2 flowcharts)
- `protocol/zones/proving` (flowchart)
- `accounts/` (sequence diagram)
- `guide/machine-payments/*` and `payments/virtual-addresses` (sequence diagrams via `MermaidDiagram`)

## Test plan

- [ ] Check `guide/node/validator-status` — state diagram should be compact, not full-screen tall
- [ ] Spot-check one or two other diagram pages above

🤖 Generated with [Claude Code](https://claude.com/claude-code)