### PR TITLE
docs: remove snapshots.tempoxyz.dev link

### DIFF
--- a/src/pages/cli/download.mdx
+++ b/src/pages/cli/download.mdx
@@ -22,27 +22,19 @@ tempo download [flags]
 | `-u, --url <url>` | Download a specific snapshot URL |
 | `--list` | List available snapshots |
 | `--resumable` | Resume an interrupted download |
-| `--minimal` | Download minimal snapshot (pruned state, suitable for validators) |
-| `--archive` | Download full archive snapshot (suitable for RPC nodes) |
 
 ## Examples
 
-Download the latest archive snapshot (for RPC nodes):
+Download a snapshot:
 
 ```bash
-tempo download --archive
+tempo download --chain mainnet
 ```
 
-Download the latest minimal snapshot (for validators):
+Download a snapshot for testnet:
 
 ```bash
-tempo download --minimal
-```
-
-Download a snapshot for a specific chain:
-
-```bash
-tempo download --archive --chain moderato
+tempo download --chain moderato
 ```
 
 List available snapshots:
@@ -51,16 +43,10 @@ List available snapshots:
 tempo download --list
 ```
 
-List available snapshots for a specific chain:
-
-```bash
-tempo download --list --chain moderato
-```
-
 Resume an interrupted download:
 
 ```bash
-tempo download --archive --resumable
+tempo download --chain mainnet --resumable
 ```
 
 Then start your node with [`tempo node`](/cli/node).

--- a/src/pages/cli/download.mdx
+++ b/src/pages/cli/download.mdx
@@ -22,19 +22,27 @@ tempo download [flags]
 | `-u, --url <url>` | Download a specific snapshot URL |
 | `--list` | List available snapshots |
 | `--resumable` | Resume an interrupted download |
+| `--minimal` | Download minimal snapshot (pruned state, suitable for validators) |
+| `--archive` | Download full archive snapshot (suitable for RPC nodes) |
 
 ## Examples
 
-Download a snapshot:
+Download the latest archive snapshot (for RPC nodes):
 
 ```bash
-tempo download --chain mainnet
+tempo download --archive
 ```
 
-Download a snapshot for testnet:
+Download the latest minimal snapshot (for validators):
 
 ```bash
-tempo download --chain moderato
+tempo download --minimal
+```
+
+Download a snapshot for a specific chain:
+
+```bash
+tempo download --archive --chain moderato
 ```
 
 List available snapshots:
@@ -43,10 +51,16 @@ List available snapshots:
 tempo download --list
 ```
 
+List available snapshots for a specific chain:
+
+```bash
+tempo download --list --chain moderato
+```
+
 Resume an interrupted download:
 
 ```bash
-tempo download --chain mainnet --resumable
+tempo download --archive --resumable
 ```
 
 Then start your node with [`tempo node`](/cli/node).

--- a/src/pages/cli/download.mdx
+++ b/src/pages/cli/download.mdx
@@ -22,7 +22,6 @@ tempo download [flags]
 | `-u, --url <url>` | Download a specific snapshot URL |
 | `--list` | List available snapshots |
 | `--resumable` | Resume an interrupted download |
-| `--minimal` | Download minimal snapshot (pruned state, suitable for validators) |
 | `--archive` | Download full archive snapshot (suitable for RPC nodes) |
 
 ## Examples
@@ -31,12 +30,6 @@ Download the latest archive snapshot (for RPC nodes):
 
 ```bash
 tempo download --archive
-```
-
-Download the latest minimal snapshot (for validators):
-
-```bash
-tempo download --minimal
 ```
 
 Download a snapshot for a specific chain:

--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -48,19 +48,9 @@ docker logs tempo
 
 Downloading a snapshot lets your node skip syncing from genesis and start participating much faster. This is recommended for both RPC nodes and validators.
 
-::::code-group
-```bash [Minimal (validators)]
-tempo download --chain mainnet --minimal
+```bash
+tempo download --chain <moderato|mainnet>
 ```
-```bash [Full (RPC / dApp backends)]
-tempo download --chain mainnet
-```
-```bash [Archive (indexers / RPC providers)]
-tempo download --chain mainnet --archive
-```
-::::
-
-For testnet, replace `mainnet` with `moderato`.
 
 ## Verifying Releases
 

--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -48,9 +48,19 @@ docker logs tempo
 
 Downloading a snapshot lets your node skip syncing from genesis and start participating much faster. This is recommended for both RPC nodes and validators.
 
-```bash
-tempo download --chain <moderato|mainnet>
+::::code-group
+```bash [Minimal (validators)]
+tempo download --chain mainnet --minimal
 ```
+```bash [Full (RPC / dApp backends)]
+tempo download --chain mainnet
+```
+```bash [Archive (indexers / RPC providers)]
+tempo download --chain mainnet --archive
+```
+::::
+
+For testnet, replace `mainnet` with `moderato`.
 
 ## Verifying Releases
 

--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -49,9 +49,6 @@ docker logs tempo
 Downloading a snapshot lets your node skip syncing from genesis and start participating much faster. This is recommended for both RPC nodes and validators.
 
 ::::code-group
-```bash [Minimal (validators)]
-tempo download --chain mainnet --minimal
-```
 ```bash [Full (RPC / dApp backends)]
 tempo download --chain mainnet
 ```

--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -60,7 +60,7 @@ tempo download --chain mainnet --archive
 ```
 ::::
 
-For testnet, replace `mainnet` with `moderato`. See [snapshots.tempoxyz.dev](https://snapshots.tempoxyz.dev/) for detailed component sizes and download options.
+For testnet, replace `mainnet` with `moderato`.
 
 ## Verifying Releases
 

--- a/src/pages/guide/node/rpc.mdx
+++ b/src/pages/guide/node/rpc.mdx
@@ -12,7 +12,7 @@ RPC nodes provide API access to the Tempo network without participating in conse
 
 ```bash /dev/null/quickstart.sh#L1-15
 # Download snapshot (this will help you sync much faster)
-tempo download --chain mainnet
+tempo download --archive
 
 # Run node
 tempo node \

--- a/src/pages/guide/node/rpc.mdx
+++ b/src/pages/guide/node/rpc.mdx
@@ -12,7 +12,7 @@ RPC nodes provide API access to the Tempo network without participating in conse
 
 ```bash /dev/null/quickstart.sh#L1-15
 # Download snapshot (this will help you sync much faster)
-tempo download --archive
+tempo download --chain mainnet
 
 # Run node
 tempo node \


### PR DESCRIPTION
Removes the link to snapshots.tempoxyz.dev from the node installation guide, as the snapshot website is being deprecated.