### PR TITLE
docs: recommend archive snapshot downloads

### DIFF
--- a/src/pages/cli/download.mdx
+++ b/src/pages/cli/download.mdx
@@ -22,27 +22,20 @@ tempo download [flags]
 | `-u, --url <url>` | Download a specific snapshot URL |
 | `--list` | List available snapshots |
 | `--resumable` | Resume an interrupted download |
-| `--minimal` | Download minimal snapshot (pruned state, suitable for validators) |
-| `--archive` | Download full archive snapshot (suitable for RPC nodes) |
+| `--archive` | Download an archive snapshot. Recommended for partner validators and RPC nodes. |
 
 ## Examples
 
-Download the latest archive snapshot (for RPC nodes):
+Download the latest recommended mainnet snapshot:
 
 ```bash
-tempo download --archive
+tempo download --chain mainnet --archive
 ```
 
-Download the latest minimal snapshot (for validators):
+Download the latest recommended testnet snapshot:
 
 ```bash
-tempo download --minimal
-```
-
-Download a snapshot for a specific chain:
-
-```bash
-tempo download --archive --chain moderato
+tempo download --chain moderato --archive
 ```
 
 List available snapshots:
@@ -60,7 +53,7 @@ tempo download --list --chain moderato
 Resume an interrupted download:
 
 ```bash
-tempo download --archive --resumable
+tempo download --chain mainnet --archive --resumable
 ```
 
 Then start your node with [`tempo node`](/cli/node).

--- a/src/pages/cli/download.mdx
+++ b/src/pages/cli/download.mdx
@@ -53,7 +53,7 @@ tempo download --list --chain moderato
 Resume an interrupted download:
 
 ```bash
-tempo download --chain mainnet --archive --resumable
+tempo download --archive --resumable
 ```
 
 Then start your node with [`tempo node`](/cli/node).

--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -46,21 +46,16 @@ docker logs tempo
 
 ## Snapshots
 
-Downloading a snapshot lets your node skip syncing from genesis and start participating much faster. This is recommended for both RPC nodes and validators.
+Downloading a snapshot lets your node skip syncing from genesis and start participating much faster. Use the archive snapshot command for both RPC nodes and validators unless the Tempo team directs you to use a specific snapshot profile.
 
 ::::code-group
-```bash [Minimal (validators)]
-tempo download --chain mainnet --minimal
-```
-```bash [Full (RPC / dApp backends)]
-tempo download --chain mainnet
-```
-```bash [Archive (indexers / RPC providers)]
+```bash [Mainnet]
 tempo download --chain mainnet --archive
 ```
+```bash [Testnet]
+tempo download --chain moderato --archive
+```
 ::::
-
-For testnet, replace `mainnet` with `moderato`. See [snapshots.tempoxyz.dev](https://snapshots.tempoxyz.dev/) for detailed component sizes and download options.
 
 ## Verifying Releases
 

--- a/src/pages/guide/node/installation.mdx
+++ b/src/pages/guide/node/installation.mdx
@@ -46,7 +46,7 @@ docker logs tempo
 
 ## Snapshots
 
-Downloading a snapshot lets your node skip syncing from genesis and start participating much faster. Use the archive snapshot command for both RPC nodes and validators unless the Tempo team directs you to use a specific snapshot profile.
+Downloading a snapshot lets your node skip syncing from genesis and start participating much faster. This is recommended for both RPC nodes and validators.
 
 ::::code-group
 ```bash [Mainnet]

--- a/src/pages/guide/node/rpc.mdx
+++ b/src/pages/guide/node/rpc.mdx
@@ -12,7 +12,7 @@ RPC nodes provide API access to the Tempo network without participating in conse
 
 ```bash /dev/null/quickstart.sh#L1-15
 # Download snapshot (this will help you sync much faster)
-tempo download --archive
+tempo download --chain mainnet --archive
 
 # Run node
 tempo node \

--- a/src/pages/guide/node/rpc.mdx
+++ b/src/pages/guide/node/rpc.mdx
@@ -12,7 +12,7 @@ RPC nodes provide API access to the Tempo network without participating in conse
 
 ```bash /dev/null/quickstart.sh#L1-15
 # Download snapshot (this will help you sync much faster)
-tempo download --chain mainnet --archive
+tempo download --archive
 
 # Run node
 tempo node \

--- a/src/pages/guide/node/validator-setup.mdx
+++ b/src/pages/guide/node/validator-setup.mdx
@@ -83,16 +83,16 @@ Once the Tempo team adds your validator on-chain, it will enter the active set i
 
 ## Running the validator
 
-The process for running a validator node is very similar to [running a full node](/guide/node/rpc). 
+The process for running a validator node is very similar to [running a full node](/guide/node/rpc).
 
 You should start by downloading the latest snapshot. Downloading the snapshot allows your validator to start participating in consensus much faster.
 
 ::::code-group
 ```bash [Mainnet]
-tempo download --chain mainnet
+tempo download --chain mainnet --archive
 ```
 ```bash [Testnet]
-tempo download --chain moderato
+tempo download --chain moderato --archive
 ```
 ::::
 


### PR DESCRIPTION
Updates node download docs to recommend explicit archive snapshots for mainnet and moderato.

Removes public minimal snapshot guidance and the snapshots viewer link from the installation page while the smaller snapshot profiles are not partner-ready.

Validation:
- pnpm run build