### PR TITLE
docs: add Querying Tempo page

### DIFF
--- a/src/pages/quickstart/querying-tempo.mdx
+++ b/src/pages/quickstart/querying-tempo.mdx
@@ -4,13 +4,11 @@ description: Write correct analytics queries for Tempo. Covers fee units, TIP-20
 showOutline: 1
 ---
 
-import { IndexSupplyQuery } from '../../components/IndexSupplyQuery'
-
 # Querying Tempo
 
 Tempo is EVM-compatible, so most query patterns you already know work here. There are a handful of differences that will silently produce wrong numbers if you carry over Ethereum assumptions.
 
-The interactive examples run live against [Index Supply](https://www.indexsupply.net) on Tempo mainnet — edit the SQL and hit **Run Query**. Static examples use generic SQL — table and column names will vary by platform.
+Examples use generic SQL — table and column names will vary by platform.
 
 ## 1. Fees are in USD, not ETH
 
@@ -34,16 +32,14 @@ Divide token amounts by `1e6`. Using `1e18` gives a result 10¹² times too smal
 
 `tx.value` is always zero on Tempo. All token movement is in `Transfer` events.
 
-<IndexSupplyQuery
-  chainId={4217}
-  title={'Recent pathUSD transfers'}
-  signatures={["Transfer"]}
-  query={`SELECT block_num, "from", "to", amount
-  FROM transfer
-  WHERE address = '0x20c0000000000000000000000000000000000000'
-  ORDER BY block_num DESC
-  LIMIT 10`}
-/>
+```sql
+SELECT date_trunc('day', block_time) AS day,
+       token_address,
+       SUM(amount) / 1e6 AS volume_usd
+FROM tip20_transfers
+GROUP BY 1, 2
+ORDER BY 1;
+```
 
 `TransferWithMemo` (used by MPP) also emits a standard `Transfer`. Query only `Transfer` to avoid double-counting.
 
@@ -65,25 +61,22 @@ ORDER BY 2 DESC;
 
 ## 6. Compute supply from Transfer events, not Mint events
 
-Genesis mints may not emit `Mint`. Derive supply from `Transfer`: mints have `from = 0x0…0`, burns have `to = 0x0…0`. Divide by `1e6` for whole tokens.
+Genesis mints may not emit `Mint`. Derive supply from `Transfer`: mints have `from = 0x0…0`, burns have `to = 0x0…0`.
 
-<IndexSupplyQuery
-  chainId={4217}
-  title={'pathUSD supply from Transfer events'}
-  signatures={["Transfer"]}
-  query={`SELECT
-    SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
-             THEN amount ELSE 0 END) AS total_minted,
-    SUM(CASE WHEN "to" = '0x0000000000000000000000000000000000000000'
-             THEN amount ELSE 0 END) AS total_burned,
-    SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
-             THEN amount
-             WHEN "to" = '0x0000000000000000000000000000000000000000'
-             THEN -amount
-             ELSE 0 END) AS supply
-  FROM transfer
-  WHERE address = '0x20c0000000000000000000000000000000000000'`}
-/>
+```sql
+SELECT
+  SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
+           THEN amount / 1e6 ELSE 0 END) AS total_minted,
+  SUM(CASE WHEN "to"   = '0x0000000000000000000000000000000000000000'
+           THEN amount / 1e6 ELSE 0 END) AS total_burned,
+  SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
+           THEN  amount / 1e6
+           WHEN "to"   = '0x0000000000000000000000000000000000000000'
+           THEN -amount / 1e6
+           ELSE 0 END) AS supply
+FROM tip20_transfers
+WHERE token_address = <token>;
+```
 
 ## Key addresses
 

--- a/src/pages/quickstart/querying-tempo.mdx
+++ b/src/pages/quickstart/querying-tempo.mdx
@@ -8,19 +8,15 @@ import { IndexSupplyQuery } from '../../components/IndexSupplyQuery'
 
 # Querying Tempo
 
-Tempo is EVM-compatible, so most query patterns you already know work here. There are a handful of differences that will silently produce wrong numbers if you carry over Ethereum assumptions. This page covers them.
+Tempo is EVM-compatible, so most query patterns you already know work here. There are a handful of differences that will silently produce wrong numbers if you carry over Ethereum assumptions.
 
-The interactive examples below run against [Index Supply](https://www.indexsupply.net) on Tempo mainnet — edit the SQL and hit **Run Query** to try variations. The static examples use generic SQL — column and table names will vary by platform.
+The interactive examples run live against [Index Supply](https://www.indexsupply.net) on Tempo mainnet — edit the SQL and hit **Run Query**. Static examples use generic SQL — table and column names will vary by platform.
 
 ## 1. Fees are in USD, not ETH
 
-On Ethereum, gas price is in wei (10⁻¹⁸ ETH). On Tempo, gas price is in **attodollars** (10⁻¹⁸ USD). The result of the fee calculation is USD. There is no native token.
+On Ethereum, gas price is in wei (10⁻¹⁸ ETH). On Tempo, it's in **attodollars** (10⁻¹⁸ USD). The fee calculation result is USD. There is no native token.
 
-The correct formula rounds to the nearest microdollar, which is how fees are actually settled:
-
-```sql
-CEIL(effective_gas_price * gas_used / 1e12) / 1e6
-```
+Round to the nearest microdollar (how fees actually settle):
 
 ```sql
 SELECT date_trunc('day', block_time) AS day,
@@ -36,69 +32,51 @@ Divide token amounts by `1e6`. Using `1e18` gives a result 10¹² times too smal
 
 ## 3. Use Transfer events for volume, not tx.value
 
-`tx.value` is always zero on Tempo. All token movement is captured in `Transfer` events.
-
-The query below sums `Transfer` event amounts for `pathUSD` (the network's reference stablecoin). Adjust the `address` filter or grouping to inspect any TIP-20 token.
+`tx.value` is always zero on Tempo. All token movement is in `Transfer` events.
 
 <IndexSupplyQuery
   chainId={4217}
-  title={'Recent pathUSD Transfer Volume'}
+  title={'Recent pathUSD transfers'}
   signatures={["Transfer"]}
-  query={`SELECT
-    block_num,
-    "from",
-    "to",
-    value
+  query={`SELECT block_num, "from", "to", value
   FROM transfer
   WHERE address = '0x20c0000000000000000000000000000000000000'
   ORDER BY block_num DESC
   LIMIT 10`}
 />
 
-`TransferWithMemo` (used by MPP and others) also emits a standard `Transfer` event. If your platform exposes both, query only `Transfer` — including both double-counts every memo transfer.
+`TransferWithMemo` (used by MPP) also emits a standard `Transfer`. Query only `Transfer` to avoid double-counting.
 
 ## 4. Use COALESCE(fee_payer, from) for attribution
 
-Sponsored transactions populate a separate `fee_payer` field. If you group by `from` to measure who paid fees or sent transactions, sponsored activity gets attributed to the wrong address.
+Sponsored transactions populate a separate `fee_payer` field. Grouping by `from` attributes sponsored activity to the wrong address.
 
 ```sql
 SELECT COALESCE(fee_payer, "from") AS payer,
-       COUNT(*) AS tx_count,
-       SUM(CEIL(effective_gas_price * gas_used / 1e12) / 1e6) AS usd_paid
+       COUNT(*) AS tx_count
 FROM transactions
 GROUP BY 1
-ORDER BY 3 DESC;
+ORDER BY 2 DESC;
 ```
 
-## 5. Exclude system transactions when measuring user activity
+## 5. Exclude system transactions from user metrics
 
-Transactions where `from = 0x0000000000000000000000000000000000000000` are system-level. Include them in raw chain metrics but exclude them when computing things like active addresses, unique senders, or user-initiated volume.
+`from = 0x0000…0000` is system-level. Include in raw chain metrics, exclude when measuring users.
 
-## 6. Compute token supply from Transfer events, not Mint events
+## 6. Compute supply from Transfer events, not Mint events
 
-Genesis mints on Tempo may not emit a `Mint` event. To get accurate supply, derive it from `Transfer` events: mints have `from = 0x0000…0000`, burns have `to = 0x0000…0000`.
+Genesis mints may not emit `Mint`. Derive supply from `Transfer`: mints have `from = 0x0…0`, burns have `to = 0x0…0`. Divide by `1e6` for whole tokens.
 
-The query below derives `pathUSD` total minted, total burned, and live supply directly from `Transfer` events.
-
-<IndexSupplyQuery
-  chainId={4217}
-  title={'pathUSD Supply from Transfer Events'}
-  signatures={["Transfer"]}
-  query={`SELECT
-    SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
-             THEN value ELSE 0 END) AS total_minted,
-    SUM(CASE WHEN "to" = '0x0000000000000000000000000000000000000000'
-             THEN value ELSE 0 END) AS total_burned,
-    SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
-             THEN value
-             WHEN "to" = '0x0000000000000000000000000000000000000000'
-             THEN -value
-             ELSE 0 END) AS supply
-  FROM transfer
-  WHERE address = '0x20c0000000000000000000000000000000000000'`}
-/>
-
-Divide each value by `1e6` to convert raw amounts to whole tokens.
+```sql
+SELECT
+  SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
+           THEN value
+           WHEN "to"   = '0x0000000000000000000000000000000000000000'
+           THEN -value
+           ELSE 0 END) AS supply
+FROM transfer
+WHERE address = '0x20c0000000000000000000000000000000000000';
+```
 
 ## Key addresses
 
@@ -107,24 +85,13 @@ Divide each value by `1e6` to convert raw amounts to whole tokens.
 | FeeManager | `0xfeec000000000000000000000000000000000000` |
 | Stablecoin DEX | `0xdec0000000000000000000000000000000000000` |
 | TIP-20 Factory | `0x20fc000000000000000000000000000000000000` |
-| PathUSD | `0x20c0000000000000000000000000000000000000` |
+| pathUSD | `0x20c0000000000000000000000000000000000000` |
 
 ## Networks
 
-### Mainnet
-
-| | |
-| --- | --- |
-| Chain ID | `4217` |
-| RPC | `https://rpc.tempo.xyz` |
-| Explorer | `https://explore.tempo.xyz` |
-| Tokenlist | `https://tokenlist.tempo.xyz/list/4217` |
-
-### Testnet (Moderato)
-
-| | |
-| --- | --- |
-| Chain ID | `42431` |
-| RPC | `https://rpc.moderato.tempo.xyz` |
-| Explorer | `https://explore.testnet.tempo.xyz` |
-| Tokenlist | `https://tokenlist.tempo.xyz/list/42431` |
+| | Mainnet | Testnet (Moderato) |
+| --- | --- | --- |
+| Chain ID | `4217` | `42431` |
+| RPC | `https://rpc.tempo.xyz` | `https://rpc.moderato.tempo.xyz` |
+| Explorer | `https://explore.tempo.xyz` | `https://explore.testnet.tempo.xyz` |
+| Tokenlist | `https://tokenlist.tempo.xyz/list/4217` | `https://tokenlist.tempo.xyz/list/42431` |

--- a/src/pages/quickstart/querying-tempo.mdx
+++ b/src/pages/quickstart/querying-tempo.mdx
@@ -1,0 +1,113 @@
+---
+title: Querying Tempo
+description: Write correct analytics queries for Tempo. Covers fee units, TIP-20 decimals, Transfer events, fee_payer attribution, system transactions, and supply.
+showOutline: 1
+---
+
+# Querying Tempo
+
+Tempo is EVM-compatible, so most query patterns you already know work here. There are a handful of differences that will silently produce wrong numbers if you carry over Ethereum assumptions. This page covers them.
+
+The examples use generic SQL — column and table names will vary by platform.
+
+## 1. Fees are in USD, not ETH
+
+On Ethereum, gas price is in wei (10⁻¹⁸ ETH). On Tempo, gas price is in **attodollars** (10⁻¹⁸ USD). The result of the fee calculation is USD. There is no native token.
+
+The correct formula rounds to the nearest microdollar, which is how fees are actually settled:
+
+```sql
+CEIL(effective_gas_price * gas_used / 1e12) / 1e6
+```
+
+```sql
+SELECT date_trunc('day', block_time) AS day,
+       SUM(CEIL(effective_gas_price * gas_used / 1e12) / 1e6) AS usd_fees
+FROM transactions
+GROUP BY 1
+ORDER BY 1;
+```
+
+## 2. TIP-20 tokens use 6 decimals, not 18
+
+Divide token amounts by `1e6`. Using `1e18` gives a result 10¹² times too small.
+
+## 3. Use Transfer events for volume, not tx.value
+
+`tx.value` is always zero on Tempo. All token movement is captured in `Transfer` events.
+
+```sql
+SELECT date_trunc('day', block_time) AS day,
+       token_address,
+       SUM(amount) / 1e6 AS volume_usd
+FROM tip20_transfers
+GROUP BY 1, 2
+ORDER BY 1;
+```
+
+`TransferWithMemo` (used by MPP and others) also emits a standard `Transfer` event. If your platform exposes both, query only `Transfer` — including both double-counts every memo transfer.
+
+## 4. Use COALESCE(fee_payer, from) for attribution
+
+Sponsored transactions populate a separate `fee_payer` field. If you group by `from` to measure who paid fees or sent transactions, sponsored activity gets attributed to the wrong address.
+
+```sql
+SELECT COALESCE(fee_payer, "from") AS payer,
+       COUNT(*) AS tx_count,
+       SUM(CEIL(effective_gas_price * gas_used / 1e12) / 1e6) AS usd_paid
+FROM transactions
+GROUP BY 1
+ORDER BY 3 DESC;
+```
+
+## 5. Exclude system transactions when measuring user activity
+
+Transactions where `from = 0x0000000000000000000000000000000000000000` are system-level. Include them in raw chain metrics but exclude them when computing things like active addresses, unique senders, or user-initiated volume.
+
+## 6. Compute token supply from Transfer events, not Mint events
+
+Genesis mints on Tempo may not emit a `Mint` event. To get accurate supply, derive it from `Transfer` events: mints have `from = 0x0000…0000`, burns have `to = 0x0000…0000`.
+
+```sql
+SELECT
+  SUM(CASE WHEN "from" = 0x0000000000000000000000000000000000000000
+           THEN amount / 1e6 ELSE 0 END) AS total_minted,
+  SUM(CASE WHEN "to"   = 0x0000000000000000000000000000000000000000
+           THEN amount / 1e6 ELSE 0 END) AS total_burned,
+  SUM(CASE WHEN "from" = 0x0000000000000000000000000000000000000000
+           THEN  amount / 1e6
+           WHEN "to"   = 0x0000000000000000000000000000000000000000
+           THEN -amount / 1e6
+           ELSE 0 END) AS supply
+FROM tip20_transfers
+WHERE token_address = <token>;
+```
+
+## Key addresses
+
+| Contract | Address |
+| --- | --- |
+| FeeManager | `0xfeec000000000000000000000000000000000000` |
+| Stablecoin DEX | `0xdec0000000000000000000000000000000000000` |
+| TIP-20 Factory | `0x20fc000000000000000000000000000000000000` |
+| PathUSD | `0x20c0000000000000000000000000000000000000` |
+
+## Networks
+
+### Mainnet
+
+| | |
+| --- | --- |
+| Chain ID | `4217` |
+| RPC | `https://rpc.tempo.xyz` |
+| Explorer | `https://explore.tempo.xyz` |
+| Tokenlist | `https://tokenlist.tempo.xyz/list/4217` |
+
+### Testnet (Moderato)
+
+| | |
+| --- | --- |
+| Chain ID | `42431` |
+| RPC | `https://rpc.moderato.tempo.xyz` |
+| Explorer | `https://explore.testnet.tempo.xyz` |
+| Tokenlist | `https://tokenlist.tempo.xyz/list/42431` |

--- a/src/pages/quickstart/querying-tempo.mdx
+++ b/src/pages/quickstart/querying-tempo.mdx
@@ -4,11 +4,13 @@ description: Write correct analytics queries for Tempo. Covers fee units, TIP-20
 showOutline: 1
 ---
 
+import { IndexSupplyQuery } from '../../components/IndexSupplyQuery'
+
 # Querying Tempo
 
 Tempo is EVM-compatible, so most query patterns you already know work here. There are a handful of differences that will silently produce wrong numbers if you carry over Ethereum assumptions. This page covers them.
 
-The examples use generic SQL — column and table names will vary by platform.
+The interactive examples below run against [Index Supply](https://www.indexsupply.net) on Tempo mainnet — edit the SQL and hit **Run Query** to try variations. The static examples use generic SQL — column and table names will vary by platform.
 
 ## 1. Fees are in USD, not ETH
 
@@ -36,14 +38,22 @@ Divide token amounts by `1e6`. Using `1e18` gives a result 10¹² times too smal
 
 `tx.value` is always zero on Tempo. All token movement is captured in `Transfer` events.
 
-```sql
-SELECT date_trunc('day', block_time) AS day,
-       token_address,
-       SUM(amount) / 1e6 AS volume_usd
-FROM tip20_transfers
-GROUP BY 1, 2
-ORDER BY 1;
-```
+The query below sums `Transfer` event amounts for `pathUSD` (the network's reference stablecoin). Adjust the `address` filter or grouping to inspect any TIP-20 token.
+
+<IndexSupplyQuery
+  chainId={4217}
+  title={'Recent pathUSD Transfer Volume'}
+  signatures={["Transfer"]}
+  query={`SELECT
+    block_num,
+    "from",
+    "to",
+    value
+  FROM transfer
+  WHERE address = '0x20c0000000000000000000000000000000000000'
+  ORDER BY block_num DESC
+  LIMIT 10`}
+/>
 
 `TransferWithMemo` (used by MPP and others) also emits a standard `Transfer` event. If your platform exposes both, query only `Transfer` — including both double-counts every memo transfer.
 
@@ -68,20 +78,27 @@ Transactions where `from = 0x0000000000000000000000000000000000000000` are syste
 
 Genesis mints on Tempo may not emit a `Mint` event. To get accurate supply, derive it from `Transfer` events: mints have `from = 0x0000…0000`, burns have `to = 0x0000…0000`.
 
-```sql
-SELECT
-  SUM(CASE WHEN "from" = 0x0000000000000000000000000000000000000000
-           THEN amount / 1e6 ELSE 0 END) AS total_minted,
-  SUM(CASE WHEN "to"   = 0x0000000000000000000000000000000000000000
-           THEN amount / 1e6 ELSE 0 END) AS total_burned,
-  SUM(CASE WHEN "from" = 0x0000000000000000000000000000000000000000
-           THEN  amount / 1e6
-           WHEN "to"   = 0x0000000000000000000000000000000000000000
-           THEN -amount / 1e6
-           ELSE 0 END) AS supply
-FROM tip20_transfers
-WHERE token_address = <token>;
-```
+The query below derives `pathUSD` total minted, total burned, and live supply directly from `Transfer` events.
+
+<IndexSupplyQuery
+  chainId={4217}
+  title={'pathUSD Supply from Transfer Events'}
+  signatures={["Transfer"]}
+  query={`SELECT
+    SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
+             THEN value ELSE 0 END) AS total_minted,
+    SUM(CASE WHEN "to" = '0x0000000000000000000000000000000000000000'
+             THEN value ELSE 0 END) AS total_burned,
+    SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
+             THEN value
+             WHEN "to" = '0x0000000000000000000000000000000000000000'
+             THEN -value
+             ELSE 0 END) AS supply
+  FROM transfer
+  WHERE address = '0x20c0000000000000000000000000000000000000'`}
+/>
+
+Divide each value by `1e6` to convert raw amounts to whole tokens.
 
 ## Key addresses
 

--- a/src/pages/quickstart/querying-tempo.mdx
+++ b/src/pages/quickstart/querying-tempo.mdx
@@ -38,7 +38,7 @@ Divide token amounts by `1e6`. Using `1e18` gives a result 10¹² times too smal
   chainId={4217}
   title={'Recent pathUSD transfers'}
   signatures={["Transfer"]}
-  query={`SELECT block_num, "from", "to", value
+  query={`SELECT block_num, "from", "to", amount
   FROM transfer
   WHERE address = '0x20c0000000000000000000000000000000000000'
   ORDER BY block_num DESC
@@ -67,16 +67,23 @@ ORDER BY 2 DESC;
 
 Genesis mints may not emit `Mint`. Derive supply from `Transfer`: mints have `from = 0x0…0`, burns have `to = 0x0…0`. Divide by `1e6` for whole tokens.
 
-```sql
-SELECT
-  SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
-           THEN value
-           WHEN "to"   = '0x0000000000000000000000000000000000000000'
-           THEN -value
-           ELSE 0 END) AS supply
-FROM transfer
-WHERE address = '0x20c0000000000000000000000000000000000000';
-```
+<IndexSupplyQuery
+  chainId={4217}
+  title={'pathUSD supply from Transfer events'}
+  signatures={["Transfer"]}
+  query={`SELECT
+    SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
+             THEN amount ELSE 0 END) AS total_minted,
+    SUM(CASE WHEN "to" = '0x0000000000000000000000000000000000000000'
+             THEN amount ELSE 0 END) AS total_burned,
+    SUM(CASE WHEN "from" = '0x0000000000000000000000000000000000000000'
+             THEN amount
+             WHEN "to" = '0x0000000000000000000000000000000000000000'
+             THEN -amount
+             ELSE 0 END) AS supply
+  FROM transfer
+  WHERE address = '0x20c0000000000000000000000000000000000000'`}
+/>
 
 ## Key addresses
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,13 @@ function syncTips(): Plugin {
         // Escape angle brackets outside of code blocks/inline code so MDX doesn't
         // treat them as JSX (e.g. `Mapping<B256, bool>` in prose).
         content = escapeAngleBrackets(content)
+        // Quote frontmatter `authors:` values that start with a YAML reserved
+        // character (e.g. `@handle`). Upstream TIPs occasionally include GitHub
+        // handles like `@0xrusowsky`, which break YAML parsing unless quoted.
+        content = content.replace(
+          /^(authors:\s*)([@&*!|>%#`].*)$/m,
+          (_m, prefix, value) => `${prefix}"${value.replace(/"/g, '\\"')}"`,
+        )
         const outputPath = path.join(outputDir, file.name.replace('.md', '.mdx'))
         await fs.writeFile(outputPath, content)
       }),

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -445,6 +445,10 @@ export default defineConfig({
             link: '/quickstart/wallet-developers',
           },
           {
+            text: 'Querying Tempo',
+            link: '/quickstart/querying-tempo',
+          },
+          {
             text: 'Contract Verification',
             link: '/quickstart/verify-contracts',
           },


### PR DESCRIPTION
Adds a new "Querying Tempo" page under **Integrate Tempo** for analysts, data engineers, and indexers writing queries against Tempo data.

It covers the EVM/data-layer differences that silently produce wrong numbers if you carry over Ethereum assumptions:

1. Fees are denominated in USD (attodollars), not ETH/wei
2. TIP-20 tokens use 6 decimals, not 18
3. `tx.value` is always 0 — use `Transfer` events for volume
4. Use `COALESCE(fee_payer, from)` for sponsored-tx attribution
5. Exclude system transactions (`from = 0x0…0`) when measuring user activity
6. Derive supply from `Transfer` events, not `Mint` events

Also includes key precompile addresses (FeeManager, DEX, TIP-20 Factory, PathUSD) and mainnet/Moderato network details.

### Placement
Sidebar entry added to `Integrate Tempo` between **Wallet Developers** and **Contract Verification**.

### Preview
`/quickstart/querying-tempo`