### PR TITLE
fix(sync): quote TIP authors with @ to prevent YAML parse error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,13 @@ function syncTips(): Plugin {
         // Escape angle brackets outside of code blocks/inline code so MDX doesn't
         // treat them as JSX (e.g. `Mapping<B256, bool>` in prose).
         content = escapeAngleBrackets(content)
+        // Quote frontmatter `authors:` values that start with a YAML reserved
+        // character (e.g. `@handle`). Upstream TIPs occasionally include GitHub
+        // handles like `@0xrusowsky`, which break YAML parsing unless quoted.
+        content = content.replace(
+          /^(authors:\s*)([@&*!|>%#`].*)$/m,
+          (_m, prefix, value) => `${prefix}"${value.replace(/"/g, '\\"')}"`,
+        )
         const outputPath = path.join(outputDir, file.name.replace('.md', '.mdx'))
         await fs.writeFile(outputPath, content)
       }),


### PR DESCRIPTION
Upstream TIPs occasionally include GitHub handles like `@0xrusowsky` in the `authors:` frontmatter field. The leading `@` is a YAML reserved character, so the build fails with:

```
[vocs:mdx] [plugin vocs:mdx] src/pages/protocol/tips/tip-1045.mdx: There was an error during the build:
  Plain value cannot start with reserved character @ at line 4, column 10:
authors: @0xrusowsky, Arsenii Kulikov @klkvr, Dan Robinson @danrobinson, Tanish…
```

This currently breaks all PR previews (e.g. #391).

Defensively quote the value in the `syncTips` plugin when it begins with any YAML reserved character (`@ & * ! | > % # \``), preserving any embedded quotes.