### PR TITLE
fix: resolve docs audit links

### DIFF
--- a/src/pages/accounts/server/index.mdx
+++ b/src/pages/accounts/server/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Handlers
-description: Server-side handlers for the Tempo Accounts SDK.
+title: Tempo Accounts Server Handlers
+description: Configure server-side Tempo Accounts SDK handlers for relaying wallet RPC requests, composing backends, and managing WebAuthn ceremonies.
 ---
 
 import { Cards, Card } from 'vocs'
@@ -35,19 +35,19 @@ export const POST = handler.fetch // Next.js
   <Card
     description="Compose multiple handlers into a single handler"
     icon="lucide:layers"
-    to="/accounts/server/compose"
+    to="/accounts/server/handler.compose"
     title="Handler.compose"
   />
   <Card
     description="Proxy RPC requests with sponsorship, auto-swap, and balance diffs"
     icon="lucide:radio"
-    to="/accounts/server/relay"
+    to="/accounts/server/handler.relay"
     title="Handler.relay"
   />
   <Card
     description="Handle WebAuthn credential registration and authentication"
     icon="lucide:fingerprint"
-    to="/accounts/server/webAuthn"
+    to="/accounts/server/handler.webAuthn"
     title="Handler.webAuthn"
   />
 </Cards>

--- a/src/pages/guide/machine-payments/use-cases/ai-model-access.mdx
+++ b/src/pages/guide/machine-payments/use-cases/ai-model-access.mdx
@@ -23,13 +23,13 @@ With MPP, your agent holds a stablecoin balance on Tempo and pays per request. N
 
 | Provider | Models | Service URL |
 |---|---|---|
-| [OpenAI](https://openai.mpp.tempo.xyz) | GPT-4o, o3, DALL·E, Whisper | `openai.mpp.tempo.xyz` |
-| [Anthropic](https://anthropic.mpp.tempo.xyz) | Claude Sonnet, Opus, Haiku | `anthropic.mpp.tempo.xyz` |
-| [Google Gemini](https://gemini.mpp.tempo.xyz) | Gemini, Veo video, image gen | `gemini.mpp.tempo.xyz` |
+| OpenAI | GPT-4o, o3, DALL·E, Whisper | `openai.mpp.tempo.xyz` |
+| Anthropic | Claude Sonnet, Opus, Haiku | `anthropic.mpp.tempo.xyz` |
+| Google Gemini | Gemini, Veo video, image gen | `gemini.mpp.tempo.xyz` |
 | [DeepSeek](https://deepseek.mpp.paywithlocus.com) | DeepSeek-V3, R1 reasoning | `deepseek.mpp.paywithlocus.com` |
 | [Mistral](https://mistral.mpp.paywithlocus.com) | Large, Codestral, Pixtral | `mistral.mpp.paywithlocus.com` |
-| [OpenRouter](https://openrouter.mpp.tempo.xyz) | 100+ models, unified API | `openrouter.mpp.tempo.xyz` |
-| [Grok](https://grok.mpp.tempo.xyz) | xAI chat, search, code exec | `grok.mpp.tempo.xyz` |
+| OpenRouter | 100+ models, unified API | `openrouter.mpp.tempo.xyz` |
+| Grok | xAI chat, search, code exec | `grok.mpp.tempo.xyz` |
 | [Perplexity](https://perplexity.mpp.paywithlocus.com) | Sonar search + grounding | `perplexity.mpp.paywithlocus.com` |
 
 ## Try it

--- a/src/pages/guide/machine-payments/use-cases/browser-automation.mdx
+++ b/src/pages/guide/machine-payments/use-cases/browser-automation.mdx
@@ -22,9 +22,9 @@ With MPP, your agent pays per browser session, per page scrape, or per CAPTCHA s
 | Provider | Capabilities | Service URL |
 |---|---|---|
 | [Browserbase](https://mpp.browserbase.com) | Headless browser sessions, web search, page fetching | `mpp.browserbase.com` |
-| [2Captcha](https://twocaptcha.mpp.tempo.xyz) | reCAPTCHA, Turnstile, hCaptcha, image captchas | `twocaptcha.mpp.tempo.xyz` |
-| [Oxylabs](https://oxylabs.mpp.tempo.xyz) | Web scraping with geo-targeting and JS rendering | `oxylabs.mpp.tempo.xyz` |
-| [Firecrawl](https://firecrawl.mpp.tempo.xyz) | Web crawling and structured data extraction | `firecrawl.mpp.tempo.xyz` |
+| 2Captcha | reCAPTCHA, Turnstile, hCaptcha, image captchas | `twocaptcha.mpp.tempo.xyz` |
+| Oxylabs | Web scraping with geo-targeting and JS rendering | `oxylabs.mpp.tempo.xyz` |
+| Firecrawl | Web crawling and structured data extraction | `firecrawl.mpp.tempo.xyz` |
 | [Diffbot](https://diffbot.mpp.paywithlocus.com) | Article, product, and discussion extraction | `diffbot.mpp.paywithlocus.com` |
 
 ## Try it

--- a/src/pages/guide/machine-payments/use-cases/compute-and-code-execution.mdx
+++ b/src/pages/guide/machine-payments/use-cases/compute-and-code-execution.mdx
@@ -23,7 +23,7 @@ With MPP, your agent pays per execution or per compute-minute with stablecoins o
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
-| [Modal](https://modal.mpp.tempo.xyz) | Serverless GPU compute, AI/ML workloads | `modal.mpp.tempo.xyz` |
+| Modal | Serverless GPU compute, AI/ML workloads | `modal.mpp.tempo.xyz` |
 | [Judge0](https://judge0.mpp.paywithlocus.com) | Code execution in 60+ languages, sandboxed | `judge0.mpp.paywithlocus.com` |
 | [Build With Locus](https://mpp.buildwithlocus.com) | Containers, Postgres, Redis, custom domains | `mpp.buildwithlocus.com` |
 

--- a/src/pages/guide/machine-payments/use-cases/image-and-media-generation.mdx
+++ b/src/pages/guide/machine-payments/use-cases/image-and-media-generation.mdx
@@ -23,9 +23,9 @@ With MPP, your agent pays per generation using stablecoins on Tempo. The price i
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
-| [fal.ai](https://fal.mpp.tempo.xyz) | 600+ models: Flux, SD, Recraft, Grok | `fal.mpp.tempo.xyz` |
-| [OpenAI](https://openai.mpp.tempo.xyz) | DALL·E image generation, Whisper audio | `openai.mpp.tempo.xyz` |
-| [Google Gemini](https://gemini.mpp.tempo.xyz) | Veo video, Nano Banana image gen | `gemini.mpp.tempo.xyz` |
+| fal.ai | 600+ models: Flux, SD, Recraft, Grok | `fal.mpp.tempo.xyz` |
+| OpenAI | DALL·E image generation, Whisper audio | `openai.mpp.tempo.xyz` |
+| Google Gemini | Veo video, Nano Banana image gen | `gemini.mpp.tempo.xyz` |
 | [Deepgram](https://deepgram.mpp.paywithlocus.com) | Nova-3 transcription, Aura-2 TTS | `deepgram.mpp.paywithlocus.com` |
 | [Mathpix](https://mathpix.mpp.paywithlocus.com) | OCR for math, science docs, LaTeX | `mathpix.mpp.paywithlocus.com` |
 

--- a/src/pages/guide/machine-payments/use-cases/location-and-maps.mdx
+++ b/src/pages/guide/machine-payments/use-cases/location-and-maps.mdx
@@ -21,11 +21,11 @@ With MPP, your agent pays per geocode, per route, or per weather query using sta
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
-| [Google Maps](https://googlemaps.mpp.tempo.xyz) | Geocoding, directions, places, routes, weather | `googlemaps.mpp.tempo.xyz` |
+| Google Maps | Geocoding, directions, places, routes, weather | `googlemaps.mpp.tempo.xyz` |
 | [Mapbox](https://mapbox.mpp.paywithlocus.com) | Geocoding, directions, isochrones, static maps | `mapbox.mpp.paywithlocus.com` |
 | [OpenWeather](https://openweather.mpp.paywithlocus.com) | Current weather, forecasts, air quality, alerts | `openweather.mpp.paywithlocus.com` |
 | [StableTravel](https://stabletravel.dev) | Flights, hotels, activities, transfers, tracking | `stabletravel.dev` |
-| [FlightAPI](https://flightapi.mpp.tempo.xyz) | Flight prices, tracking, airport schedules | `flightapi.mpp.tempo.xyz` |
+| FlightAPI | Flight prices, tracking, airport schedules | `flightapi.mpp.tempo.xyz` |
 | [IPinfo](https://ipinfo.mpp.paywithlocus.com) | IP geolocation, ASN, privacy detection | `ipinfo.mpp.paywithlocus.com` |
 
 ## Try it

--- a/src/pages/guide/machine-payments/use-cases/storage.mdx
+++ b/src/pages/guide/machine-payments/use-cases/storage.mdx
@@ -21,8 +21,8 @@ With MPP, your agent pays per upload or per repo creation using stablecoins. The
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
-| [Object Storage](https://storage.mpp.tempo.xyz) | S3/R2-compatible storage, dynamic per-size pricing | `storage.mpp.tempo.xyz` |
-| [Code Storage](https://codestorage.mpp.tempo.xyz) | Paid Git repo creation, authenticated clone URLs | `codestorage.mpp.tempo.xyz` |
+| Object Storage | S3/R2-compatible storage, dynamic per-size pricing | `storage.mpp.tempo.xyz` |
+| Code Storage | Paid Git repo creation, authenticated clone URLs | `codestorage.mpp.tempo.xyz` |
 
 ## Try it
 

--- a/src/pages/guide/machine-payments/use-cases/translation-and-language.mdx
+++ b/src/pages/guide/machine-payments/use-cases/translation-and-language.mdx
@@ -23,7 +23,7 @@ With MPP, your agent pays per translation, per transcription, or per TTS request
 |---|---|---|
 | [DeepL](https://deepl.mpp.paywithlocus.com) | 30+ languages, professional quality translation | `deepl.mpp.paywithlocus.com` |
 | [Deepgram](https://deepgram.mpp.paywithlocus.com) | Nova-3 transcription, Aura-2 TTS, sentiment | `deepgram.mpp.paywithlocus.com` |
-| [OpenAI](https://openai.mpp.tempo.xyz) | Whisper transcription, TTS | `openai.mpp.tempo.xyz` |
+| OpenAI | Whisper transcription, TTS | `openai.mpp.tempo.xyz` |
 
 ## Try it
 

--- a/src/pages/guide/machine-payments/use-cases/web-search-and-research.mdx
+++ b/src/pages/guide/machine-payments/use-cases/web-search-and-research.mdx
@@ -24,11 +24,11 @@ With MPP, your agent pays per search query or page extraction in a single HTTP r
 | Provider | Capabilities | Service URL |
 |---|---|---|
 | [Parallel](https://parallelmpp.dev) | Web search, page extraction, multi-hop research | `parallelmpp.dev` |
-| [Exa](https://exa.mpp.tempo.xyz) | AI-powered search, content retrieval, answers | `exa.mpp.tempo.xyz` |
+| Exa | AI-powered search, content retrieval, answers | `exa.mpp.tempo.xyz` |
 | [Brave](https://brave.mpp.paywithlocus.com) | Web, news, images, videos, AI answers | `brave.mpp.paywithlocus.com` |
-| [Firecrawl](https://firecrawl.mpp.tempo.xyz) | Web scraping, crawling, structured extraction | `firecrawl.mpp.tempo.xyz` |
+| Firecrawl | Web scraping, crawling, structured extraction | `firecrawl.mpp.tempo.xyz` |
 | [Diffbot](https://diffbot.mpp.paywithlocus.com) | Article, product, and discussion extraction | `diffbot.mpp.paywithlocus.com` |
-| [Oxylabs](https://oxylabs.mpp.tempo.xyz) | Web scraping with geo-targeting and JS rendering | `oxylabs.mpp.tempo.xyz` |
+| Oxylabs | Web scraping with geo-targeting and JS rendering | `oxylabs.mpp.tempo.xyz` |
 
 ## Try it
 

--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -39,7 +39,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 | | |
 |---|---|
 | **Scope** | Embed consensus context into the block header to unlock deferred verification, plus T4 bug fixes and security hardening |
-| **TIPs** | [TIP-1031: Embed Consensus Context in the Block Header](/protocol/tips/tip-1031), [TIP-1046: T4 Hardfork Meta TIP](/protocol/tips/tip-1046) |
+| **TIPs** | [TIP-1031: Embed Consensus Context in the Block Header](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1031.md), [TIP-1046: T4 Hardfork Meta TIP](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1046.md) |
 | **Details** | [T4 network upgrade](/protocol/upgrades/t4) |
 | **Release** | v1.7.0 (targeted for Mon, May 11, 2026 16:00 CEST) |
 | **Testnet** | Moderato: May 14, 2026 16:00 CEST (unix: 1778767200) |
@@ -50,7 +50,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 
 All node operators must upgrade before the T4 activation timestamp. TIP-1031 changes how block headers are produced and verified; non-upgraded nodes will have their proposals rejected and will fall out of consensus at activation.
 
-Smart contract developers and integrators are not directly affected by TIP-1031, but should review [TIP-1046](/protocol/tips/tip-1046) for the bundled gas accounting changes and access-key scope validation updates that may affect transaction gas usage post-T4.
+Smart contract developers and integrators are not directly affected by TIP-1031, but should review [TIP-1046](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1046.md) for the bundled gas accounting changes and access-key scope validation updates that may affect transaction gas usage post-T4.
 
 ---
 
@@ -59,7 +59,7 @@ Smart contract developers and integrators are not directly affected by TIP-1031,
 | | |
 |---|---|
 | **Scope** | Enhanced access keys with periodic limits, call scoping, and an authorization ABI update; signature verification precompile; and virtual addresses for TIP-20 deposit forwarding |
-| **TIPs** | [TIP-1011: Enhanced Access Key Permissions](/protocol/tips/tip-1011), [TIP-1020: Signature Verification Precompile](/protocol/tips/tip-1020), [TIP-1022: Virtual Addresses for TIP-20 Deposit Forwarding](/protocol/tips/tip-1022) |
+| **TIPs** | [TIP-1011: Enhanced Access Key Permissions](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1011.md), [TIP-1020: Signature Verification Precompile](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md), [TIP-1022: Virtual Addresses for TIP-20 Deposit Forwarding](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) |
 | **Details** | [T3 network upgrade](/protocol/upgrades/t3) |
 | **Release** | [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) |
 | **Testnet** | Moderato: Apr 21, 2026 16:00 CEST (unix: 1776780000) |
@@ -75,7 +75,7 @@ See the [T3 network upgrade](/protocol/upgrades/t3) page for breaking changes, m
 | | |
 |---|---|
 | **Scope** | Compound transfer policies, ValidatorConfig V2, and audit-driven bug fixes |
-| **TIPs** | [TIP-1015: Compound Transfer Policies](/protocol/tips/tip-1015), [TIP-1004: Permit for TIP-20](/protocol/tips/tip-1004), [TIP-1017: Validator Config V2](/protocol/tips/tip-1017), [TIP-1036: T2 Hardfork Bug Fixes](/protocol/tips/tip-1036) |
+| **TIPs** | [TIP-1015: Compound Transfer Policies](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1015.md), [TIP-1004: Permit for TIP-20](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1004.md), [TIP-1017: Validator Config V2](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1017.md), [TIP-1036: T2 Hardfork Bug Fixes](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1036.md) |
 | **Release** | v1.5.0 |
 | **Testnet** | Moderato: Mar 26, 2026 16:00 CET (unix: 1774537200) |
 | **Mainnet** | Mar 31, 2026 16:00 CEST (unix: 1774965600) |
@@ -100,7 +100,7 @@ See the [T3 network upgrade](/protocol/upgrades/t3) page for breaking changes, m
 | | |
 |---|---|
 | **Scope** | T1A removes the 16.7M per-transaction gas limit in favor of Tempo's 30M cap; T1B adds keychain precompile gas metering and expiring nonce replay-protection hardening |
-| **TIPs** | T1A: [TIP-1010: Mainnet Gas Parameters](https://docs.tempo.xyz/protocol/tips/tip-1010); T1B: upgrade hardening release |
+| **TIPs** | T1A: [TIP-1010: Mainnet Gas Parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md); T1B: upgrade hardening release |
 | **Release** | [v1.3.1](https://github.com/tempoxyz/tempo/releases/tag/v1.3.1) |
 | **Testnet** | T1A + T1B: Feb 23, 2026 15:00 UTC (unix: 1771858800) |
 | **Mainnet** | T1A: Feb 12, 2026 15:00 UTC (unix: 1770908400); T1B: Feb 23, 2026 15:00 UTC (unix: 1771858800) |
@@ -113,7 +113,7 @@ See the [T3 network upgrade](/protocol/upgrades/t3) page for breaking changes, m
 | | |
 |---|---|
 | **Scope** | Mainnet-ready gas economics, expiring nonces, and security hardening |
-| **TIPs** | [TIP-1000: State Creation Cost Increase](https://docs.tempo.xyz/protocol/tips/tip-1000), [TIP-1009: Expiring Nonces](https://docs.tempo.xyz/protocol/tips/tip-1009), [TIP-1010: Mainnet Gas Parameters](https://docs.tempo.xyz/protocol/tips/tip-1010) |
+| **TIPs** | [TIP-1000: State Creation Cost Increase](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md), [TIP-1009: Expiring Nonces](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1009.md), [TIP-1010: Mainnet Gas Parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md) |
 | **Testnet** | Feb 5, 2026 15:00 UTC (unix: 1770303600) — Release: [v1.1.0](https://github.com/tempoxyz/tempo/releases/tag/v1.1.0) |
 | **Mainnet** | Feb 12, 2026 15:00 UTC (unix: 1770908400) — Release: [v1.1.1](https://github.com/tempoxyz/tempo/releases/tag/v1.1.1) |
 | **Priority** | <Badge variant="red">Required</Badge> |

--- a/src/pages/guide/node/validator-keys.mdx
+++ b/src/pages/guide/node/validator-keys.mdx
@@ -54,7 +54,7 @@ If the signing share is lost â€” for example by deleting `<datadir>/consensus` â
 
 ## ValidatorConfig V2 precompile
 
-All key and identity operations are executed through the ValidatorConfig V2 precompile ([TIP-1017](/protocol/tips/tip-1017)):
+All key and identity operations are executed through the ValidatorConfig V2 precompile ([TIP-1017](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1017.md)):
 
 ```solidity
 address constant VALIDATOR_CONFIG_V2 = 0xCCCCCCCC00000000000000000000000000000001;

--- a/src/pages/guide/payments/virtual-addresses.mdx
+++ b/src/pages/guide/payments/virtual-addresses.mdx
@@ -134,7 +134,7 @@ A few things matter in production:
   <Card
     title="TIP-1022 specification"
     description="Read the full protocol definition, including derivation rules, transfer paths, and invariants."
-    to="/protocol/tips/tip-1022"
+    to="https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md"
     icon="lucide:file-text"
   />
   <Card

--- a/src/pages/learn/use-cases/payroll.mdx
+++ b/src/pages/learn/use-cases/payroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stablecoins for Payroll
-description: Faster payroll funding, cheaper cross-border payouts, and new revenue streams for payroll providers using stablecoins.
+description: Learn how payroll providers can use stablecoins for faster account funding, cheaper cross-border payouts, and embedded wallet revenue.
 ---
 
 import { Cards, Card } from 'vocs'
@@ -124,9 +124,9 @@ The stablecoin you pay employees with is only as reliable as the infrastructure 
     icon="lucide:wallet"
   />
   <Card
-    title="Deep dive: Stablecoins for Payroll"
-    description="Full blog post with detailed analysis and use case examples."
-    to="https://tempo.xyz/blog/stablecoins-payroll"
+    title="Global Payouts"
+    description="Cross-border payout mechanics, cost comparisons, and implementation steps."
+    to="/learn/use-cases/global-payouts"
     icon="lucide:book-open"
   />
   <Card

--- a/src/pages/protocol/fees/spec-fee.mdx
+++ b/src/pages/protocol/fees/spec-fee.mdx
@@ -173,7 +173,7 @@ If validators have not specified a fee token preference, the protocol falls back
 
 ## Gas Parameters
 
-As of [TIP-1010](/protocol/tips/tip-1010), Tempo uses the following mainnet gas parameters:
+As of [TIP-1010](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md), Tempo uses the following mainnet gas parameters:
 
 | Parameter | Value |
 |-----------|-------|

--- a/src/pages/protocol/tip20-rewards/spec.mdx
+++ b/src/pages/protocol/tip20-rewards/spec.mdx
@@ -57,7 +57,7 @@ Users must call `setRewardRecipient(recipient)` to opt in. When opted in:
 
 Setting recipient to `address(0)` opts out.
 
-`setRewardRecipient(...)` rejects [TIP-1022](/protocol/tips/tip-1022) virtual addresses: reward recipients must remain canonical accounts rather than forwarding aliases, because reward assignment is not a TIP-20 forwarding path.
+`setRewardRecipient(...)` rejects [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) virtual addresses: reward recipients must remain canonical accounts rather than forwarding aliases, because reward assignment is not a TIP-20 forwarding path.
 
 ## TIP-403 Integration
 All token movements must pass TIP-403 policy checks:
@@ -76,6 +76,6 @@ All token movements must pass TIP-403 policy checks:
 This section captures changes introduced by the [T3 network upgrade](/protocol/upgrades/t3) for integrators migrating from T2. The spec above is the canonical post-T3 specification; this appendix exists for reference and will be removed in a future docs revision.
 :::
 
-T3 introduced [TIP-1022](/protocol/tips/tip-1022) virtual addresses, which affect TIP-20 rewards in one place:
+T3 introduced [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) virtual addresses, which affect TIP-20 rewards in one place:
 
 - `setRewardRecipient(...)` now rejects virtual addresses. Reward recipients must be canonical accounts, not forwarding aliases.

--- a/src/pages/protocol/tip20/spec.mdx
+++ b/src/pages/protocol/tip20/spec.mdx
@@ -448,7 +448,7 @@ TIP-20 tokens cannot be sent to other TIP-20 token contract addresses. The imple
 Any attempt to transfer to a TIP-20 token address must revert with `InvalidRecipient`. This prevents accidental token loss by sending funds to token contracts instead of user accounts.
 
 ## Virtual Address Recipients
-Recipient-bearing TIP-20 paths — `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `mint`, and `mintWithMemo` — resolve [TIP-1022](/protocol/tips/tip-1022) virtual addresses before running recipient authorization and mint-recipient checks. When a recipient `to` is a registered virtual address, the effective recipient becomes the registered master wallet, and authorization, balance updates, and event emission target that master wallet.
+Recipient-bearing TIP-20 paths — `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `mint`, and `mintWithMemo` — resolve [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) virtual addresses before running recipient authorization and mint-recipient checks. When a recipient `to` is a registered virtual address, the effective recipient becomes the registered master wallet, and authorization, balance updates, and event emission target that master wallet.
 
 Virtual addresses are valid TIP-20 recipients on those paths but remain forwarding aliases rather than canonical TIP-20 holders. Non-TIP-20 tokens sent to a virtual address do not forward. Forwarded deposits appear as two-hop standard `Transfer` events in the same transaction; indexers and explorers should collapse that pair into one logical deposit to the resolved master wallet.
 
@@ -469,7 +469,7 @@ While quote tokens can be changed, choose carefully as the update process requir
 ## Permit (TIP-1004)
 TIP-20 tokens support [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) `permit`, added in the [T2 network upgrade](/protocol/upgrades/t2). A token owner signs an EIP-712 typed message off-chain authorizing a spender, and any third party can submit that signature on-chain — combining approve and action into a single transaction without the owner paying gas.
 
-The `DOMAIN_SEPARATOR` is computed dynamically on every call using `block.chainid`, so it remains correct after a chain fork. Each owner has a monotonically increasing `nonce` to prevent replay. Only `v = 27` or `v = 28` is accepted; `v = 0` or `v = 1` is intentionally **not** normalized (see [TIP-1004](/protocol/tips/tip-1004) for rationale).
+The `DOMAIN_SEPARATOR` is computed dynamically on every call using `block.chainid`, so it remains correct after a chain fork. Each owner has a monotonically increasing `nonce` to prevent replay. Only `v = 27` or `v = 28` is accepted; `v = 0` or `v = 1` is intentionally **not** normalized (see [TIP-1004](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1004.md) for rationale).
 
 ## Pause Controls
 Pause controls `pause` and `unpause` govern all transfer operations and reward related flows. When paused, transfers and memo transfers halt, but administrative and configuration functions remain allowed. The `paused()` getter reflects the current state and must be checked by all affected entrypoints.
@@ -610,7 +610,7 @@ interface ITIP20Factory {
 This section captures changes introduced by the [T3 network upgrade](/protocol/upgrades/t3) for integrators migrating from T2. The spec above is the canonical post-T3 specification; this appendix exists for reference and will be removed in a future docs revision.
 :::
 
-T3 introduced [TIP-1022](/protocol/tips/tip-1022) virtual addresses, which affect TIP-20 in the following ways:
+T3 introduced [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) virtual addresses, which affect TIP-20 in the following ways:
 
 - Virtual-address recipient resolution applies to recipient-bearing TIP-20 paths: `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `mint`, and `mintWithMemo`. See [Virtual Address Recipients](#virtual-address-recipients).
 - When an operation targets a registered virtual address, the effective recipient becomes the registered master wallet before recipient authorization and mint-recipient checks run.

--- a/src/pages/protocol/tip20/virtual-addresses.mdx
+++ b/src/pages/protocol/tip20/virtual-addresses.mdx
@@ -38,7 +38,7 @@ The important idea is simple: the virtual address is for routing and attribution
 
 ## Address format
 
-A virtual address is still a normal 20-byte EVM address. [TIP-1022](/protocol/tips/tip-1022) gives those 20 bytes a specific layout:
+A virtual address is still a normal 20-byte EVM address. [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) gives those 20 bytes a specific layout:
 
 ```text
 0x | masterId (4 bytes) | VIRTUAL_MAGIC (10 bytes) | userTag (6 bytes)
@@ -138,7 +138,7 @@ TIP-1022 is deliberately narrow in scope.
 
 ### It only changes TIP-20 deposit paths
 
-Virtual forwarding applies only to the TIP-20 transfer and mint paths defined by [TIP-1022](/protocol/tips/tip-1022). It is not a general EVM alias system.
+Virtual forwarding applies only to the TIP-20 transfer and mint paths defined by [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md). It is not a general EVM alias system.
 
 ### It does not change ERC-20 contracts deployed on Tempo
 
@@ -160,7 +160,7 @@ Adopting virtual addresses is straightforward conceptually:
 - ongoing operations: derive deposit addresses offchain
 - reconciliation: decode the `userTag` from events and credit the right customer internally
 
-If you want the exact transfer semantics, event shape, and validation rules, read [TIP-1022](/protocol/tips/tip-1022) alongside the [TIP-20 specification](/protocol/tip20/spec).
+If you want the exact transfer semantics, event shape, and validation rules, read [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) alongside the [TIP-20 specification](/protocol/tip20/spec).
 
 ## Learn more
 
@@ -174,7 +174,7 @@ If you want the exact transfer semantics, event shape, and validation rules, rea
   <Card
     title="TIP-1022 specification"
     description="Read the full TIP with address derivation, forwarding semantics, and invariants."
-    to="/protocol/tips/tip-1022"
+    to="https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md"
     icon="lucide:file-text"
   />
   <Card

--- a/src/pages/protocol/tip403/spec.mdx
+++ b/src/pages/protocol/tip403/spec.mdx
@@ -231,7 +231,7 @@ TIP-20 tokens store the current TIP403 registry policy ID they adhere to in thei
 
 **Policy Changes:** When a token's transfer policy is changed via `changeTransferPolicyId()`, all future transfers are immediately subject to the new policy.
 
-**Virtual addresses:** Policy-configuration functions that accept literal member addresses (`createPolicyWithAccounts`, `modifyPolicyWhitelist`, `modifyPolicyBlacklist`) reject [TIP-1022](/protocol/tips/tip-1022) virtual addresses. TIP-20 policy checks for transfers and mints to a virtual address run against the resolved master wallet rather than the forwarding alias, so policy membership must be configured on the master address.
+**Virtual addresses:** Policy-configuration functions that accept literal member addresses (`createPolicyWithAccounts`, `modifyPolicyWhitelist`, `modifyPolicyBlacklist`) reject [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) virtual addresses. TIP-20 policy checks for transfers and mints to a virtual address run against the resolved master wallet rather than the forwarding alias, so policy membership must be configured on the master address.
 
 ### Example Usage
 
@@ -275,7 +275,7 @@ return data.policyType == PolicyType.WHITELIST
 This section captures changes introduced by the [T3 network upgrade](/protocol/upgrades/t3) for integrators migrating from T2. The spec above is the canonical post-T3 specification; this appendix exists for reference and will be removed in a future docs revision.
 :::
 
-T3 introduced [TIP-1022](/protocol/tips/tip-1022) virtual addresses, which affect TIP-403 in two places:
+T3 introduced [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) virtual addresses, which affect TIP-403 in two places:
 
 - Policy-configuration functions that take literal member addresses (`createPolicyWithAccounts`, `modifyPolicyWhitelist`, `modifyPolicyBlacklist`) now reject virtual addresses.
 - TIP-20 policy checks for virtual-address transfers and mints now run against the resolved master wallet, not the forwarding alias. Policy membership must be configured on the master address.

--- a/src/pages/protocol/tips/index.mdx
+++ b/src/pages/protocol/tips/index.mdx
@@ -1,8 +1,7 @@
 ---
-description: Browse all Tempo Improvement Proposals (TIPs) — design documents that specify protocol changes and serve as the source of truth for implementation.
+title: Tempo Improvement Proposals
+description: Browse Tempo Improvement Proposals covering protocol changes, network upgrades, precompiles, transaction formats, and stablecoin standards.
 ---
-
-import { TipsList } from '../../../components/TipsList'
 
 # Tempo Improvement Proposals (TIPs)
 
@@ -10,5 +9,4 @@ TIPs are design documents that describe changes to the Tempo protocol. Each TIP 
 
 ---
 
-<TipsList />
-
+TIP pages redirect to the canonical TIP markdown in the [Tempo repository](https://github.com/tempoxyz/tempo/tree/main/tips).

--- a/src/pages/protocol/transactions/spec-tempo-transaction.mdx
+++ b/src/pages/protocol/transactions/spec-tempo-transaction.mdx
@@ -614,7 +614,7 @@ There is one decoder nuance: because `KeyAuthorization` uses canonical trailing 
 Do not hand-encode `expiry = 0` or rely on `Some(0)` as a sentinel. The supported encoding to target is omission, and the protocol translates omitted expiry to `u64::MAX` when materializing the `AccountKeychain.authorizeKey(...)` call.
 :::
 
-Intrinsic gas for `key_authorization` accounts for the storage written for periodic-limit state and call-scope entries. See [TIP-1011](/protocol/tips/tip-1011#intrinsic-gas-for-key-authorization) for slot-counting rules.
+Intrinsic gas for `key_authorization` accounts for the storage written for periodic-limit state and call-scope entries. See [TIP-1011](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1011.md#intrinsic-gas-for-key-authorization) for slot-counting rules.
 
 #### Keychain Precompile
 
@@ -1214,7 +1214,7 @@ Because a single transaction can invalidate multiple others by spending balances
 This section captures changes introduced by the [T3 network upgrade](/protocol/upgrades/t3) for integrators migrating from T2. The spec above is the canonical post-T3 specification; this appendix exists for reference and will be removed in a future docs revision.
 :::
 
-T3 expanded access keys through [TIP-1011](/protocol/tips/tip-1011) in the following ways:
+T3 expanded access keys through [TIP-1011](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1011.md) in the following ways:
 
 - `KeyAuthorization` gained `allowed_calls` (call-scope allowlist).
 - `TokenLimit` gained `period` (recurring vs. one-time spending limits).
@@ -1222,7 +1222,7 @@ T3 expanded access keys through [TIP-1011](/protocol/tips/tip-1011) in the follo
 - A non-expiring `key_authorization` omits `expiry` in tx RLP. At the Account Keychain ABI boundary, the protocol translates that omission to `u64::MAX`. Literal `0` is not a valid non-expiring sentinel to rely on.
 - Access-key validation gained two new execution checks: call scopes must pass before execution begins, and access-key-signed transactions may not perform contract creation anywhere in the batch.
 - The Account Keychain precompile ABI changed in lockstep — `authorizeKey(...)` now takes a `KeyRestrictions` tuple, `getRemainingLimit(...)` is replaced by `getRemainingLimitWithPeriod(...)`, and `setAllowedCalls(...)` / `removeAllowedCalls(...)` / `getAllowedCalls(...)` are added. See the [Account Keychain spec](./AccountKeychain) for full details.
-- Intrinsic gas for `key_authorization` accounts for periodic-limit state and call-scope storage. See [TIP-1011](/protocol/tips/tip-1011#intrinsic-gas-for-key-authorization) for the canonical slot-counting rules.
+- Intrinsic gas for `key_authorization` accounts for periodic-limit state and call-scope storage. See [TIP-1011](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1011.md#intrinsic-gas-for-key-authorization) for the canonical slot-counting rules.
 
 ### Pre-T3 KeyAuthorization (reference only)
 

--- a/src/pages/protocol/upgrades/t2.mdx
+++ b/src/pages/protocol/upgrades/t2.mdx
@@ -19,10 +19,10 @@ Partners should upgrade nodes to the T2-compatible release before the moderato a
 ## Overview
 
 T2 is Tempo's next network upgrade, building on T1. It introduces the following new features:
-- Compound transfer policies ([TIP-1015](/protocol/tips/tip-1015))
-- Permit support for TIP-20 tokens ([TIP-1004](/protocol/tips/tip-1004))
-- a new Validator Config V2 precompile ([TIP-1017](/protocol/tips/tip-1017))
-- and security improvements ([TIP-1036](/protocol/tips/tip-1036)).
+- Compound transfer policies ([TIP-1015](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1015.md))
+- Permit support for TIP-20 tokens ([TIP-1004](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1004.md))
+- a new Validator Config V2 precompile ([TIP-1017](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1017.md))
+- and security improvements ([TIP-1036](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1036.md)).
 
 **Action required:** All node operators must upgrade to the T2-compatible release before the activation timestamp.
 
@@ -30,7 +30,7 @@ T2 is Tempo's next network upgrade, building on T1. It introduces the following 
 
 ### TIP-1015: Compound Transfer Policies
 
-**Spec:** [TIP-1015](/protocol/tips/tip-1015)
+**Spec:** [TIP-1015](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1015.md)
 
 **TLDR:** Extends TIP-403 policies so token issuers can set different authorization rules for senders, recipients, and mint recipients. Previously a single policy applied to both sides of a transfer.
 
@@ -42,7 +42,7 @@ T2 is Tempo's next network upgrade, building on T1. It introduces the following 
 
 ### TIP-1017: Validator Config V2
 
-**Spec:** [TIP-1017](/protocol/tips/tip-1017)
+**Spec:** [TIP-1017](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1017.md)
 
 **Operator guide:** [Controlling validator lifecycle](/guide/node/validator-lifecycle)
 
@@ -56,7 +56,7 @@ T2 is Tempo's next network upgrade, building on T1. It introduces the following 
 
 ### TIP-1004: Permit for TIP-20
 
-**Spec:** [TIP-1004](/protocol/tips/tip-1004)
+**Spec:** [TIP-1004](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1004.md)
 
 **TLDR:** Adds EIP-2612 compatible `permit()` to all TIP-20 tokens, enabling gasless approvals via off-chain signatures.
 
@@ -67,4 +67,4 @@ T2 is Tempo's next network upgrade, building on T1. It introduces the following 
 
 ### Meta TIP: Security Improvements
 
-[TIP-1036: T2 Hardfork Improvements](/protocol/tips/tip-1036)
+[TIP-1036: T2 Hardfork Improvements](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1036.md)

--- a/src/pages/protocol/upgrades/t3.mdx
+++ b/src/pages/protocol/upgrades/t3.mdx
@@ -20,9 +20,9 @@ Partners should upgrade nodes to the T3-compatible release before the Moderato a
 
 | TIP | What it does | Who should review |
 |-----|-------------|-------------------|
-| [TIP-1011](/protocol/tips/tip-1011) | Periodic spending limits, call scoping, and a ban on access-key contract creation | Wallets, account SDKs, apps using connected apps or subscriptions |
-| [TIP-1020](/protocol/tips/tip-1020) | Signature verification precompile for secp256k1, P256, and WebAuthn | Smart contract teams, account integrators, wallet SDKs |
-| [TIP-1022](/protocol/tips/tip-1022) | [Virtual addresses](/protocol/tip20/virtual-addresses) for TIP-20 deposit forwarding | Exchanges, ramps, custodians, payment processors, explorers, indexers |
+| [TIP-1011](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1011.md) | Periodic spending limits, call scoping, and a ban on access-key contract creation | Wallets, account SDKs, apps using connected apps or subscriptions |
+| [TIP-1020](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md) | Signature verification precompile for secp256k1, P256, and WebAuthn | Smart contract teams, account integrators, wallet SDKs |
+| [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) | [Virtual addresses](/protocol/tip20/virtual-addresses) for TIP-20 deposit forwarding | Exchanges, ramps, custodians, payment processors, explorers, indexers |
 
 ## Breaking changes
 
@@ -61,7 +61,7 @@ See [Virtual addresses for TIP-20 deposits](/protocol/tip20/virtual-addresses) f
 
 ### Signature verification precompile
 
-[TIP-1020](/protocol/tips/tip-1020) is additive — existing verifier setups keep working. Teams that want a standard onchain verification surface can adopt the precompile instead of maintaining custom verifier contracts. See the [Signature Verification with Foundry](/sdk/foundry/signature-verifier) guide.
+[TIP-1020](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md) is additive — existing verifier setups keep working. Teams that want a standard onchain verification surface can adopt the precompile instead of maintaining custom verifier contracts. See the [Signature Verification with Foundry](/sdk/foundry/signature-verifier) guide.
 
 ## Compatible SDK releases
 
@@ -81,5 +81,5 @@ The Accounts SDK and `wallet_authorizeAccessKey` docs still describe the legacy 
 
 ## Related docs
 - [Virtual addresses for TIP-20 deposits](/protocol/tip20/virtual-addresses)
-- [TIP-1022](/protocol/tips/tip-1022)
+- [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md)
 - Coordinating meta TIP: [tempoxyz/tempo#3273](https://github.com/tempoxyz/tempo/pull/3273)

--- a/src/pages/protocol/upgrades/t4.mdx
+++ b/src/pages/protocol/upgrades/t4.mdx
@@ -23,7 +23,7 @@ Node operators must upgrade to the T4-compatible release (v1.7.0, targeted for M
 ## Overview
 
 T4 is Tempo's next network upgrade. It introduces the following changes:
-- Embedding consensus context into the block header to unlock deferred verification and reduce finalization latency ([TIP-1031](/protocol/tips/tip-1031))
+- Embedding consensus context into the block header to unlock deferred verification and reduce finalization latency ([TIP-1031](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1031.md))
 - A bundle of T4 bug fixes and security hardening (https://tips.sh/1046)
 
 **Action required for node operators:** Upgrade to v1.7.0 before the Moderato activation timestamp. Non-upgraded nodes will fall out of consensus.
@@ -34,11 +34,11 @@ T4-compatible SDK releases will be listed here as they ship.
 
 ## Related docs
 - [Network upgrades and releases](/guide/node/network-upgrades)
-- [TIP-1031: Embed Consensus Context in the Block Header](/protocol/tips/tip-1031)
-- [TIP-1046: T4 Hardfork Meta TIP](/protocol/tips/tip-1046)
+- [TIP-1031: Embed Consensus Context in the Block Header](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1031.md)
+- [TIP-1046: T4 Hardfork Meta TIP](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1046.md)
 
 ## Feature TIPs
 
 ### TIP-1031: Embed Consensus Context in the Block Header
 
-[TIP-1031](/protocol/tips/tip-1031) adds an optional `Context` field (epoch, view, parent view, leader) as the last field of `TempoHeader`. This commits consensus metadata to the block hash so Tempo blocks implement Commonware's `CertifiableBlock` trait, enabling deferred verification (optimistic notarization with async background verification) and reduced finalization latency. Pre-activation headers are unchanged; post-activation headers require the field and validators reject mismatched context.
+[TIP-1031](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1031.md) adds an optional `Context` field (epoch, view, parent view, leader) as the last field of `TempoHeader`. This commits consensus metadata to the block hash so Tempo blocks implement Commonware's `CertifiableBlock` trait, enabling deferred verification (optimistic notarization with async background verification) and reduced finalization latency. Pre-activation headers are unchanged; post-activation headers require the field and validators reject mismatched context.

--- a/src/pages/quickstart/evm-compatibility.mdx
+++ b/src/pages/quickstart/evm-compatibility.mdx
@@ -97,7 +97,7 @@ At the VM layer, all opcodes are supported out of the box. Due to the lack of a 
 
 ### State Creation Costs
 
-Tempo uses higher gas costs for state-creating operations to prevent state growth attacks ([TIP-1000](/protocol/tips/tip-1000)):
+Tempo uses higher gas costs for state-creating operations to prevent state growth attacks ([TIP-1000](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md)):
 
 | Operation | Tempo | Ethereum |
 |-----------|-------|----------|

--- a/src/pages/quickstart/predeployed-contracts.mdx
+++ b/src/pages/quickstart/predeployed-contracts.mdx
@@ -14,8 +14,8 @@ Core protocol contracts that power Tempo's features.
 | [**Fee Manager**](/protocol/fees/spec-fee-amm#2-feemanager-contract) | [`0xfeec000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0xfeec000000000000000000000000000000000000) | Handle fee payments and conversions |
 | [**Stablecoin DEX**](/protocol/exchange) | [`0xdec0000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0xdec0000000000000000000000000000000000000) | Enshrined DEX for stablecoin swaps |
 | [**TIP-403 Registry**](/protocol/tip403/spec) | [`0x403c000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x403c000000000000000000000000000000000000) | Transfer policy registry |
-| [**Signature Verifier**](/protocol/tips/tip-1020) | [`0x5165300000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x5165300000000000000000000000000000000000) | Verify secp256k1, P256, and WebAuthn signatures onchain |
-| [**Address Registry**](/protocol/tips/tip-1022) | [`0xFDC0000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0xFDC0000000000000000000000000000000000000) | Resolve virtual TIP-20 deposit addresses to registered master wallets |
+| [**Signature Verifier**](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md) | [`0x5165300000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x5165300000000000000000000000000000000000) | Verify secp256k1, P256, and WebAuthn signatures onchain |
+| [**Address Registry**](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) | [`0xFDC0000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0xFDC0000000000000000000000000000000000000) | Resolve virtual TIP-20 deposit addresses to registered master wallets |
 | [**pathUSD**](/protocol/exchange/quote-tokens#pathusd) | [`0x20c0000000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000000) | First stablecoin deployed |
 
 ## Standard Utilities

--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -6,7 +6,7 @@ description: Build, test, and deploy smart contracts on Tempo using Foundry. Acc
 
 Tempo is supported as a first-class citizen in [Foundry](https://github.com/foundry-rs/foundry): the leading Ethereum development toolkit.
 
-Install the latest Foundry release to access Tempo's [protocol-level features](/protocol/) in `forge`, `cast`, `anvil`, and `chisel`, and to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
+Install the latest Foundry release to access Tempo's [protocol-level features](/protocol) in `forge`, `cast`, `anvil`, and `chisel`, and to build, test, and deploy contracts that go [beyond the limits of standard EVM chains](/quickstart/evm-compatibility).
 
 :::warning[`tempo-foundry` is deprecated]
 `tempo-foundry` and `foundryup -n tempo` are deprecated. Switch to the latest upstream Foundry release with `foundryup`.

--- a/src/pages/sdk/foundry/signature-verifier.mdx
+++ b/src/pages/sdk/foundry/signature-verifier.mdx
@@ -5,7 +5,7 @@ description: Verify secp256k1, P256, and WebAuthn signatures in smart contracts 
 
 # Signature Verification with Foundry
 
-The [TIP-1020](/protocol/tips/tip-1020) `SignatureVerifier` precompile lets contracts verify secp256k1, P256, and WebAuthn signatures through a single interface — no custom verifier contracts needed. This is available after the [T3 network upgrade](/protocol/upgrades/t3).
+The [TIP-1020](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md) `SignatureVerifier` precompile lets contracts verify secp256k1, P256, and WebAuthn signatures through a single interface — no custom verifier contracts needed. This is available after the [T3 network upgrade](/protocol/upgrades/t3).
 
 The Foundry project template for Tempo ships with a working example that demonstrates signature verification in a relayed mail contract. Initialize it with:
 
@@ -136,6 +136,6 @@ The secp256k1 and P256 relay tests run against the T3 hardfork automatically via
 
 ## Related
 
-- [TIP-1020: Signature Verification Precompile](/protocol/tips/tip-1020)
+- [TIP-1020: Signature Verification Precompile](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md)
 - [T3 Network Upgrade](/protocol/upgrades/t3)
 - [Foundry for Tempo](/sdk/foundry)

--- a/src/snippets/tempo-tx-properties.mdx
+++ b/src/snippets/tempo-tx-properties.mdx
@@ -1548,7 +1548,7 @@ In **Viem** and **Wagmi**, expiring nonces are handled automatically.
 
 ### Expiring Nonces
 
-[TIP-1009](/protocol/tips/tip-1009) introduces expiring nonces: transactions automatically expire if not executed within a specified time window. 
+[TIP-1009](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1009.md) introduces expiring nonces: transactions automatically expire if not executed within a specified time window. 
 
 **Benefits:**
 - No nonce tracking required
@@ -2076,7 +2076,7 @@ For cases requiring ordered sequences within a key, Tempo's **2D nonce system** 
 </Tabs>
 
 :::warning
-**Reuse nonce keys instead of generating random ones.** Creating a new nonce key incurs a state creation cost that increases with the number of active keys (see [TIP-1000](/protocol/tips/tip-1000)). For most applications, using a small set of sequential nonce keys (e.g., `1n`, `2n`, `3n`) is sufficient and much more cost-effective than generating random nonce keys for each transaction.
+**Reuse nonce keys instead of generating random ones.** Creating a new nonce key incurs a state creation cost that increases with the number of active keys (see [TIP-1000](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md)). For most applications, using a small set of sequential nonce keys (e.g., `1n`, `2n`, `3n`) is sufficient and much more cost-effective than generating random nonce keys for each transaction.
 :::
 
 ### Scheduled Transactions

--- a/vercel.json
+++ b/vercel.json
@@ -53,6 +53,46 @@
       "source": "/guide/bridge-usdc-relay",
       "destination": "/guide/bridge-relay",
       "permanent": true
+    },
+    {
+      "source": "/network-upgrades",
+      "destination": "/guide/node/network-upgrades",
+      "permanent": true
+    },
+    {
+      "source": "/AccountKeychain",
+      "destination": "/protocol/transactions/AccountKeychain",
+      "permanent": true
+    },
+    {
+      "source": "/guide/node/validator-config-v2",
+      "destination": "/guide/node/network-upgrades",
+      "permanent": true
+    },
+    {
+      "source": "/accounts/server/compose",
+      "destination": "/accounts/server/handler.compose",
+      "permanent": true
+    },
+    {
+      "source": "/accounts/server/relay",
+      "destination": "/accounts/server/handler.relay",
+      "permanent": true
+    },
+    {
+      "source": "/accounts/server/webAuthn",
+      "destination": "/accounts/server/handler.webAuthn",
+      "permanent": true
+    },
+    {
+      "source": "/tip-:id",
+      "destination": "https://github.com/tempoxyz/tempo/blob/main/tips/tip-:id.md",
+      "permanent": true
+    },
+    {
+      "source": "/protocol/tips/tip-:id",
+      "destination": "https://github.com/tempoxyz/tempo/blob/main/tips/tip-:id.md",
+      "permanent": true
     }
   ],
   "rewrites": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,3 @@
-import * as fs from 'node:fs/promises'
-import * as path from 'node:path'
 import react from '@vitejs/plugin-react'
 import { Instance } from 'prool'
 import { defineConfig, loadEnv, type Plugin } from 'vite'
@@ -16,7 +14,7 @@ export default defineConfig(({ mode }) => {
   const useHttp = process.env.CI === 'true' || process.env.VITE_USE_HTTP === 'true'
 
   return {
-    plugins: [syncTips(), vocs(), react(), ...(useHttp ? [] : [mkcert()]), tempoNode()],
+    plugins: [vocs(), react(), ...(useHttp ? [] : [mkcert()]), tempoNode()],
     server: useHttp
       ? {
           host: 'localhost',
@@ -37,108 +35,6 @@ function tempoNode(): Plugin {
       console.log('→ starting tempo node...')
       await instance.start()
       console.log('√ tempo node started on port 8545')
-    },
-  }
-}
-
-/**
- * Escape angle brackets in prose so MDX does not interpret them as JSX.
- * Preserves content inside fenced code blocks and inline code spans.
- */
-function escapeAngleBrackets(source: string): string {
-  const lines = source.split('\n')
-  const result: string[] = []
-  let inCodeBlock = false
-
-  for (const line of lines) {
-    if (/^```/.test(line)) {
-      inCodeBlock = !inCodeBlock
-      result.push(line)
-      continue
-    }
-    if (inCodeBlock) {
-      result.push(line)
-      continue
-    }
-    // Split by inline code spans to avoid escaping inside them
-    const parts = line.split(/(`[^`]*`)/)
-    for (let i = 0; i < parts.length; i++) {
-      if (i % 2 === 0) {
-        // Escape < > that would be misread as JSX. Use backslash escapes
-        // which MDX/micromark supports.
-        parts[i] = parts[i].replace(/</g, '&lt;').replace(/>/g, '&gt;')
-      }
-    }
-    result.push(parts.join(''))
-  }
-
-  return result.join('\n')
-}
-
-function syncTips(): Plugin {
-  const repo = 'tempoxyz/tempo'
-  const outputDir = 'src/pages/protocol/tips'
-
-  let synced = false
-
-  async function sync() {
-    if (synced) return
-    synced = true
-
-    console.log('→ syncing TIPs from GitHub...')
-
-    const res = await fetch(`https://api.github.com/repos/${repo}/contents/tips`)
-    if (!res.ok) {
-      console.error('✗ failed to fetch TIPs directory:', res.statusText)
-      return
-    }
-
-    const files = (await res.json()) as Array<{ name: string; download_url: string; type: string }>
-    const tipFiles = files.filter((f) => f.type === 'file' && /^tip-\d+\.md$/.test(f.name))
-
-    await fs.mkdir(outputDir, { recursive: true })
-
-    await Promise.all(
-      tipFiles.map(async (file) => {
-        let content = await fetch(file.download_url).then((r) => r.text())
-        // Strip stale Solidity interface links from upstream TIPs. The linked
-        // files are no longer published, so keeping the link would surface dead
-        // references in the docs UI and fail Vocs' dead-link checker.
-        content = content.replace(
-          /^- \[[^\]]+\.sol\]\(tips\/(?:ref-impls|verify)\/src\/interfaces\/[^)]+\)\n/gm,
-          '',
-        )
-        content = content.replace(
-          /\[([^\]]+\.sol)\]\(tips\/(?:ref-impls|verify)\/src\/interfaces\/[^)]+\)/g,
-          '$1',
-        )
-        // tip-0000 links to `./tip_template.md`, which lives in the tempo
-        // repo but not in the docs site.
-        content = content.replace(
-          /\(\.\/tip_template\.md\)/g,
-          '(https://github.com/tempoxyz/tempo/blob/main/tips/tip_template.md)',
-        )
-        // Rewrite inter-TIP links from ./tip-NNNN.md to ./tip-NNNN (synced as .mdx,
-        // Vocs resolves extensionless paths).
-        content = content.replace(/\(\.\/tip-(\d+)\.md\)/g, '(./tip-$1)')
-        // Escape angle brackets outside of code blocks/inline code so MDX doesn't
-        // treat them as JSX (e.g. `Mapping<B256, bool>` in prose).
-        content = escapeAngleBrackets(content)
-        const outputPath = path.join(outputDir, file.name.replace('.md', '.mdx'))
-        await fs.writeFile(outputPath, content)
-      }),
-    )
-
-    console.log(`√ synced ${tipFiles.length} TIPs`)
-  }
-
-  return {
-    name: 'sync-tips',
-    async buildStart() {
-      await sync()
-    },
-    async configureServer() {
-      await sync()
     },
   }
 }


### PR DESCRIPTION
## Summary

Fix Ahrefs audit issues by adding legacy redirects, correcting broken docs links, redirecting TIP routes to upstream TIP markdown, and removing clickable links to service roots that return 404.
