### PR TITLE
fix: stabilize private zone e2e

### DIFF
--- a/e2e/deposit-to-a-zone.test.ts
+++ b/e2e/deposit-to-a-zone.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { waitForEnabledAction } from './private-zone-actions'
 
 test('prepare zone access and deposit to Zone A', async ({ page }) => {
   test.setTimeout(180000)
@@ -35,9 +36,14 @@ test('prepare zone access and deposit to Zone A', async ({ page }) => {
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const depositButton = page.getByRole('button', { name: /^Deposit 100 pathUSD$/i }).first()
 
-  if (await getFundsButton.isVisible()) {
-    await getFundsButton.click()
-    await expect(depositButton).toBeVisible({ timeout: 90000 })
+  const initialAction = await waitForEnabledAction([
+    { locator: getFundsButton, name: 'fund' },
+    { locator: depositButton, name: 'deposit' },
+  ])
+
+  if (initialAction.name === 'fund') {
+    await initialAction.locator.click()
+    await expect(depositButton).toBeEnabled({ timeout: 90000 })
   }
 
   await depositButton.click()

--- a/e2e/private-zone-actions.ts
+++ b/e2e/private-zone-actions.ts
@@ -1,0 +1,33 @@
+import { expect, type Locator } from '@playwright/test'
+
+type Action = {
+  locator: Locator
+  name: string
+}
+
+export async function waitForEnabledAction(actions: Action[], timeout = 120000) {
+  await expect
+    .poll(
+      async () => {
+        for (const action of actions) {
+          const visible = await action.locator.isVisible().catch(() => false)
+          if (!visible) continue
+
+          const enabled = await action.locator.isEnabled().catch(() => false)
+          if (enabled) return action.name
+        }
+
+        return ''
+      },
+      { timeout },
+    )
+    .not.toBe('')
+
+  for (const action of actions) {
+    const visible = await action.locator.isVisible().catch(() => false)
+    const enabled = await action.locator.isEnabled().catch(() => false)
+    if (visible && enabled) return action
+  }
+
+  throw new Error('No enabled action found')
+}

--- a/e2e/send-tokens-across-zones.test.ts
+++ b/e2e/send-tokens-across-zones.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { waitForEnabledAction } from './private-zone-actions'
 
 test('send pathUSD from Zone A into Zone B', async ({ page }) => {
   test.setTimeout(240000)
@@ -35,18 +36,17 @@ test('send pathUSD from Zone A into Zone B', async ({ page }) => {
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const topUpButton = page.getByRole('button', { name: /^Approve \+ top up Zone A$/i }).first()
 
-  await expect
-    .poll(async () => (await getFundsButton.isVisible()) || (await topUpButton.isVisible()), {
-      timeout: 90000,
-    })
-    .toBe(true)
+  const initialAction = await waitForEnabledAction([
+    { locator: getFundsButton, name: 'fund' },
+    { locator: topUpButton, name: 'top-up' },
+  ])
 
-  if (await getFundsButton.isVisible()) {
-    await getFundsButton.click()
-    await expect(topUpButton).toBeVisible({ timeout: 90000 })
+  if (initialAction.name === 'fund') {
+    await initialAction.locator.click()
+    await expect(topUpButton).toBeEnabled({ timeout: 90000 })
   }
 
-  if (await topUpButton.isVisible()) {
+  if ((await topUpButton.isVisible()) && (await topUpButton.isEnabled())) {
     await topUpButton.click()
   }
 

--- a/e2e/send-tokens-within-a-zone.test.ts
+++ b/e2e/send-tokens-within-a-zone.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { waitForEnabledAction } from './private-zone-actions'
 
 test('prepare zone balance and send tokens within Zone A', async ({ page }) => {
   test.setTimeout(180000)
@@ -35,18 +36,17 @@ test('prepare zone balance and send tokens within Zone A', async ({ page }) => {
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const topUpButton = page.getByRole('button', { name: /^Approve \+ top up Zone A$/i }).first()
 
-  await expect
-    .poll(async () => (await getFundsButton.isVisible()) || (await topUpButton.isVisible()), {
-      timeout: 90000,
-    })
-    .toBe(true)
+  const initialAction = await waitForEnabledAction([
+    { locator: getFundsButton, name: 'fund' },
+    { locator: topUpButton, name: 'top-up' },
+  ])
 
-  if (await getFundsButton.isVisible()) {
-    await getFundsButton.click()
-    await expect(topUpButton).toBeVisible({ timeout: 90000 })
+  if (initialAction.name === 'fund') {
+    await initialAction.locator.click()
+    await expect(topUpButton).toBeEnabled({ timeout: 90000 })
   }
 
-  if (await topUpButton.isVisible()) await topUpButton.click()
+  if ((await topUpButton.isVisible()) && (await topUpButton.isEnabled())) await topUpButton.click()
   await expect(page.getByRole('link', { name: 'View receipt' }).first()).toBeVisible({
     timeout: 120000,
   })

--- a/e2e/swap-across-zones.test.ts
+++ b/e2e/swap-across-zones.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { waitForEnabledAction } from './private-zone-actions'
 
 test('swap pathUSD from Zone A into betaUSD on Zone B', async ({ page }) => {
   test.setTimeout(240000)
@@ -35,18 +36,17 @@ test('swap pathUSD from Zone A into betaUSD on Zone B', async ({ page }) => {
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const topUpButton = page.getByRole('button', { name: /^Approve \+ top up Zone A$/i }).first()
 
-  await expect
-    .poll(async () => (await getFundsButton.isVisible()) || (await topUpButton.isVisible()), {
-      timeout: 90000,
-    })
-    .toBe(true)
+  const initialAction = await waitForEnabledAction([
+    { locator: getFundsButton, name: 'fund' },
+    { locator: topUpButton, name: 'top-up' },
+  ])
 
-  if (await getFundsButton.isVisible()) {
-    await getFundsButton.click()
-    await expect(topUpButton).toBeVisible({ timeout: 90000 })
+  if (initialAction.name === 'fund') {
+    await initialAction.locator.click()
+    await expect(topUpButton).toBeEnabled({ timeout: 90000 })
   }
 
-  if (await topUpButton.isVisible()) {
+  if ((await topUpButton.isVisible()) && (await topUpButton.isEnabled())) {
     await topUpButton.click()
   }
 

--- a/e2e/withdraw-from-a-zone.test.ts
+++ b/e2e/withdraw-from-a-zone.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { waitForEnabledAction } from './private-zone-actions'
 
 test.describe.configure({ retries: 0, timeout: 120000 })
 
@@ -37,18 +38,17 @@ test('prepare zone balance and withdraw from Zone A', async ({ page }) => {
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const topUpButton = page.getByRole('button', { name: /^Approve \+ top up Zone A$/i }).first()
 
-  await expect
-    .poll(async () => (await getFundsButton.isVisible()) || (await topUpButton.isVisible()), {
-      timeout: 90000,
-    })
-    .toBe(true)
+  const initialAction = await waitForEnabledAction([
+    { locator: getFundsButton, name: 'fund' },
+    { locator: topUpButton, name: 'top-up' },
+  ])
 
-  if (await getFundsButton.isVisible()) {
-    await getFundsButton.click()
-    await expect(topUpButton).toBeVisible({ timeout: 90000 })
+  if (initialAction.name === 'fund') {
+    await initialAction.locator.click()
+    await expect(topUpButton).toBeEnabled({ timeout: 90000 })
   }
 
-  if (await topUpButton.isVisible()) {
+  if ((await topUpButton.isVisible()) && (await topUpButton.isEnabled())) {
     await topUpButton.click()
   }
 

--- a/src/components/guides/Demo.tsx
+++ b/src/components/guides/Demo.tsx
@@ -17,9 +17,9 @@ import LucideWalletCards from '~icons/lucide/wallet-cards'
 import { cva, cx } from '../../../cva.config'
 import { usePostHogTracking } from '../../lib/posthog'
 import {
-  getZoneTransportConfig,
+  getZoneRpcHttpUrl,
+  getZoneRpcTransportConfig,
   moderatoZoneRpcUrls,
-  stripRpcBasicAuth,
 } from '../../lib/private-zones.ts'
 import { useRootWebAuthnAccount } from '../../lib/useRootWebAuthnAccount.ts'
 import { useTempoWalletConnector, useWebAuthnConnector } from '../../wagmi.config'
@@ -307,8 +307,8 @@ export namespace Container {
               account: rootWebAuthnAccount,
               chain: zoneModerato(zone),
               transport: zoneHttp(
-                stripRpcBasicAuth(zoneRpcUrl),
-                getZoneTransportConfig(zoneRpcUrl),
+                getZoneRpcHttpUrl(zone, zoneRpcUrl),
+                getZoneRpcTransportConfig(zone, zoneRpcUrl),
               ),
             }).extend(tempoActions()) as unknown as ZoneClientLike)
           : undefined,

--- a/src/components/guides/zones/DepositToZone.tsx
+++ b/src/components/guides/zones/DepositToZone.tsx
@@ -7,9 +7,9 @@ import { http as zoneHttp, zoneModerato } from 'viem/tempo/zones'
 import { useConnection, useConnectorClient, usePublicClient } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import {
-  getZoneTransportConfig,
+  getZoneRpcHttpUrl,
+  getZoneRpcTransportConfig,
   moderatoZoneRpcUrls,
-  stripRpcBasicAuth,
 } from '../../../lib/private-zones.ts'
 import { useRootWebAuthnAccount } from '../../../lib/useRootWebAuthnAccount.ts'
 import { useZoneAuthorization, type ZoneAuthClientLike } from '../../../lib/useZoneAuthorization.ts'
@@ -92,8 +92,8 @@ function ConnectedZoneFlow(props: { address: Hex; mode: DepositMode }) {
             account: rootWebAuthnAccount,
             chain: zoneModerato(ZONE_ID),
             transport: zoneHttp(
-              stripRpcBasicAuth(moderatoZoneRpcUrls[ZONE_ID]),
-              getZoneTransportConfig(moderatoZoneRpcUrls[ZONE_ID]),
+              getZoneRpcHttpUrl(ZONE_ID, moderatoZoneRpcUrls[ZONE_ID]),
+              getZoneRpcTransportConfig(ZONE_ID, moderatoZoneRpcUrls[ZONE_ID]),
             ),
           }).extend(tempoActions()) as unknown as ZoneClientLike)
         : undefined,

--- a/src/components/guides/zones/SendTokensAcrossZones.tsx
+++ b/src/components/guides/zones/SendTokensAcrossZones.tsx
@@ -7,10 +7,10 @@ import { http as zoneHttp, zoneModerato } from 'viem/tempo/zones'
 import { useConnection, useConnectorClient, usePublicClient } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import {
-  getZoneTransportConfig,
+  getZoneRpcHttpUrl,
+  getZoneRpcTransportConfig,
   publicSettlementLookbackBlocks,
   routerCallbackGasLimit,
-  stripRpcBasicAuth,
   swapAndDepositRouter,
   ZONE_A,
   ZONE_B,
@@ -115,8 +115,8 @@ function ConnectedZoneFlow(props: { address: Hex }) {
             account: rootWebAuthnAccount,
             chain: zoneModerato(ZONE_A.id),
             transport: zoneHttp(
-              stripRpcBasicAuth(ZONE_A.rpcUrl),
-              getZoneTransportConfig(ZONE_A.rpcUrl),
+              getZoneRpcHttpUrl(ZONE_A.id, ZONE_A.rpcUrl),
+              getZoneRpcTransportConfig(ZONE_A.id, ZONE_A.rpcUrl),
             ),
           }).extend(tempoActions()) as unknown as ZoneClientLike)
         : undefined,
@@ -129,8 +129,8 @@ function ConnectedZoneFlow(props: { address: Hex }) {
             account: rootWebAuthnAccount,
             chain: zoneModerato(ZONE_B.id),
             transport: zoneHttp(
-              stripRpcBasicAuth(ZONE_B.rpcUrl),
-              getZoneTransportConfig(ZONE_B.rpcUrl),
+              getZoneRpcHttpUrl(ZONE_B.id, ZONE_B.rpcUrl),
+              getZoneRpcTransportConfig(ZONE_B.id, ZONE_B.rpcUrl),
             ),
           }).extend(tempoActions()) as unknown as ZoneClientLike)
         : undefined,

--- a/src/components/guides/zones/SendTokensWithinZone.tsx
+++ b/src/components/guides/zones/SendTokensWithinZone.tsx
@@ -7,9 +7,9 @@ import { http as zoneHttp, zoneModerato } from 'viem/tempo/zones'
 import { useConnection, useConnectorClient } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import {
-  getZoneTransportConfig,
+  getZoneRpcHttpUrl,
+  getZoneRpcTransportConfig,
   moderatoZoneRpcUrls,
-  stripRpcBasicAuth,
 } from '../../../lib/private-zones.ts'
 import { useRootWebAuthnAccount } from '../../../lib/useRootWebAuthnAccount.ts'
 import { useZoneAuthorization, type ZoneAuthClientLike } from '../../../lib/useZoneAuthorization.ts'
@@ -75,8 +75,8 @@ function ConnectedZoneFlow(props: { address: Hex }) {
             account: rootWebAuthnAccount,
             chain: zoneModerato(ZONE_ID),
             transport: zoneHttp(
-              stripRpcBasicAuth(moderatoZoneRpcUrls[ZONE_ID]),
-              getZoneTransportConfig(moderatoZoneRpcUrls[ZONE_ID]),
+              getZoneRpcHttpUrl(ZONE_ID, moderatoZoneRpcUrls[ZONE_ID]),
+              getZoneRpcTransportConfig(ZONE_ID, moderatoZoneRpcUrls[ZONE_ID]),
             ),
           }).extend(tempoActions()) as unknown as ZoneClientLike)
         : undefined,

--- a/src/components/guides/zones/SwapAcrossZones.tsx
+++ b/src/components/guides/zones/SwapAcrossZones.tsx
@@ -7,12 +7,12 @@ import { http as zoneHttp, zoneModerato } from 'viem/tempo/zones'
 import { useConnection, useConnectorClient, usePublicClient } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import {
-  getZoneTransportConfig,
+  getZoneRpcHttpUrl,
+  getZoneRpcTransportConfig,
   moderatoZoneFactory,
   publicSettlementLookbackBlocks,
   routerCallbackGasLimit,
   stablecoinDex,
-  stripRpcBasicAuth,
   swapAndDepositRouter,
   ZONE_A,
   ZONE_B,
@@ -135,8 +135,8 @@ function ConnectedZoneFlow(props: { address: Hex }) {
             account: rootWebAuthnAccount,
             chain: zoneModerato(ZONE_A.id),
             transport: zoneHttp(
-              stripRpcBasicAuth(ZONE_A.rpcUrl),
-              getZoneTransportConfig(ZONE_A.rpcUrl),
+              getZoneRpcHttpUrl(ZONE_A.id, ZONE_A.rpcUrl),
+              getZoneRpcTransportConfig(ZONE_A.id, ZONE_A.rpcUrl),
             ),
           }).extend(tempoActions()) as unknown as ZoneClientLike)
         : undefined,
@@ -149,8 +149,8 @@ function ConnectedZoneFlow(props: { address: Hex }) {
             account: rootWebAuthnAccount,
             chain: zoneModerato(ZONE_B.id),
             transport: zoneHttp(
-              stripRpcBasicAuth(ZONE_B.rpcUrl),
-              getZoneTransportConfig(ZONE_B.rpcUrl),
+              getZoneRpcHttpUrl(ZONE_B.id, ZONE_B.rpcUrl),
+              getZoneRpcTransportConfig(ZONE_B.id, ZONE_B.rpcUrl),
             ),
           }).extend(tempoActions()) as unknown as ZoneClientLike)
         : undefined,

--- a/src/components/guides/zones/WithdrawFromZone.tsx
+++ b/src/components/guides/zones/WithdrawFromZone.tsx
@@ -7,10 +7,10 @@ import { http as zoneHttp, zoneModerato } from 'viem/tempo/zones'
 import { useConnection, useConnectorClient, usePublicClient } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import {
-  getZoneTransportConfig,
+  getZoneRpcHttpUrl,
+  getZoneRpcTransportConfig,
   moderatoZoneRpcUrls,
   publicSettlementLookbackBlocks,
-  stripRpcBasicAuth,
   zoneRpcSyncTimeout,
 } from '../../../lib/private-zones.ts'
 import { useRootWebAuthnAccount } from '../../../lib/useRootWebAuthnAccount.ts'
@@ -110,8 +110,8 @@ function ConnectedZoneFlow(props: { address: Hex; mode: WithdrawalMode }) {
             account: rootWebAuthnAccount,
             chain: zoneModerato(ZONE_ID),
             transport: zoneHttp(
-              stripRpcBasicAuth(moderatoZoneRpcUrls[ZONE_ID]),
-              getZoneTransportConfig(moderatoZoneRpcUrls[ZONE_ID]),
+              getZoneRpcHttpUrl(ZONE_ID, moderatoZoneRpcUrls[ZONE_ID]),
+              getZoneRpcTransportConfig(ZONE_ID, moderatoZoneRpcUrls[ZONE_ID]),
             ),
           }).extend(tempoActions()) as unknown as ZoneClientLike)
         : undefined,

--- a/src/lib/private-zones.ts
+++ b/src/lib/private-zones.ts
@@ -98,6 +98,22 @@ export function getZoneTransportConfig(rpcUrl: string): ZoneTransportConfig | un
   }
 }
 
+export function getZoneRpcHttpUrl(zoneId: number, rpcUrl: string) {
+  const location = (globalThis as { location?: { origin: string } }).location
+
+  if (import.meta.env.VITE_E2E === 'true' && zoneId in moderatoZoneRpcUrls && location) {
+    return `${location.origin}/__e2e_zone_rpc/${zoneId}`
+  }
+
+  return stripRpcBasicAuth(rpcUrl)
+}
+
+export function getZoneRpcTransportConfig(zoneId: number, rpcUrl: string) {
+  if (import.meta.env.VITE_E2E === 'true' && zoneId in moderatoZoneRpcUrls) return undefined
+
+  return getZoneTransportConfig(rpcUrl)
+}
+
 function encodeBase64(value: string) {
   if (typeof globalThis.btoa === 'function') return globalThis.btoa(value)
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,6 +75,35 @@ function escapeAngleBrackets(source: string): string {
   return result.join('\n')
 }
 
+function quoteTipFrontmatterFields(source: string): string {
+  if (!source.startsWith('---\n')) return source
+
+  return source.replace(/^---\n([\s\S]*?)\n---/, (_, frontmatter: string) => {
+    const fieldsToQuote = new Set(['authors'])
+    const normalized = frontmatter
+      .split('\n')
+      .map((line) => {
+        const match = /^([A-Za-z][\w-]*):\s*(.+)$/.exec(line)
+        if (!match || !fieldsToQuote.has(match[1])) return line
+
+        const value = match[2].trim()
+        if (
+          value.startsWith('"') ||
+          value.startsWith("'") ||
+          value.startsWith('[') ||
+          value.startsWith('{')
+        ) {
+          return line
+        }
+
+        return `${match[1]}: ${JSON.stringify(value)}`
+      })
+      .join('\n')
+
+    return `---\n${normalized}\n---`
+  })
+}
+
 function syncTips(): Plugin {
   const repo = 'tempoxyz/tempo'
   const outputDir = 'src/pages/protocol/tips'
@@ -105,11 +134,7 @@ function syncTips(): Plugin {
         // files are no longer published, so keeping the link would surface dead
         // references in the docs UI and fail Vocs' dead-link checker.
         content = content.replace(
-          /^- \[[^\]]+\.sol\]\(tips\/(?:ref-impls|verify)\/src\/interfaces\/[^)]+\)\n/gm,
-          '',
-        )
-        content = content.replace(
-          /\[([^\]]+\.sol)\]\(tips\/(?:ref-impls|verify)\/src\/interfaces\/[^)]+\)/g,
+          /\[([^\]]+)\]\((?:tips\/)?(?:ref-impls|verify)\/src\/[^)]+\.sol\)/g,
           '$1',
         )
         // tip-0000 links to `./tip_template.md`, which lives in the tempo
@@ -120,7 +145,8 @@ function syncTips(): Plugin {
         )
         // Rewrite inter-TIP links from ./tip-NNNN.md to ./tip-NNNN (synced as .mdx,
         // Vocs resolves extensionless paths).
-        content = content.replace(/\(\.\/tip-(\d+)\.md\)/g, '(./tip-$1)')
+        content = content.replace(/\((?:\.\/)?tip-(\d+)\.md\)/g, '(./tip-$1)')
+        content = quoteTipFrontmatterFields(content)
         // Escape angle brackets outside of code blocks/inline code so MDX doesn't
         // treat them as JSX (e.g. `Mapping<B256, bool>` in prose).
         content = escapeAngleBrackets(content)
@@ -134,6 +160,9 @@ function syncTips(): Plugin {
 
   return {
     name: 'sync-tips',
+    async configResolved() {
+      await sync()
+    },
     async buildStart() {
       await sync()
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { Instance } from 'prool'
 import { defineConfig, loadEnv, type Plugin } from 'vite'
 import mkcert from 'vite-plugin-mkcert'
 import { vocs } from 'vocs/vite'
+import { moderatoZoneRpcUrls } from './src/lib/private-zones.ts'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
@@ -15,15 +16,42 @@ export default defineConfig(({ mode }) => {
 
   const useHttp = process.env.CI === 'true' || process.env.VITE_USE_HTTP === 'true'
 
+  const e2eZoneProxy = env.VITE_E2E === 'true' ? getE2EZoneProxy() : undefined
+
   return {
     plugins: [syncTips(), vocs(), react(), ...(useHttp ? [] : [mkcert()]), tempoNode()],
     server: useHttp
       ? {
           host: 'localhost',
+          proxy: e2eZoneProxy,
         }
       : undefined,
   }
 })
+
+function getE2EZoneProxy() {
+  return Object.fromEntries(
+    Object.entries(moderatoZoneRpcUrls).map(([zoneId, rpcUrl]) => {
+      const parsedUrl = new URL(rpcUrl)
+      const authorization = `Basic ${Buffer.from(
+        `${decodeURIComponent(parsedUrl.username)}:${decodeURIComponent(parsedUrl.password)}`,
+      ).toString('base64')}`
+      parsedUrl.username = ''
+      parsedUrl.password = ''
+
+      return [
+        `/__e2e_zone_rpc/${zoneId}`,
+        {
+          changeOrigin: true,
+          headers: { authorization },
+          rewrite: () => '/',
+          secure: true,
+          target: parsedUrl.toString(),
+        },
+      ]
+    }),
+  )
+}
 
 function tempoNode(): Plugin {
   return {


### PR DESCRIPTION
## Summary

Stabilize private-zone E2E flows by routing authenticated zone RPC through the Vite dev server in E2E mode and waiting for enabled action buttons before clicking.