### PR TITLE
docs: rename sidebar 'Connect to Zones' to 'Private Transactions'

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -226,7 +226,7 @@ export default defineConfig({
             ],
           },
           {
-            text: 'Connect to Zones',
+            text: 'Private Transactions',
             collapsed: true,
             items: [
               {


### PR DESCRIPTION
Renames the sidebar item under **Build on Tempo** from "Connect to Zones" to "Private Transactions" for clarity — users want to transact privately, not "connect to a zone."