### PR TITLE
docs: add explicit local NVMe storage requirement for validators

### DIFF
--- a/src/pages/guide/node/system-requirements.mdx
+++ b/src/pages/guide/node/system-requirements.mdx
@@ -8,6 +8,10 @@ These are the minimum and recommended system requirements for running a validato
 It is likely, that the nodes will not require as much resources at the beginning of the chain,
 but we still highly recommend to follow the recommended specifications. This will allow for future growth and scalability.
 
+:::danger[Storage requirement]
+Validators must run on local NVMe / direct-attached storage. Network-attached volumes (EBS, GCP Persistent Disk, Azure Managed Disk, NAS, SAN) are **not supported**.
+:::
+
 Consensus state can live on a lower performance volume (for example, EBS), but execution state needs NVMe storage.
 If you want to separate them, use `--datadir` for execution data and `--consensus.datadir` for consensus data.
 

--- a/src/pages/guide/node/system-requirements.mdx
+++ b/src/pages/guide/node/system-requirements.mdx
@@ -8,8 +8,8 @@ These are the minimum and recommended system requirements for running a validato
 It is likely, that the nodes will not require as much resources at the beginning of the chain,
 but we still highly recommend to follow the recommended specifications. This will allow for future growth and scalability.
 
-:::danger[Storage requirement]
-Validators must run on local NVMe / direct-attached storage. Network-attached volumes (EBS, GCP Persistent Disk, Azure Managed Disk, NAS, SAN) are **not supported**.
+:::danger[Execution storage requirement]
+Validators must run execution state on local NVMe / direct-attached storage. Network-attached volumes (EBS, GCP Persistent Disk, Azure Managed Disk, NAS, SAN) are **not supported** for execution.
 :::
 
 Consensus state can live on a lower performance volume (for example, EBS), but execution state needs NVMe storage.


### PR DESCRIPTION
Adds a prominent `danger` callout to the System Requirements page making the local NVMe storage requirement explicit:

> **Validators must run on local NVMe / direct-attached storage.** Network-attached volumes (EBS, GCP Persistent Disk, Azure Managed Disk, NAS, SAN) are not supported.

The existing warning about network-attached storage (line ~43) uses softer language; this adds an unmissable callout at the top of the page.