### PR TITLE
docs: update flip orders + tokenlist for T5 (TIP-1030, TIP-1056, TIP-1026)

### DIFF
--- a/src/pages/protocol/exchange/providing-liquidity.mdx
+++ b/src/pages/protocol/exchange/providing-liquidity.mdx
@@ -79,11 +79,12 @@ function placeFlip(
 **Parameters:**
 - All parameters from `place()`, plus:
 - `flipTick` - The price where the order will flip to when filled
-  - Must be greater than `tick` if `isBid` is true
-  - Must be less than `tick` if `isBid` is false
+  - Must be greater than or equal to `tick` if `isBid` is true
+  - Must be less than or equal to `tick` if `isBid` is false
+  - `flipTick == tick` is allowed after the [T5 network upgrade](/protocol/upgrades/t5) ([TIP-1030](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1030.md)) — useful for pegged pairs where you want to buy and sell at the same tick
 
 **Returns:**
-- `orderId` - Unique identifier for this flip order
+- `orderId` - Unique identifier for this flip order. The same `orderId` is reused across every flip of the order's lifetime ([TIP-1056](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1056.md))
 
 **Example: Place a flip order providing liquidity on both sides**
 ```solidity
@@ -99,13 +100,22 @@ uint128 orderId = exchange.placeFlip(
 
 When this order is completely filled:
 1. You buy 1000 USDG at $0.9990
-2. A new order automatically sells 1000 USDG at $1.0010
-3. When that fills, it flips back to a bid at $0.9990
+2. The same order is rewritten in place to sell 1000 USDG at $1.0010 — the `orderId` does not change, and an `OrderFlipped` event is emitted (not `OrderPlaced`)
+3. When that side fills, the order flips back to a bid at $0.9990 — again, same `orderId`, another `OrderFlipped` event
 4. This continues indefinitely, earning the spread each time
 
 :::info
 Flip orders act like a liquidity pool position, automatically providing liquidity on both sides of the market as they're filled back and forth.
 :::
+
+#### Tracking flip orders
+
+Indexers, analytics, and order-tracking UIs should follow a flip order by its persistent `orderId`:
+
+- **Before T5:** each fill emitted `OrderFilled` followed by `OrderPlaced` for the new opposite-side order with a freshly allocated `orderId`. One logical flip strategy looked like a chain of unrelated orders that had to be stitched together off-chain.
+- **After T5:** each fill emits `OrderFilled` followed by `OrderFlipped(orderId, newSide, newTick, ...)`. The `orderId` is unchanged, no new id is allocated, and `nextOrderId` does not advance.
+
+If your indexer currently keys order state by `(orderId)` and assumes each `orderId` represents a single side, update it to handle `OrderFlipped` and let a single `orderId` change side and tick over its lifetime. See the [compatibility section of TIP-1056](https://tips.sh/1056#compatibility) for migration guidance.
 
 ## Understanding Ticks
 
@@ -152,7 +162,7 @@ Orders follow a specific lifecycle:
 2. **Filling**: As market orders execute against your order:
    - Your order fills partially or completely
    - Proceeds are credited to your DEX balance
-   - If a flip order fills completely, a new order is immediately created on the opposite side
+   - If a flip order fills completely, the same order is rewritten in place on the opposite side, keeping its `orderId` and emitting `OrderFlipped` (after the [T5 network upgrade](/protocol/upgrades/t5); pre-T5, a new order with a new `orderId` was created and `OrderPlaced` was emitted)
 
 ## Cancelling Orders
 

--- a/src/pages/quickstart/tokenlist.mdx
+++ b/src/pages/quickstart/tokenlist.mdx
@@ -31,6 +31,49 @@ As an example, here's Tempo's tokenlist, fetched from [tokenlist.tempo.xyz/list/
 
 ## Adding a New Token
 
+There are two ways to publish token metadata on Tempo:
+
+| | On-chain (`logoURI`) | This registry |
+|---|---|---|
+| Available | T5+ | Today |
+| What you get | Icon readable directly from the token contract | Canonical metadata + icon recognized by tokenlist consumers and the Explorer |
+| Best for | Issuers who only need an icon and want full self-custody of it | Tokens that need `coingeckoId`, `bridgeInfo`, display `label`, or a fallback icon for clients that don't yet read on-chain `logoURI` |
+
+Most issuers will want both: set `logoURI` on-chain so any wallet or explorer can render the icon without registry lookup, and register here for the richer metadata extensions.
+
+### Setting `logoURI` on-chain (T5+)
+
+After the [T5 network upgrade](/protocol/upgrades/t5), every TIP-20 exposes an optional on-chain `logoURI` field ([TIP-1026](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1026.md)). Set it at creation via the new 7-arg `createToken` overload on the factory:
+
+```solidity
+function createToken(
+    string calldata name,
+    string calldata symbol,
+    string calldata currency,
+    address quoteToken,
+    address admin,
+    bytes32 salt,
+    string calldata logoURI
+) external returns (address);
+```
+
+Or update it later on a deployed token via the admin-only setter (requires `DEFAULT_ADMIN_ROLE`):
+
+```solidity
+function setLogoURI(string calldata newLogoURI) external;
+```
+
+Either path emits `LogoURIUpdated(address indexed updater, string newLogoURI)` from the **token's own address** (not the factory) with `updater = msg.sender`. Wallets and explorers can read the current value from any TIP-20 via `logoURI() returns (string memory)`.
+
+**Field rules:**
+
+- String, max 256 bytes — reverts `LogoURITooLong` otherwise
+- If non-empty, must be a syntactically valid URI with a scheme in the allowlist `https`, `http`, `ipfs`, `data` (case-insensitive) — reverts `InvalidLogoURI` otherwise
+- Empty string is valid and clears the field
+- Same SVG / square aspect / minimal-whitespace recommendations as the [Icon Requirements](#icon-requirements) below
+
+### Registering in the tokenlist
+
 1. **Fork** [tempoxyz/tempo-apps](https://github.com/tempoxyz/tempo-apps)
 
 2. **Add token** to `data/<chain_id>/tokenlist.json` in `apps/tokenlist`:


### PR DESCRIPTION
**Draft — do not merge until T5 is active on Moderato.**

Follow-up to #405. Updates the public DEX flip-order docs and the token onboarding guide to reflect T5 behavior. Held as draft so the docs go live alongside the activation rather than ahead of it.

## Files changed

### `src/pages/protocol/exchange/providing-liquidity.mdx`

- **Flip Orders section:**
  - `flipTick == tick` is now allowed (TIP-1030); validation rules updated from strictly greater/less to greater-or-equal / less-or-equal, with a note about the pegged-pairs use case
  - `orderId` description clarifies the same id is reused across every flip (TIP-1056)
  - Walkthrough rewritten: filled flip orders are rewritten in place and emit `OrderFlipped` (not `OrderPlaced`) — the `orderId` does not change
  - New "Tracking flip orders" subsection with explicit before-T5 vs after-T5 indexer guidance and a link to the [TIP-1056 compatibility section](https://tips.sh/1056#compatibility)
- **Order Execution Timeline:** updated the flip-order step to describe in-place rewrite + `OrderFlipped`, with a parenthetical noting the pre-T5 behavior

### `src/pages/quickstart/tokenlist.mdx`

- "Adding a New Token" now opens with a comparison table covering the two paths (on-chain `logoURI` vs registry) and recommends doing both
- New "Setting `logoURI` on-chain (T5+)" subsection with the verified TIP-1026 ABI: 7-arg `createToken` overload, `setLogoURI`, `LogoURIUpdated` (emitted from token's own address), `logoURI()` view, plus on-chain validation rules (256-byte cap, scheme allowlist `https`/`http`/`ipfs`/`data`, empty-string-clears-field)
- Existing registry steps preserved under a "Registering in the tokenlist" subheading; Token Extensions and Icon Requirements unchanged
- The `#adding-a-new-token` anchor is preserved so external links (including the one in `t5.mdx` from #405) keep working

## Verification

- `pnpm run check` runs clean (3 pre-existing warnings in `scripts/lighthouse.ts`, unrelated)
- TIP-1026 ABI signatures verified against [`tempoxyz/tempo` `tips/tip-1026.md`](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1026.md)

## Sequencing

Per the T5 rollout plan, this PR will be marked ready for review and merged after T5 activates on Moderato (June 3, 2026 4pm CEST per #405). Until then it sits as a draft.
