### PR TITLE
docs: document TempoOFTWrapper as recommended bridge-out flow

### DIFF
--- a/src/pages/guide/bridge-layerzero.mdx
+++ b/src/pages/guide/bridge-layerzero.mdx
@@ -287,7 +287,8 @@ cast send 0x20C000000000000000000000b9537d11c60E8b50 \
   'approve(address,uint256)' \
   0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0 \
   $((<AMOUNT> + <NATIVE_FEE>)) \
-  --rpc-url https://rpc.tempo.xyz --private-key $PRIVATE_KEY
+  --rpc-url https://rpc.tempo.xyz \
+  --private-key $PRIVATE_KEY
 ```
 
 One approval covers both the bridge amount and the fee since they share the same token. Use a max approval if you bridge frequently.
@@ -301,10 +302,19 @@ cast send 0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0 \
   0x20C000000000000000000000b9537d11c60E8b50 \
   "(30184,$(cast abi-encode 'f(address)' <DESTINATION_ADDRESS>),<AMOUNT>,<MIN_AMOUNT>,0x,0x,0x)" \
   <NATIVE_FEE> \
-  --rpc-url https://rpc.tempo.xyz --private-key $PRIVATE_KEY
+  --rpc-url https://rpc.tempo.xyz \
+  --private-key $PRIVATE_KEY
 ```
 
-`<NATIVE_FEE>` here is `maxNativeFee` — the call reverts if the fee at execution exceeds this. Track delivery at `https://scan.layerzero-api.com/v1/messages/tx/<TX_HASH>`.
+`<NATIVE_FEE>` here is `maxNativeFee` — the call reverts if the fee at execution exceeds this.
+
+### Verify transaction status
+
+Track delivery to the destination chain via the LayerZero scan API:
+
+```text
+https://scan.layerzero-api.com/v1/messages/tx/<TX_HASH>
+```
 
 :::::
 

--- a/src/pages/guide/bridge-layerzero.mdx
+++ b/src/pages/guide/bridge-layerzero.mdx
@@ -32,12 +32,15 @@ See the full token list at [tokenlist.tempo.xyz](https://tokenlist.tempo.xyz/lis
 
 ## LayerZero contracts on Tempo
 
-| Contract | Address |
-|----------|---------|
-| **EndpointV2** | [`0x20Bb7C2E2f4e5ca2B4c57060d1aE2615245dCc9C`](https://explore.tempo.xyz/address/0x20Bb7C2E2f4e5ca2B4c57060d1aE2615245dCc9C) |
-| **LZEndpointDollar** | [`0x0cEb237E109eE22374a567c6b09F373C73FA4cBb`](https://explore.tempo.xyz/address/0x0cEb237E109eE22374a567c6b09F373C73FA4cBb) |
+| Contract | Address | Purpose |
+|----------|---------|---------|
+| **EndpointV2** | [`0x20Bb7C2E2f4e5ca2B4c57060d1aE2615245dCc9C`](https://explore.tempo.xyz/address/0x20Bb7C2E2f4e5ca2B4c57060d1aE2615245dCc9C) | Standard LayerZero endpoint |
+| **LZEndpointDollar** | [`0x0cEb237E109eE22374a567c6b09F373C73FA4cBb`](https://explore.tempo.xyz/address/0x0cEb237E109eE22374a567c6b09F373C73FA4cBb) | Routes messaging fees through a stablecoin (no `msg.value` on Tempo). See [EndpointDollar](#endpointdollar). |
+| **TempoOFTWrapper** | [`0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0`](https://explore.tempo.xyz/address/0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0) | Bundles wrap, approve, and send into one transaction for outbound bridging. See [Bridge from Tempo](#bridge-from-tempo). |
 
 Tempo's LayerZero Endpoint ID is **`30410`**.
+
+Accepted fee tokens for `LZEndpointDollar`: `USDC.e`, `USDT0`, `pathUSD` (whitelisted 6-decimal stablecoins).
 
 ## Stargate tokens
 

--- a/src/pages/guide/bridge-layerzero.mdx
+++ b/src/pages/guide/bridge-layerzero.mdx
@@ -260,23 +260,11 @@ await walletClient.writeContract({
 
 ## Bridge from Tempo
 
-To bridge from Tempo back to another chain, call `sendToken` on the Stargate OFT contract on Tempo. The process is similar to bridging in - quote, approve, send - but includes additional steps to prepare the messaging fee.
-
-Because Tempo has no native gas token, LayerZero messaging fees are paid in a whitelisted stablecoin via [LZEndpointDollar](#endpointdollar). The fee token must be `USDC.e`, `USDT0`, or `pathUSD`. There are two ways to send: the **TempoOFTWrapper** (recommended, 2 transactions) or the **manual flow** (5 transactions). Both produce identical on-chain results.
-
-### Recommended: TempoOFTWrapper
-
-The [`TempoOFTWrapper`](https://docs.layerzero.network/v2/developers/tempo/how-to/support-ofts-and-oapps) bundles wrapping, approvals, and sending into a single transaction.
-
-| Contract | Address |
-|----------|---------|
-| **TempoOFTWrapper** | [`0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0`](https://explore.tempo.xyz/address/0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0) |
-
-`sendOFT` atomically wraps the fee portion of your stablecoin into LZD, approves LZD to the OFT, and calls `send()`. If the re-quoted fee at execution time exceeds `maxNativeFee`, the entire transaction reverts.
+Use [`TempoOFTWrapper`](https://explore.tempo.xyz/address/0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0) (`0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0`). It pulls your stablecoin, wraps the fee portion into LZD, and calls `send()` on the OFT in a single transaction. Pay fees in `USDC.e`, `USDT0`, or `pathUSD`.
 
 #### Using cast (Foundry)
 
-This example bridges USDC.e from Tempo to Base, paying fees in USDC.e.
+This example bridges USDC.e from Tempo to Base.
 
 :::::steps
 
@@ -290,22 +278,21 @@ cast call 0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
   --rpc-url https://rpc.tempo.xyz
 ```
 
-Take the first returned number as `<NATIVE_FEE>` (in stablecoin units, not ETH).
+The first returned number is `<NATIVE_FEE>` in stablecoin units.
 
-### Approve the fee token to the wrapper
-
-When the bridge token and fee token are the same (both USDC.e here), approve `<AMOUNT> + <NATIVE_FEE>` in a single call. If they differ (e.g., bridging EURC.e but paying fees in USDC.e), approve each separately.
+### Approve USDC.e to the wrapper
 
 ```bash
 cast send 0x20C000000000000000000000b9537d11c60E8b50 \
   'approve(address,uint256)' \
   0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0 \
   $((<AMOUNT> + <NATIVE_FEE>)) \
-  --rpc-url https://rpc.tempo.xyz \
-  --private-key $PRIVATE_KEY
+  --rpc-url https://rpc.tempo.xyz --private-key $PRIVATE_KEY
 ```
 
-### Send via the wrapper
+One approval covers both the bridge amount and the fee since they share the same token. Use a max approval if you bridge frequently.
+
+### Send
 
 ```bash
 cast send 0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0 \
@@ -314,42 +301,30 @@ cast send 0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0 \
   0x20C000000000000000000000b9537d11c60E8b50 \
   "(30184,$(cast abi-encode 'f(address)' <DESTINATION_ADDRESS>),<AMOUNT>,<MIN_AMOUNT>,0x,0x,0x)" \
   <NATIVE_FEE> \
-  --rpc-url https://rpc.tempo.xyz \
-  --private-key $PRIVATE_KEY
+  --rpc-url https://rpc.tempo.xyz --private-key $PRIVATE_KEY
 ```
 
-The fourth argument is `maxNativeFee` - the maximum messaging fee you accept. The call reverts if the re-quoted fee at execution exceeds this value.
-
-### Verify transaction status
-
-```text
-https://scan.layerzero-api.com/v1/messages/tx/<SOURCE_TX_HASH>
-```
+`<NATIVE_FEE>` here is `maxNativeFee` — the call reverts if the fee at execution exceeds this. Track delivery at `https://scan.layerzero-api.com/v1/messages/tx/<TX_HASH>`.
 
 :::::
 
 #### Using TypeScript (viem)
 
 ```typescript
-import { createWalletClient, createPublicClient, http, parseUnits, pad } from 'viem'
+import { createWalletClient, createPublicClient, http, parseUnits, pad, parseAbi } from 'viem'
 import { tempo } from 'viem/chains'
 import { privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount('0x...')
-
 const walletClient = createWalletClient({ account, chain: tempo, transport: http() })
 const publicClient = createPublicClient({ chain: tempo, transport: http() })
 
-// Stargate OFT for USDC.e on Tempo
-const stargateOFT = '0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392' as const
-// USDC.e on Tempo (bridge token + fee token)
+const oft = '0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392' as const // Stargate USDC.e
 const usdce = '0x20C000000000000000000000b9537d11c60E8b50' as const
-// TempoOFTWrapper
 const wrapper = '0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0' as const
 
-const amount = parseUnits('1', 6) // 1 USDC.e
-const minAmount = parseUnits('0.99', 6) // 1% slippage tolerance
-
+const amount = parseUnits('1', 6)
+const minAmount = parseUnits('0.99', 6)
 const sendParam = {
   dstEid: 30184, // Base
   to: pad(account.address),
@@ -360,96 +335,31 @@ const sendParam = {
   oftCmd: '0x' as const,
 }
 
-const wrapperAbi = [
-  {
-    name: 'sendOFT',
-    type: 'function',
-    stateMutability: 'nonpayable',
-    inputs: [
-      { name: 'oft', type: 'address' },
-      { name: 'feeToken', type: 'address' },
-      {
-        name: 'sendParam',
-        type: 'tuple',
-        components: [
-          { name: 'dstEid', type: 'uint32' },
-          { name: 'to', type: 'bytes32' },
-          { name: 'amountLD', type: 'uint256' },
-          { name: 'minAmountLD', type: 'uint256' },
-          { name: 'extraOptions', type: 'bytes' },
-          { name: 'composeMsg', type: 'bytes' },
-          { name: 'oftCmd', type: 'bytes' },
-        ],
-      },
-      { name: 'maxNativeFee', type: 'uint256' },
-    ],
-    outputs: [
-      {
-        name: 'msgReceipt',
-        type: 'tuple',
-        components: [
-          { name: 'guid', type: 'bytes32' },
-          { name: 'nonce', type: 'uint64' },
-          {
-            name: 'fee',
-            type: 'tuple',
-            components: [
-              { name: 'nativeFee', type: 'uint256' },
-              { name: 'lzTokenFee', type: 'uint256' },
-            ],
-          },
-        ],
-      },
-      {
-        name: 'oftReceipt',
-        type: 'tuple',
-        components: [
-          { name: 'amountSentLD', type: 'uint256' },
-          { name: 'amountReceivedLD', type: 'uint256' },
-        ],
-      },
-    ],
-  },
-] as const
+const wrapperAbi = parseAbi([
+  'function sendOFT(address oft, address feeToken, (uint32 dstEid, bytes32 to, uint256 amountLD, uint256 minAmountLD, bytes extraOptions, bytes composeMsg, bytes oftCmd) sendParam, uint256 maxNativeFee)',
+])
 
-// 1. Quote the fee
+// 1. Quote
 const msgFee = await publicClient.readContract({
-  address: stargateOFT,
-  abi: stargateAbi, // same ABI as the manual flow
-  functionName: 'quoteSend',
-  args: [sendParam, false],
+  address: oft, abi: stargateAbi, functionName: 'quoteSend', args: [sendParam, false],
 })
 
-// 2. Approve USDC.e to the wrapper (bridge amount + messaging fee)
+// 2. Approve USDC.e to wrapper (bridge amount + fee)
 await walletClient.writeContract({
-  address: usdce,
-  abi: erc20Abi,
-  functionName: 'approve',
+  address: usdce, abi: erc20Abi, functionName: 'approve',
   args: [wrapper, amount + msgFee.nativeFee],
 })
 
-// 3. Send via wrapper (atomic wrap + approve + send)
+// 3. Send (wrap + approve + send happen atomically inside)
 await walletClient.writeContract({
-  address: wrapper,
-  abi: wrapperAbi,
-  functionName: 'sendOFT',
-  args: [stargateOFT, usdce, sendParam, msgFee.nativeFee],
+  address: wrapper, abi: wrapperAbi, functionName: 'sendOFT',
+  args: [oft, usdce, sendParam, msgFee.nativeFee],
 })
 ```
 
 :::warning
-**Do not use the wrapper for compose messages where the composer refunds the original sender.** The wrapper becomes `msg.sender` for the OFT call, so refunds are sent to the wrapper address - not the user - and funds will be permanently lost. Use the manual flow below for those cases.
+**Do not use the wrapper for compose messages that refund `msg.sender`.** Refunds go to the wrapper, not your wallet, and are lost. For that case call the OFT directly — see [LayerZero's direct flow](https://docs.layerzero.network/v2/developers/tempo/how-to/support-ofts-and-oapps#direct-flow-1-view-call-5-transactions).
 :::
-
-:::tip
-You can preflight `sendOFT` with `eth_call` to obtain `oftReceipt.amountSentLD` before sending the live transaction, which is useful for avoiding dust on amounts near the Stargate minimum.
-:::
-
-### Manual flow (advanced)
-
-The wrapper covers all standard bridging. The only case that requires calling the OFT directly is **compose messages where the destination composer refunds the original sender** — the wrapper becomes `msg.sender`, so refunds would go to the wrapper and be lost.
-
-If you need that, follow the LayerZero direct-flow reference: [Direct flow (5 transactions) in LZ docs](https://docs.layerzero.network/v2/developers/tempo/how-to/support-ofts-and-oapps#direct-flow-1-view-call-5-transactions). The sequence is `quote` → `approve(USDC.e → LZD)` → `wrap` → `approve(LZD → OFT)` → `approve(USDC.e → OFT)` → `send{value: 0}`.
 
 ### Bus vs. Taxi mode
 

--- a/src/pages/guide/bridge-layerzero.mdx
+++ b/src/pages/guide/bridge-layerzero.mdx
@@ -32,15 +32,12 @@ See the full token list at [tokenlist.tempo.xyz](https://tokenlist.tempo.xyz/lis
 
 ## LayerZero contracts on Tempo
 
-| Contract | Address | Purpose |
-|----------|---------|---------|
-| **EndpointV2** | [`0x20Bb7C2E2f4e5ca2B4c57060d1aE2615245dCc9C`](https://explore.tempo.xyz/address/0x20Bb7C2E2f4e5ca2B4c57060d1aE2615245dCc9C) | Standard LayerZero endpoint |
-| **LZEndpointDollar** | [`0x0cEb237E109eE22374a567c6b09F373C73FA4cBb`](https://explore.tempo.xyz/address/0x0cEb237E109eE22374a567c6b09F373C73FA4cBb) | Routes messaging fees through a stablecoin (no `msg.value` on Tempo). See [EndpointDollar](#endpointdollar). |
-| **TempoOFTWrapper** | [`0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0`](https://explore.tempo.xyz/address/0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0) | Bundles wrap, approve, and send into one transaction for outbound bridging. See [Bridge from Tempo](#bridge-from-tempo). |
+| Contract | Address |
+|----------|---------|
+| **EndpointV2** | [`0x20Bb7C2E2f4e5ca2B4c57060d1aE2615245dCc9C`](https://explore.tempo.xyz/address/0x20Bb7C2E2f4e5ca2B4c57060d1aE2615245dCc9C) |
+| **LZEndpointDollar** | [`0x0cEb237E109eE22374a567c6b09F373C73FA4cBb`](https://explore.tempo.xyz/address/0x0cEb237E109eE22374a567c6b09F373C73FA4cBb) |
 
 Tempo's LayerZero Endpoint ID is **`30410`**.
-
-Accepted fee tokens for `LZEndpointDollar`: `USDC.e`, `USDT0`, `pathUSD` (whitelisted 6-decimal stablecoins).
 
 ## Stargate tokens
 
@@ -448,200 +445,11 @@ await walletClient.writeContract({
 You can preflight `sendOFT` with `eth_call` to obtain `oftReceipt.amountSentLD` before sending the live transaction, which is useful for avoiding dust on amounts near the Stargate minimum.
 :::
 
-### Manual flow
+### Manual flow (advanced)
 
-Use this flow if you cannot use the wrapper (e.g., compose messages with refund-to-sender semantics). It requires 5 transactions plus a quote and produces the same end state.
+The wrapper covers all standard bridging. The only case that requires calling the OFT directly is **compose messages where the destination composer refunds the original sender** — the wrapper becomes `msg.sender`, so refunds would go to the wrapper and be lost.
 
-#### Using cast (Foundry)
-
-This example bridges USDC.e from Tempo to Base.
-
-:::::steps
-
-### Quote the fee
-
-```bash
-cast call 0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
-  'quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)((uint256,uint256))' \
-  "(30184,$(cast abi-encode 'f(address)' <DESTINATION_ADDRESS>),<AMOUNT>,<MIN_AMOUNT>,0x,0x,0x)" \
-  false \
-  --rpc-url https://rpc.tempo.xyz
-```
-
-Take the first returned number as `<NATIVE_FEE>` (in stablecoin units, not ETH).
-
-### Approve USDC.e to the LZD wrapper
-
-Approve the `LZEndpointDollar` wrapper contract to spend `<NATIVE_FEE>` of your USDC.e. This is the amount needed to cover the LayerZero messaging fee.
-
-```bash
-cast send 0x20C000000000000000000000b9537d11c60E8b50 \
-  "approve(address,uint256)" \
-  0x0cEb237E109eE22374a567c6b09F373C73FA4cBb \
-  <NATIVE_FEE> \
-  --rpc-url https://rpc.tempo.xyz \
-  --private-key $PRIVATE_KEY
-```
-
-### Wrap USDC.e into LZD
-
-Wrap your USDC.e into the LZD token so it can be used as a messaging fee by the LayerZero endpoint.
-
-```bash
-cast send 0x0cEb237E109eE22374a567c6b09F373C73FA4cBb \
-  "wrap(address,address,uint256)" \
-  0x20C000000000000000000000b9537d11c60E8b50 \
-  <WALLET_ADDRESS> \
-  <NATIVE_FEE> \
-  --rpc-url https://rpc.tempo.xyz \
-  --private-key $PRIVATE_KEY
-```
-
-### Approve LZD to Stargate
-
-Approve the Stargate OFT contract to spend your LZD so it can pay the messaging fee when sending.
-
-```bash
-cast send 0x0cEb237E109eE22374a567c6b09F373C73FA4cBb \
-  "approve(address,uint256)" \
-  0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
-  <NATIVE_FEE> \
-  --rpc-url https://rpc.tempo.xyz \
-  --private-key $PRIVATE_KEY
-```
-
-### Approve token on Tempo
-
-```bash
-cast send 0x20C000000000000000000000b9537d11c60E8b50 \
-  'approve(address,uint256)' \
-  0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
-  <AMOUNT> \
-  --rpc-url https://rpc.tempo.xyz \
-  --private-key $PRIVATE_KEY
-```
-
-### Send bridge transaction
-
-No `--value` is needed on Tempo - the messaging fee is paid in a TIP-20 stablecoin via [EndpointDollar](#endpointdollar).
-
-```bash
-cast send 0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
-  'sendToken((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),(uint256,uint256),address)' \
-  "(30184,$(cast abi-encode 'f(address)' <DESTINATION_ADDRESS>),<AMOUNT>,<MIN_AMOUNT>,0x,0x,0x)" \
-  "(<NATIVE_FEE>,0)" \
-  <TEMPO_ADDRESS> \
-  --rpc-url https://rpc.tempo.xyz \
-  --private-key $PRIVATE_KEY
-```
-
-### Verify transaction status
-
-```text
-https://scan.layerzero-api.com/v1/messages/tx/<SOURCE_TX_HASH>
-```
-
-:::::
-
-#### Using TypeScript (viem)
-
-```typescript
-import { createWalletClient, createPublicClient, http, parseUnits, pad } from 'viem'
-import { tempo } from 'viem/chains'
-import { privateKeyToAccount } from 'viem/accounts'
-
-const account = privateKeyToAccount('0x...')
-
-const walletClient = createWalletClient({
-  account,
-  chain: tempo,
-  transport: http(),
-})
-
-// Stargate OFT for USDC.e on Tempo
-const stargateOFT = '0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392' as const
-// USDC.e on Tempo
-const usdce = '0x20C000000000000000000000b9537d11c60E8b50' as const
-// LZEndpointDollar wrapper
-const lzd = '0x0cEb237E109eE22374a567c6b09F373C73FA4cBb' as const
-
-const amount = parseUnits('1', 6) // 1 USDC.e
-const minAmount = parseUnits('0.99', 6) // 1% slippage tolerance
-
-const sendParam = {
-  dstEid: 30184, // Base
-  to: pad(account.address),
-  amountLD: amount,
-  minAmountLD: minAmount,
-  extraOptions: '0x' as const,
-  composeMsg: '0x' as const,
-  oftCmd: '0x' as const, // taxi mode (immediate)
-}
-
-const wrapAbi = [
-  {
-    name: 'wrap',
-    type: 'function',
-    stateMutability: 'nonpayable',
-    inputs: [
-      { name: 'token', type: 'address' },
-      { name: 'to', type: 'address' },
-      { name: 'amount', type: 'uint256' },
-    ],
-    outputs: [],
-  },
-] as const
-
-// 1. Quote the fee
-const publicClient = createPublicClient({ chain: tempo, transport: http() })
-
-const msgFee = await publicClient.readContract({
-  address: stargateOFT,
-  abi: stargateAbi, // same ABI as above
-  functionName: 'quoteSend',
-  args: [sendParam, false],
-})
-
-// 2. Approve USDC.e to LZD wrapper (for the messaging fee)
-await walletClient.writeContract({
-  address: usdce,
-  abi: erc20Abi,
-  functionName: 'approve',
-  args: [lzd, msgFee.nativeFee],
-})
-
-// 3. Wrap USDC.e into LZD
-await walletClient.writeContract({
-  address: lzd,
-  abi: wrapAbi,
-  functionName: 'wrap',
-  args: [usdce, account.address, msgFee.nativeFee],
-})
-
-// 4. Approve LZD to Stargate (for the messaging fee)
-await walletClient.writeContract({
-  address: lzd,
-  abi: erc20Abi,
-  functionName: 'approve',
-  args: [stargateOFT, msgFee.nativeFee],
-})
-
-// 5. Approve USDC.e to Stargate (for the bridge amount)
-await walletClient.writeContract({
-  address: usdce,
-  abi: erc20Abi,
-  functionName: 'approve',
-  args: [stargateOFT, amount],
-})
-
-// 6. Send the bridge transaction (no value - fee handled via EndpointDollar)
-await walletClient.writeContract({
-  address: stargateOFT,
-  abi: stargateAbi,
-  functionName: 'sendToken',
-  args: [sendParam, msgFee, account.address],
-})
-```
+If you need that, follow the LayerZero direct-flow reference: [Direct flow (5 transactions) in LZ docs](https://docs.layerzero.network/v2/developers/tempo/how-to/support-ofts-and-oapps#direct-flow-1-view-call-5-transactions). The sequence is `quote` → `approve(USDC.e → LZD)` → `wrap` → `approve(LZD → OFT)` → `approve(USDC.e → OFT)` → `send{value: 0}`.
 
 ### Bus vs. Taxi mode
 

--- a/src/pages/guide/bridge-layerzero.mdx
+++ b/src/pages/guide/bridge-layerzero.mdx
@@ -262,7 +262,192 @@ await walletClient.writeContract({
 
 To bridge from Tempo back to another chain, call `sendToken` on the Stargate OFT contract on Tempo. The process is similar to bridging in - quote, approve, send - but includes additional steps to prepare the messaging fee.
 
-Because Tempo has no native gas token, LayerZero messaging fees are paid in a TIP-20 stablecoin via [LZEndpointDollar](#endpointdollar). Before sending a bridge transaction, you must wrap your USDC.e into an LZD (LayerZero Dollar) token that the endpoint can consume as a fee. This involves approving USDC.e to the LZD wrapper contract, wrapping it, and then approving the resulting LZD to the Stargate pool.
+Because Tempo has no native gas token, LayerZero messaging fees are paid in a whitelisted stablecoin via [LZEndpointDollar](#endpointdollar). The fee token must be `USDC.e`, `USDT0`, or `pathUSD`. There are two ways to send: the **TempoOFTWrapper** (recommended, 2 transactions) or the **manual flow** (5 transactions). Both produce identical on-chain results.
+
+### Recommended: TempoOFTWrapper
+
+The [`TempoOFTWrapper`](https://docs.layerzero.network/v2/developers/tempo/how-to/support-ofts-and-oapps) bundles wrapping, approvals, and sending into a single transaction.
+
+| Contract | Address |
+|----------|---------|
+| **TempoOFTWrapper** | [`0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0`](https://explore.tempo.xyz/address/0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0) |
+
+`sendOFT` atomically wraps the fee portion of your stablecoin into LZD, approves LZD to the OFT, and calls `send()`. If the re-quoted fee at execution time exceeds `maxNativeFee`, the entire transaction reverts.
+
+#### Using cast (Foundry)
+
+This example bridges USDC.e from Tempo to Base, paying fees in USDC.e.
+
+:::::steps
+
+### Quote the fee
+
+```bash
+cast call 0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
+  'quoteSend((uint32,bytes32,uint256,uint256,bytes,bytes,bytes),bool)((uint256,uint256))' \
+  "(30184,$(cast abi-encode 'f(address)' <DESTINATION_ADDRESS>),<AMOUNT>,<MIN_AMOUNT>,0x,0x,0x)" \
+  false \
+  --rpc-url https://rpc.tempo.xyz
+```
+
+Take the first returned number as `<NATIVE_FEE>` (in stablecoin units, not ETH).
+
+### Approve the fee token to the wrapper
+
+When the bridge token and fee token are the same (both USDC.e here), approve `<AMOUNT> + <NATIVE_FEE>` in a single call. If they differ (e.g., bridging EURC.e but paying fees in USDC.e), approve each separately.
+
+```bash
+cast send 0x20C000000000000000000000b9537d11c60E8b50 \
+  'approve(address,uint256)' \
+  0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0 \
+  $((<AMOUNT> + <NATIVE_FEE>)) \
+  --rpc-url https://rpc.tempo.xyz \
+  --private-key $PRIVATE_KEY
+```
+
+### Send via the wrapper
+
+```bash
+cast send 0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0 \
+  'sendOFT(address,address,(uint32,bytes32,uint256,uint256,bytes,bytes,bytes),uint256)' \
+  0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392 \
+  0x20C000000000000000000000b9537d11c60E8b50 \
+  "(30184,$(cast abi-encode 'f(address)' <DESTINATION_ADDRESS>),<AMOUNT>,<MIN_AMOUNT>,0x,0x,0x)" \
+  <NATIVE_FEE> \
+  --rpc-url https://rpc.tempo.xyz \
+  --private-key $PRIVATE_KEY
+```
+
+The fourth argument is `maxNativeFee` - the maximum messaging fee you accept. The call reverts if the re-quoted fee at execution exceeds this value.
+
+### Verify transaction status
+
+```text
+https://scan.layerzero-api.com/v1/messages/tx/<SOURCE_TX_HASH>
+```
+
+:::::
+
+#### Using TypeScript (viem)
+
+```typescript
+import { createWalletClient, createPublicClient, http, parseUnits, pad } from 'viem'
+import { tempo } from 'viem/chains'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+const walletClient = createWalletClient({ account, chain: tempo, transport: http() })
+const publicClient = createPublicClient({ chain: tempo, transport: http() })
+
+// Stargate OFT for USDC.e on Tempo
+const stargateOFT = '0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392' as const
+// USDC.e on Tempo (bridge token + fee token)
+const usdce = '0x20C000000000000000000000b9537d11c60E8b50' as const
+// TempoOFTWrapper
+const wrapper = '0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0' as const
+
+const amount = parseUnits('1', 6) // 1 USDC.e
+const minAmount = parseUnits('0.99', 6) // 1% slippage tolerance
+
+const sendParam = {
+  dstEid: 30184, // Base
+  to: pad(account.address),
+  amountLD: amount,
+  minAmountLD: minAmount,
+  extraOptions: '0x' as const,
+  composeMsg: '0x' as const,
+  oftCmd: '0x' as const,
+}
+
+const wrapperAbi = [
+  {
+    name: 'sendOFT',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'oft', type: 'address' },
+      { name: 'feeToken', type: 'address' },
+      {
+        name: 'sendParam',
+        type: 'tuple',
+        components: [
+          { name: 'dstEid', type: 'uint32' },
+          { name: 'to', type: 'bytes32' },
+          { name: 'amountLD', type: 'uint256' },
+          { name: 'minAmountLD', type: 'uint256' },
+          { name: 'extraOptions', type: 'bytes' },
+          { name: 'composeMsg', type: 'bytes' },
+          { name: 'oftCmd', type: 'bytes' },
+        ],
+      },
+      { name: 'maxNativeFee', type: 'uint256' },
+    ],
+    outputs: [
+      {
+        name: 'msgReceipt',
+        type: 'tuple',
+        components: [
+          { name: 'guid', type: 'bytes32' },
+          { name: 'nonce', type: 'uint64' },
+          {
+            name: 'fee',
+            type: 'tuple',
+            components: [
+              { name: 'nativeFee', type: 'uint256' },
+              { name: 'lzTokenFee', type: 'uint256' },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'oftReceipt',
+        type: 'tuple',
+        components: [
+          { name: 'amountSentLD', type: 'uint256' },
+          { name: 'amountReceivedLD', type: 'uint256' },
+        ],
+      },
+    ],
+  },
+] as const
+
+// 1. Quote the fee
+const msgFee = await publicClient.readContract({
+  address: stargateOFT,
+  abi: stargateAbi, // same ABI as the manual flow
+  functionName: 'quoteSend',
+  args: [sendParam, false],
+})
+
+// 2. Approve USDC.e to the wrapper (bridge amount + messaging fee)
+await walletClient.writeContract({
+  address: usdce,
+  abi: erc20Abi,
+  functionName: 'approve',
+  args: [wrapper, amount + msgFee.nativeFee],
+})
+
+// 3. Send via wrapper (atomic wrap + approve + send)
+await walletClient.writeContract({
+  address: wrapper,
+  abi: wrapperAbi,
+  functionName: 'sendOFT',
+  args: [stargateOFT, usdce, sendParam, msgFee.nativeFee],
+})
+```
+
+:::warning
+**Do not use the wrapper for compose messages where the composer refunds the original sender.** The wrapper becomes `msg.sender` for the OFT call, so refunds are sent to the wrapper address - not the user - and funds will be permanently lost. Use the manual flow below for those cases.
+:::
+
+:::tip
+You can preflight `sendOFT` with `eth_call` to obtain `oftReceipt.amountSentLD` before sending the live transaction, which is useful for avoiding dust on amounts near the Stargate minimum.
+:::
+
+### Manual flow
+
+Use this flow if you cannot use the wrapper (e.g., compose messages with refund-to-sender semantics). It requires 5 transactions plus a quote and produces the same end state.
 
 #### Using cast (Foundry)
 


### PR DESCRIPTION
## Summary

Adds documentation for [`TempoOFTWrapper`](https://explore.tempo.xyz/address/0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0) (`0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0`), which collapses the bridge-out flow from **5 transactions + quote → 2 transactions + quote** by bundling `wrap`, `approve`, and `send` atomically.

## Why

LayerZero's ["Support OFTs and OApps on Tempo"](https://docs.layerzero.network/v2/developers/tempo/how-to/support-ofts-and-oapps) doc treats this wrapper as the default integration path, and Boltz Exchange uses it in production (see [`directSend.ts`](https://github.com/BoltzExchange/boltz-web-app/blob/main/packages/boltz-swaps/src/oft/directSend.ts)). Tempo docs currently only document the manual 5-tx flow, so anyone following Tempo's docs writes more code than they need to and pays more gas than required.

It also introduces a few related facts that LZ docs include but Tempo docs omit:
- The fee token whitelist is not just USDC.e — it's `USDC.e`, `USDT0`, or `pathUSD`.
- `sendOFT` reverts atomically if the re-quoted fee at execution exceeds `maxNativeFee` (slippage protection on the fee, not just the bridged amount).
- Compose-with-refund-to-sender breaks under the wrapper because the wrapper becomes `msg.sender` — funds get refunded to the wrapper and are lost. Documented as a warning, with the manual flow kept as the supported alternative for that case.

## Changes

- **Bridge from Tempo intro** — Reframed to mention both flows up front and list the three accepted fee tokens.
- **New section: `### Recommended: TempoOFTWrapper`** with:
  - Contract address table
  - cast (Foundry) walkthrough: quote → approve → `sendOFT`
  - TypeScript (viem) walkthrough with full `sendOFT` ABI
  - Warnings: compose-refund pitfall, max-fee semantics
  - Preflight tip using `eth_call`
- **Existing 5-tx flow** moved under `### Manual flow` as the fallback for compose-with-refund cases.

## Verification

The `sendOFT` ABI used here is verified against [Boltz Exchange's TypeScript integration](https://github.com/BoltzExchange/boltz-web-app/blob/main/packages/boltz-swaps/src/oft/directSend.ts):

```solidity
function sendOFT(
  address oft,
  address feeToken,
  (uint32 dstEid, bytes32 to, uint256 amountLD, uint256 minAmountLD,
   bytes extraOptions, bytes composeMsg, bytes oftCmd) sendParam,
  uint256 maxNativeFee
) returns (
  (bytes32 guid, uint64 nonce, (uint256 nativeFee, uint256 lzTokenFee) fee),
  (uint256 amountSentLD, uint256 amountReceivedLD)
)
```

Selector: `0xef9c7618`. Contract has bytecode (~10KB) at `0xbb95daF376cd63F258d7c37a4eFe57c10055E8E0` on Tempo mainnet (verified via `cast code`).

## Related

- Stacks on top of #399 (manual flow) and #400 (EndpointDollar wording fix). No conflicts with either.
- Follow-ups (separate PRs, not blocking):
  - Document `OFTAlt` / `OFTAdapterAlt` / `OFTBurnSelfMintAlt` for OFT deployers
  - Note that `addExecutorNativeDropOption` reverts on Tempo
  - Add TIP-1010 `enforcedOptions` guidance for inbound `lzReceive` gas