### PR TITLE
docs: mark T4 active on mainnet

### DIFF
--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.7.0 (targeted) | Mon, May 11, 2026 | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
+| [v1.7.0](https://github.com/tempoxyz/tempo/releases/tag/v1.7.0) | Mon, May 11, 2026 | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
 | [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) | Apr 16, 2026 | Moderato + Mainnet | Required for T3; implements enhanced access key permissions with periodic limits and call scoping (TIP-1011), the signature verification precompile (TIP-1020), and virtual addresses for TIP-20 deposit forwarding (TIP-1022). | <Badge variant="red">Required</Badge> |
 | [v1.5.3](https://github.com/tempoxyz/tempo/releases/tag/v1.5.3) | Apr 9, 2026 | Moderato + Mainnet | Patch release that restores OTLP HTTPS telemetry and fixes an epoch-transition consensus race that could incorrectly block straggling peers. Validators that skipped v1.5.2 should upgrade directly to this release. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.5.2](https://github.com/tempoxyz/tempo/releases/tag/v1.5.2) | Apr 8, 2026 | Moderato + Mainnet | Maintenance release with the latest reth update, payload builder and RPC improvements, plus transaction validation and mempool hardening. | <Badge variant="yellow">Recommended</Badge> |
@@ -41,14 +41,14 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 | **Scope** | Embed consensus context into the block header to unlock deferred verification, plus T4 bug fixes and security hardening |
 | **TIPs** | [TIP-1031: Embed Consensus Context in the Block Header](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1031.md), [TIP-1046: T4 Hardfork Meta TIP](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1046.md) |
 | **Details** | [T4 network upgrade](/protocol/upgrades/t4) |
-| **Release** | v1.7.0 (targeted for Mon, May 11, 2026 16:00 CEST) |
+| **Release** | [v1.7.0](https://github.com/tempoxyz/tempo/releases/tag/v1.7.0) |
 | **Testnet** | Moderato: May 14, 2026 16:00 CEST (unix: 1778767200) |
 | **Mainnet** | Presto: May 18, 2026 16:00 CEST (unix: 1779112800) |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
 ### Who is affected?
 
-All node operators must upgrade before the T4 activation timestamp. TIP-1031 changes how block headers are produced and verified; non-upgraded nodes will have their proposals rejected and will fall out of consensus at activation.
+All node operators needed to upgrade before the T4 activation timestamp. TIP-1031 changed how block headers are produced and verified; non-upgraded nodes have their proposals rejected and have fallen out of consensus.
 
 Smart contract developers and integrators are not directly affected by TIP-1031, but should review [TIP-1046](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1046.md) for the bundled gas accounting changes and access-key scope validation updates that may affect transaction gas usage post-T4.
 

--- a/src/pages/protocol/upgrades/t4.mdx
+++ b/src/pages/protocol/upgrades/t4.mdx
@@ -8,7 +8,7 @@ description: Details and timeline for the T4 network upgrade, including consensu
 This page summarizes T4 scope.
 
 :::info[T4 status]
-T4 has activated on Moderato (testnet). Presto (mainnet) activation is scheduled for May 18, 2026.
+T4 is active on both Moderato (testnet) and Presto (mainnet).
 :::
 
 ## Timeline
@@ -18,15 +18,13 @@ T4 has activated on Moderato (testnet). Presto (mainnet) activation is scheduled
 | Moderato (testnet) | May 14, 2026 4pm CEST | `1778767200` |
 | Presto (mainnet) | May 18, 2026 4pm CEST | `1779112800` |
 
-Node operators must upgrade to the T4-compatible release (v1.7.0, targeted for May 11, 2026 4pm CEST) before the Moderato activation timestamp.
+Node operators needed to upgrade to the T4-compatible release (v1.7.0, released May 11, 2026 4pm CEST) before the Moderato activation timestamp.
 
 ## Overview
 
-T4 is Tempo's next network upgrade. It introduces the following changes:
+T4 is Tempo's current network upgrade. It introduced the following changes:
 - Embedding consensus context into the block header to unlock deferred verification and reduce finalization latency ([TIP-1031](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1031.md))
 - A bundle of T4 bug fixes and security hardening (https://tips.sh/1046)
-
-**Action required for node operators:** Upgrade to v1.7.0 before the Moderato activation timestamp. Non-upgraded nodes will fall out of consensus.
 
 ## Compatible SDK releases
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -729,7 +729,7 @@ export default defineConfig({
                 link: '/protocol/upgrades/t5',
               },
               {
-                text: 'T4',
+                text: 'T4 (Active)',
                 link: '/protocol/upgrades/t4',
               },
               {


### PR DESCRIPTION
T4 activated on Presto (mainnet) today (May 18, 2026 4pm CEST). This PR updates docs to reflect the activation.

## Changes

- **`src/pages/protocol/upgrades/t4.mdx`**
  - Status callout: "scheduled for May 18" → "T4 is active on both Moderato (testnet) and Presto (mainnet)"
  - Intro: "next network upgrade" → "current network upgrade"
  - v1.7.0: "targeted" → "released"
  - Removed the now-redundant **Action required for node operators** bold line (deadline has passed)
- **`src/pages/guide/node/network-upgrades.mdx`**
  - Node Operator Updates table: linked `v1.7.0` to its GitHub release and dropped "(targeted)"
  - T4 section **Release** row: linked release, dropped "(targeted for…)"
  - **Who is affected?** rewritten in past tense
- **`vocs.config.ts`**
  - Sidebar entry `T4` → `T4 (Active)` (matches T3/T2 convention)

## Searched for but found no other T3→T4 callouts to update

No pages have an explicit T3 → T4 migration appendix. Existing migration appendices in `tip20/spec.mdx`, `AccountKeychain.mdx`, `spec-tempo-transaction.mdx`, `tip20-rewards/spec.mdx`, `tip403/spec.mdx`, and `sdk/foundry/index.mdx` are all T2 → T3 (since T4 had no integrator-facing breaking changes — TIP-1031 is consensus-only and TIP-1046 is a bug-fix meta TIP).

The T4 → T5 migration callouts on the exchange / providing-liquidity pages remain accurate (T5 is still upcoming).