### PR TITLE
Refresh stale docs index pages

### DIFF
--- a/src/pages/guide/issuance/index.mdx
+++ b/src/pages/guide/issuance/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Stablecoin Issuance
 
-Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
+Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, configure permissions, and make the token usable for payments and transaction fees.
 
 <Cards>
   <Card

--- a/src/pages/guide/stablecoin-dex/index.mdx
+++ b/src/pages/guide/stablecoin-dex/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Exchange Stablecoins
 
-Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX enables optimal pricing for cross-stablecoin payments while minimizing chain load.
+Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX provides onchain liquidity for cross-stablecoin payments, fee conversion, and applications that need predictable stablecoin routing.
 
 <Cards>
   <Card

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # SDKs
 
-Tempo is building clients in multiple languages to make integration as easy as possible.
+Tempo SDKs help teams connect wallets, send transactions, manage tokens, and use payment-specific protocol features without rebuilding chain plumbing from scratch. Start with the language or toolchain your application already uses.
 
 <Cards>
   <Card


### PR DESCRIPTION
## Summary
- refresh stale SDK index intro copy
- clarify stablecoin issuance index scope
- clarify stablecoin DEX index use cases

## Verification
- corepack pnpm build

SEO audit context: these pages had article:modified_time older than 90 days and were classified as light-touch refresh candidates.