### PR TITLE
Refresh stale docs index copy

### DIFF
--- a/src/pages/guide/issuance/index.mdx
+++ b/src/pages/guide/issuance/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Stablecoin Issuance
 
-Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
+Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, configure permissions, and integrate your stablecoin with Tempo's payment infrastructure.
 
 <Cards>
   <Card

--- a/src/pages/guide/stablecoin-dex/index.mdx
+++ b/src/pages/guide/stablecoin-dex/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Exchange Stablecoins
 
-Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX enables optimal pricing for cross-stablecoin payments while minimizing chain load.
+Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX supports cross-stablecoin payments by routing through shared liquidity while minimizing chain load.
 
 <Cards>
   <Card
@@ -36,5 +36,4 @@ Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The
     icon="lucide:droplet"
     title="Providing Liquidity"
   />
-  
 </Cards>

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # SDKs
 
-Tempo is building clients in multiple languages to make integration as easy as possible.
+Use Tempo SDKs to send transactions, integrate account flows, and build with Tempo from the language or toolchain your application already uses.
 
 <Cards>
   <Card


### PR DESCRIPTION
## Summary
- Refresh SDK index copy with concrete integration language
- Clarify stablecoin issuance index coverage
- Clarify stablecoin DEX index copy and remove trailing whitespace

## Verification
- git diff --check
- Live HTML spot-check confirmed Vocs infers titles from H1 and explicit descriptions render for /guide/issuance and /sdk

Note: pnpm formatter could not run in this sandbox because corepack invoked pnpm v11.1.3 while the repo requires pnpm 10.28.1.