### PR TITLE
Refresh stale SEO docs pages

### DIFF
--- a/src/pages/guide/issuance/index.mdx
+++ b/src/pages/guide/issuance/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Stablecoin Issuance
 
-Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
+Create and manage your own stablecoin on Tempo. These guides cover token creation, minting, fee-token support, and operational controls for payment applications.
 
 <Cards>
   <Card

--- a/src/pages/learn/tempo/performance.mdx
+++ b/src/pages/learn/tempo/performance.mdx
@@ -14,7 +14,7 @@ Tempo is built on the [Reth](https://reth.rs/) SDK, the most performant and flex
 
 Tempo houses the team that built and maintains Reth, and several other pieces of core blockchain developer software such as [Foundry](https://getfoundry.sh/). We are already benchmarking 20,000 TPS on testnet with a clear line of sight to an order of magnitude higher by mainnet.
 
-This throughput is critical for payment use cases. Whether processing payroll for thousands of employees, settling marketplace transactions, or handling microtransactions at scale, Tempo's performance ensures that your payment flows won't be bottlenecked by blockchain capacity.
+This throughput is critical for payment use cases. Whether processing payroll for thousands of employees, settling marketplace transactions, or handling high-volume machine payments, Tempo's architecture is designed to keep payment flows from being bottlenecked by blockchain capacity.
 
 ## Fast Finality
 

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # SDKs
 
-Tempo is building clients in multiple languages to make integration as easy as possible.
+Tempo provides SDKs and tooling for common integration paths, from TypeScript applications to Foundry-based contract development.
 
 <Cards>
   <Card


### PR DESCRIPTION
## Summary
- Refresh stale copy on SDK, stablecoin issuance, and performance docs pages
- Make each change substantive so git-derived article modified times update with useful content

## Verification
- Ran docs frontmatter audit: no missing descriptions found
- Ran git diff --check