### PR TITLE
docs: clarify network upgrade sidebar labels

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -725,19 +725,19 @@ export default defineConfig({
             collapsed: true,
             items: [
               {
-                text: 'T5',
+                text: 'T5 (Next)',
                 link: '/protocol/upgrades/t5',
               },
               {
-                text: 'T4 (Active)',
+                text: 'T4 (Latest)',
                 link: '/protocol/upgrades/t4',
               },
               {
-                text: 'T3 (Active)',
+                text: 'T3',
                 link: '/protocol/upgrades/t3',
               },
               {
-                text: 'T2 (Active)',
+                text: 'T2',
                 link: '/protocol/upgrades/t2',
               },
             ],


### PR DESCRIPTION
Updates the **Network Upgrades** sidebar labels for clarity:

- Removes `(Active)` from T2 and T3
- Adds `(Latest)` next to T4
- Adds `(Next)` next to T5

### Before
- T5
- T4 (Active)
- T3 (Active)
- T2 (Active)

### After
- T5 (Next)
- T4 (Latest)
- T3
- T2