### PR TITLE
Add Morpho and MeshPay to ecosystem docs

### DIFF
--- a/src/pages/ecosystem/bridges.mdx
+++ b/src/pages/ecosystem/bridges.mdx
@@ -25,6 +25,12 @@ Get started with the [Bungee docs](https://docs.bungee.exchange/) or try the [Bu
 
 Transfer assets to Tempo with [Stargate](https://stargate.finance/).
 
+## Morpho
+
+[Morpho](https://morpho.org) is an open credit network for onchain lending and borrowing. Morpho connects lenders and borrowers to noncustodial credit markets, enabling applications and institutions to access lending, borrowing, and vault-based yield opportunities on Tempo.
+
+Explore the [Morpho docs](https://docs.morpho.org/) to get started.
+
 ## Relay
 
 [Relay](https://relay.link) provides instant cross-chain bridging and transaction execution. Relay enables users and applications to move assets to Tempo from other chains with fast finality and low fees, powered by a network of relayers that fill orders on the destination chain.

--- a/src/pages/ecosystem/orchestration.mdx
+++ b/src/pages/ecosystem/orchestration.mdx
@@ -28,3 +28,9 @@ Get started by creating an account [here](https://app.brale.xyz/buy/signup/).
 [Bridge](https://www.bridge.xyz) (a Stripe Company) provides stablecoin orchestration infrastructure for moving money between fiat and crypto rails. Bridge supports Tempo with APIs for issuance, wallets, and cross-border stablecoin transfers, enabling fintechs and platforms to build payment flows that span traditional and onchain systems.
 
 Get started with [Bridge's Tempo Integration Guide](https://apidocs.bridge.xyz/get-started/guides/move-money/tempo-integration-guide#tempo-integration-guide).
+
+## MeshPay
+
+[MeshPay](https://www.meshpay.com) provides crypto payment infrastructure for accepting payments from hundreds of wallets and settling in stablecoins or local currency. Developers can use MeshPay to support checkout, deposits, payouts, on- and off-ramps, and stablecoin settlement flows on Tempo.
+
+Explore the [MeshPay docs](https://docs.meshconnect.com/overview) to get started.

--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -91,6 +91,14 @@ Bridge to Tempo through the [Relay app](https://relay.link) and explore the [Rel
 
 Get started with the [Squid docs](https://docs.squidrouter.com/) or try the [bridge app](https://app.squidrouter.com/).
 
+## DeFi & Liquidity
+
+### Morpho
+
+[Morpho](https://morpho.org) is an open credit network for onchain lending and borrowing. Morpho connects lenders and borrowers to noncustodial credit markets, enabling applications and institutions to access lending, borrowing, and vault-based yield opportunities on Tempo.
+
+Explore the [Morpho docs](https://docs.morpho.org/) to get started.
+
 ## Data & Analytics
 
 ### Allium
@@ -375,3 +383,9 @@ Get started by creating an account [here](https://app.brale.xyz/buy/signup/).
 [Bridge](https://www.bridge.xyz) (a Stripe Company) provides stablecoin orchestration infrastructure for moving money between fiat and crypto rails. Bridge supports Tempo with APIs for issuance, wallets, and cross-border stablecoin transfers — enabling fintechs and platforms to build payment flows that span traditional and onchain systems.
 
 Get started with [Bridge's Tempo Integration Guide](https://apidocs.bridge.xyz/get-started/guides/move-money/tempo-integration-guide#tempo-integration-guide).
+
+### MeshPay
+
+[MeshPay](https://www.meshpay.com) provides crypto payment infrastructure for accepting payments from hundreds of wallets and settling in stablecoins or local currency. Developers can use MeshPay to support checkout, deposits, payouts, on- and off-ramps, and stablecoin settlement flows on Tempo.
+
+Explore the [MeshPay docs](https://docs.meshconnect.com/overview) to get started.


### PR DESCRIPTION
## Summary
- Add Morpho to the ecosystem bridge/liquidity docs and developer tools page
- Add MeshPay to the orchestration docs and developer tools page

## Validation
- corepack pnpm check:types
- corepack pnpm build