### PR TITLE
Add Morpho and Mesh ecosystem docs

### DIFF
--- a/src/pages/ecosystem/defi.mdx
+++ b/src/pages/ecosystem/defi.mdx
@@ -1,0 +1,14 @@
+---
+title: DeFi
+description: Access lending, borrowing, vaults, and other DeFi infrastructure on Tempo.
+---
+
+# DeFi
+
+Access lending, borrowing, vaults, and other DeFi infrastructure on Tempo.
+
+## Morpho
+
+[Morpho](https://morpho.org/) is an open credit network for lending and borrowing. Builders can use Morpho's non-custodial infrastructure to create lending markets, vault-based earn products, structured products, and other credit applications onchain.
+
+Explore the [Morpho docs](https://docs.morpho.org/) and [developer portal](https://developers.morpho.org/) to start integrating.

--- a/src/pages/ecosystem/index.mdx
+++ b/src/pages/ecosystem/index.mdx
@@ -53,6 +53,12 @@ Integrating with Tempo is easy by leveraging services provided by our infrastruc
     title="Smart Contract Libraries"
   />
   <Card
+    description="Access lending, borrowing, vaults, and other DeFi infrastructure on Tempo"
+    to="/ecosystem/defi"
+    icon="lucide:landmark"
+    title="DeFi"
+  />
+  <Card
     description="Connect to Tempo with reliable RPC endpoints and managed node services"
     to="/ecosystem/node-infrastructure"
     icon="lucide:server"

--- a/src/pages/ecosystem/orchestration.mdx
+++ b/src/pages/ecosystem/orchestration.mdx
@@ -28,3 +28,9 @@ Get started by creating an account [here](https://app.brale.xyz/buy/signup/).
 [Bridge](https://www.bridge.xyz) (a Stripe Company) provides stablecoin orchestration infrastructure for moving money between fiat and crypto rails. Bridge supports Tempo with APIs for issuance, wallets, and cross-border stablecoin transfers, enabling fintechs and platforms to build payment flows that span traditional and onchain systems.
 
 Get started with [Bridge's Tempo Integration Guide](https://apidocs.bridge.xyz/get-started/guides/move-money/tempo-integration-guide#tempo-integration-guide).
+
+## Mesh
+
+[Mesh](https://www.meshpay.com/) is a global crypto payments network that connects exchanges, wallets, and payment service providers through one integration. Mesh helps applications accept crypto from 300+ wallets and exchanges, then settle in stablecoins or local currency.
+
+Explore the [Mesh docs](https://docs.meshconnect.com/overview) to start integrating payments, deposits, verification, payouts, and stablecoin settlement.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -491,6 +491,10 @@ export default defineConfig({
                 link: '/ecosystem/smart-contract-libraries',
               },
               {
+                text: 'DeFi',
+                link: '/ecosystem/defi',
+              },
+              {
                 text: 'Node Infrastructure',
                 link: '/ecosystem/node-infrastructure',
               },


### PR DESCRIPTION
## Summary
- Add a DeFi ecosystem docs page featuring Morpho
- Add DeFi to the ecosystem docs index and sidebar
- Add Mesh to the orchestration ecosystem docs page

## Validation
- corepack pnpm check:types