### PR TITLE
Refresh stale docs pages for SEO

### DIFF
--- a/src/pages/guide/issuance/index.mdx
+++ b/src/pages/guide/issuance/index.mdx
@@ -8,6 +8,9 @@ import { Cards, Card } from 'vocs'
 
 Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
 
+Start with token creation, then add operational controls for minting, fees,
+rewards, and transfer policies as your deployment moves toward production.
+
 <Cards>
   <Card
     description="Create your own stablecoin using the TIP-20 token standard with built-in compliance features"

--- a/src/pages/guide/node/index.mdx
+++ b/src/pages/guide/node/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Tempo Node
 
-Running a Tempo node allows you to interact with the network directly, providing your own RPC access or contributing to network infrastructure. Nodes provide JSON-RPC API access for applications, explorers, and wallets but do not participate in consensus.
+Running a Tempo node allows you to interact with the network directly, providing your own RPC access or contributing to network infrastructure. RPC nodes provide JSON-RPC API access for applications, explorers, and wallets. Validator participation requires separate onboarding and operational coordination with Tempo.
 
 ## Supported Platforms
 

--- a/src/pages/guide/stablecoin-dex/index.mdx
+++ b/src/pages/guide/stablecoin-dex/index.mdx
@@ -8,6 +8,9 @@ import { Cards, Card } from 'vocs'
 
 Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX enables optimal pricing for cross-stablecoin payments while minimizing chain load.
 
+Use these guides when your application needs to quote swaps, execute stablecoin
+conversions, or provide liquidity for payment and fee flows.
+
 <Cards>
   <Card
     description="Learn about pathUSD, the root quote token that powers stablecoin interoperability"

--- a/src/pages/learn/index.mdx
+++ b/src/pages/learn/index.mdx
@@ -10,6 +10,9 @@ Tempo is a general-purpose blockchain optimized for payments. Tempo is designed 
 
 Tempo was designed in close collaboration with an exceptional group of [design partners](https://tempo.xyz/ecosystem) who are helping to validate the system against real payment workloads. Here, we have written about what stablecoins are and how Tempo is designed from the ground up for the use cases they enable.
 
+These pages explain the business and technical concepts behind Tempo before you
+move into implementation guides.
+
 <Cards>
   <Card
     description="Learn what stablecoins are, how they work, and the real-world use cases they enable"

--- a/src/pages/protocol/fees/fee-amm/index.mdx
+++ b/src/pages/protocol/fees/fee-amm/index.mdx
@@ -18,6 +18,9 @@ When a user pays fees in a stablecoin that differs from the validator's preferen
 
 This conversion happens automatically at the end of each block through batched swaps, preventing MEV attacks like sandwiching.
 
+Because conversions are batched at the protocol level, users do not need to
+submit a separate swap transaction before paying fees.
+
 ## Learn More
 
 <Cards>

--- a/src/pages/protocol/fees/index.mdx
+++ b/src/pages/protocol/fees/index.mdx
@@ -12,6 +12,9 @@ For a stablecoin to be accepted, it must be USD-denominated, issued as a native 
 
 Tempo uses a fixed base fee (rather than a variable base fee as in EIP-1559), set so that a TIP-20 transfer costs less than $0.001. All fees accrue to the validator who proposes the block.
 
+Applications can abstract this away from users by selecting a supported fee
+token or sponsoring fees through the account and transaction flows.
+
 ## Learn More
 
 <Cards>

--- a/src/pages/protocol/tip20-rewards/overview.mdx
+++ b/src/pages/protocol/tip20-rewards/overview.mdx
@@ -17,6 +17,9 @@ Traditional reward mechanisms require tokens to be staked in separate contracts,
 - **Efficient at Scale**: Constant-time updates regardless of the number of token holders
 - **Policy Compliant**: All reward transfers respect TIP-403 transfer policies
 
+Issuers can use this for stablecoin programs that need native, auditable reward
+distribution without moving balances into a separate staking contract.
+
 ## Links
 
 <Cards>

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -8,6 +8,9 @@ import { Cards, Card } from 'vocs'
 
 Tempo is building clients in multiple languages to make integration as easy as possible.
 
+Choose the SDK that matches your application stack, then use the protocol and
+guide sections for transaction, account, and token behavior.
+
 <Cards>
   <Card
     description="Build on Tempo using TypeScript"

--- a/src/pages/sdk/typescript/prool/setup.mdx
+++ b/src/pages/sdk/typescript/prool/setup.mdx
@@ -6,6 +6,9 @@ description: Set up infinite pooled Tempo node instances in TypeScript with Proo
 
 Setup infinite pooled Tempo node instances in TypeScript using [`prool`](https://github.com/wevm/prool) by following the steps below.
 
+This setup is useful for integration tests that need isolated Tempo RPC
+instances without manually starting and stopping nodes between test cases.
+
 ::::steps
 
 ## Install
@@ -70,4 +73,3 @@ After you have set up Tempo with Prool, you can now:
 - Run Tempo locally alongside your Vite or Next.js development server
 
 ::::
-


### PR DESCRIPTION
## Summary\n- Add small, substantive clarifications to stale docs pages surfaced by the daily SEO freshness audit\n- Improve index-page context for issuance, nodes, stablecoin DEX, fees, rewards, SDKs, and Prool setup\n\n## Validation\n- git diff --check passed\n- Attempted targeted Biome check with corepack pnpm; dependencies were not installed in the writable clone and the command exited 254 without diagnostics