### PR TITLE
docs: fix placeholder #TODO links in embed-passkeys guide

### DIFF
--- a/src/pages/guide/use-accounts/embed-passkeys.mdx
+++ b/src/pages/guide/use-accounts/embed-passkeys.mdx
@@ -247,7 +247,7 @@ export const config = createConfig({
 
 Now that you have created your first passkey account, you can now:
 - learn the [Best Practices](#best-practices) below
-- follow a guide on how to [make a payment](#TODO), [create a stablecoin](#TODO), and [more](#TODO) with a passkey account.
+- follow a guide on how to [make a payment](/guide/payments), [create a stablecoin](/guide/issuance), and [more](/guide/use-accounts) with a passkey account.
 
 ::::
 


### PR DESCRIPTION
Fix three broken `#TODO` placeholder links in the embed-passkeys guide.

Changes:
- `guide/use-accounts/embed-passkeys.md`: `[make a payment](#TODO)` → `[make a payment](/guide/payments)`
- `guide/use-accounts/embed-passkeys.md`: `[create a stablecoin](#TODO)` → `[create a stablecoin](/guide/issuance)`
- `guide/use-accounts/embed-passkeys.md`: `[more](#TODO)` → `[more](/guide/use-accounts)`

Links were derived by analogy with the equivalent section in `embed-tempo-wallet.md`, which already contains the correct targets for `make a payment` and `create a stablecoin`. The `more` link points to the parent section index, which lists all available guides for passkey accounts.

Test plan
Documentation-only change; no code paths affected.