### PR TITLE
docs: fix incorrect link in use-for-fees guide

### DIFF
--- a/src/pages/guide/issuance/use-for-fees.mdx
+++ b/src/pages/guide/issuance/use-for-fees.mdx
@@ -119,7 +119,7 @@ require(reserveValidator > 0, "No liquidity available for fee conversion");
 
 :::
 
-If the pool has no liquidity (`reserveValidatorToken == 0`), you'll need to add liquidity to the fee pool before users can pay fees with your token. See the [Create a Stablecoin](/guide/issuance/create-a-stablecoin) guide for instructions on minting fee AMM liquidity.
+If the pool has no liquidity (`reserveValidatorToken == 0`), you'll need to add liquidity to the fee pool before users can pay fees with your token. See the [Managing Fee Liquidity](/guide/stablecoin-dex/managing-fee-liquidity) guide for instructions on minting fee AMM liquidity.
 
 ### Send payment with your token as fee
 


### PR DESCRIPTION
Fix a link that points to the wrong page in the use-for-fees guide.

The text says "See the [Create a Stablecoin] guide for instructions on minting fee AMM liquidity.", but that page only covers token creation, it contains no instructions on minting fee AMM liquidity. 
The Managing Fee Liquidity page is the correct target, as it covers adding liquidity to the fee pool, LP tokens, and first liquidity provider flow.

Changes:
- `guide/issuance/use-for-fees.md`: `[Create a Stablecoin](/guide/issuance/create-a-stablecoin)` → `[Managing Fee Liquidity](/guide/stablecoin-dex/managing-fee-liquidity)`

Test plan
Documentation-only change; no code paths affected.