### PR TITLE
docs: fix outdated Stargate documentation URL

### DIFF
--- a/src/pages/guide/bridge-layerzero.mdx
+++ b/src/pages/guide/bridge-layerzero.mdx
@@ -536,6 +536,6 @@ How fees flow:
 ## Further reading
 
 - [LayerZero V2 documentation](https://docs.layerzero.network/v2)
-- [Stargate documentation](https://stargateprotocol.gitbook.io/stargate/v2-developer-docs)
+- [Stargate documentation](https://docs.stargate.finance/introduction/overview)
 - [Bridges & Exchanges on Tempo](/ecosystem/bridges)
 - [Getting Funds on Tempo](/guide/getting-funds)


### PR DESCRIPTION
Fix an outdated link to the Stargate documentation in the bridge-layerzero guide.

The previous URL pointed to the old gitbook version of the Stargate V2 docs, 
which has since moved to the official docs site. The new URL is the current 
and maintained documentation.

Changes:
- `guide/bridge-layerzero.md`: `[Stargate documentation](https://stargateprotocol.gitbook.io/stargate/v2-developer-docs)` → `[Stargate documentation](https://docs.stargate.finance/introduction/overview)`

Test plan
Documentation-only change; no code paths affected.