### PR TITLE
docs: add missing contact links in validator guides

### DIFF
--- a/src/pages/guide/node/validator-lifecycle.mdx
+++ b/src/pages/guide/node/validator-lifecycle.mdx
@@ -27,7 +27,7 @@ The node will finish processing the current block before shutting down. Avoid us
 **You cannot reset a validator's data and continue with the same identity.** Doing so risks inconsistent voting, which can cause irrecoverable network safety failures.
 :::
 
-If you need to reset your validator's data, you must rotate to a new validator identity. This requires coordinating with the Tempo team to deactivate your old identity and register a new one. Don't hesitate to reach out — even with the Tempo team, this is a routine operation.
+If you need to reset your validator's data, you must rotate to a new validator identity. This requires coordinating with the Tempo team to deactivate your old identity and register a new one. Don't hesitate to [reach out](mailto:partners@tempo.xyz) — even with the Tempo team, this is a routine operation.
 
 :::info
 Self-service data resets are coming soon. Once available, you will be able to rotate to a new identity and reset your data without coordinating with the Tempo team. See [Rotate validator identity](#rotate-validator-identity).

--- a/src/pages/guide/node/validator-status.mdx
+++ b/src/pages/guide/node/validator-status.mdx
@@ -127,6 +127,6 @@ curl -s localhost:8002/metrics | grep consensus_engine_dkg_manager_ceremony_fail
 
 If `how_often_dealer` or `how_often_player` is increasing, your node is actively participating in DKG ceremonies. After your validator has been added to the network, you should alert on these metrics, as they indicate that your validator is actively participating in the network.
 
-If your validator is not connected to other peers, but at least 3 epochs have passed, check that your node is properly configured — e.g. firewall settings are open to other peers. If you have reset your validator's state, your validator might have been blocked due to double-signing a block. In that case, please reach out to the Tempo team — even with the Tempo team, resolving this requires coordinating a new validator identity.
+If your validator is not connected to other peers, but at least 3 epochs have passed, check that your node is properly configured — e.g. firewall settings are open to other peers. If you have reset your validator's state, your validator might have been blocked due to double-signing a block. In that case, please [reach out to the Tempo team](mailto:partners@tempo.xyz) — even with the Tempo team, resolving this requires coordinating a new validator identity.
 
 


### PR DESCRIPTION
Add missing contact links to the Tempo team email address across three 
validator guide pages.

The validator-troubleshooting page already links "reach out to the Tempo team" to mailto:partners@tempo.xyz. This change applies the same pattern to two other pages where the same call to action appears without a link.

Changes:
- `guide/node/validator-lifecycle.md`: `reach out` → `[reach out](mailto:partners@tempo.xyz)`
- `guide/node/validator-status.md`: `reach out to the Tempo team` → `[reach out to the Tempo team](mailto:partners@tempo.xyz)`

Test plan
Documentation-only change; no code paths affected.