### PR TITLE
docs: add missing link to CONTRIBUTING.md in integrate-tempo page

### DIFF
--- a/src/pages/quickstart/integrate-tempo.mdx
+++ b/src/pages/quickstart/integrate-tempo.mdx
@@ -79,4 +79,4 @@ If you're interested in learning more about how Tempo works under the hood, feel
   />
 </Cards>
 
-We welcome contributions from the community to help improve and expand the project.
+We welcome contributions from the community to help improve and expand the project. See our [contributing guide](https://github.com/tempoxyz/.github/blob/main/CONTRIBUTING.md) to get started.


### PR DESCRIPTION
Add a link to the contributing guide in the last sentence of the 
integrate-tempo page.

The sentence "We welcome contributions from the community to help improve and expand the project." has no link, leaving the reader with no clear next step. The correct target is the CONTRIBUTING.md in the tempoxyz/.github repository.

Changes:
- `quickstart/integrate-tempo.md`: add link to contributing guide  
  `We welcome contributions from the community to help improve and expand the project.`  
  → `We welcome contributions from the community to help improve and expand the project. See our [contributing guide](https://github.com/tempoxyz/.github/blob/main/CONTRIBUTING.md) to get started.`

Test plan
Documentation-only change; no code paths affected.