### PR TITLE
Add SenseiNode to node infrastructure ecosystem page

### DIFF
--- a/src/pages/ecosystem/node-infrastructure.mdx
+++ b/src/pages/ecosystem/node-infrastructure.mdx
@@ -47,6 +47,12 @@ Get started by visiting the [Tempo chain page](https://drpc.org/chainlist/tempo-
 
 Get started on the [Tempo Chain Page](https://www.quicknode.com/chains/tempo) and follow the [QuickStart guide](https://www.quicknode.com/docs/tempo) to create your Tempo RPC endpoint.
 
+## SenseiNode
+
+[SenseiNode](https://senseinode.com) operates institutional-grade RPC and validator infrastructure across 35+ protocols, backed by SOC 2 Type II and ISO 27001:2022 certifications. SenseiNode does not ship commodity endpoints. Their engineering team sizes, tunes, and operates every deployment around your specific workload, available out of the box.
+
+Reach out to the concierge infrastructure team at [info@senseinode.com](mailto:info@senseinode.com) or visit [senseinode.com](https://senseinode.com) to scope your Tempo RPC requirements and receive a tailored proposal within 24 hours.
+
 ## Validation Cloud
 
 [Validation Cloud](https://www.validationcloud.io/tempo) provides validators and institutional-grade, full-archive RPC nodes for Tempo. Built for high performance, low latency, and SOC 2 Type II compliance, Validation Cloud is purpose-built for powering real-world payments and stablecoin use cases at scale.


### PR DESCRIPTION
Adds SenseiNode as a node infrastructure partner on the [Node Infrastructure](https://docs.tempo.xyz/ecosystem/node-infrastructure) ecosystem page.