### PR TITLE
Add T5 activation timestamps

### DIFF
--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.8.0 | Targeted for May 27, 2026 | Moderato + Mainnet | Required for T5; introduces the enshrined TIP-20 reserve channel precompile, payment lane classification, DEX flip-order improvements, multihop FeeAMM routing, optional on-chain TIP-20 `logoURI`, implicit approvals, and key authorization witnesses. | <Badge variant="red">Required</Badge> |
+| v1.8.0 | Targeted for May 27, 2026 | Testnet + Mainnet | Required for T5; introduces the enshrined TIP-20 reserve channel precompile, payment lane classification, DEX flip-order improvements, multihop FeeAMM routing, optional on-chain TIP-20 `logoURI`, implicit approvals, and key authorization witnesses. | <Badge variant="red">Required</Badge> |
 | [v1.7.0](https://github.com/tempoxyz/tempo/releases/tag/v1.7.0) | Mon, May 11, 2026 | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
 | [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) | Apr 16, 2026 | Moderato + Mainnet | Required for T3; implements enhanced access key permissions with periodic limits and call scoping (TIP-1011), the signature verification precompile (TIP-1020), and virtual addresses for TIP-20 deposit forwarding (TIP-1022). | <Badge variant="red">Required</Badge> |
 | [v1.5.3](https://github.com/tempoxyz/tempo/releases/tag/v1.5.3) | Apr 9, 2026 | Moderato + Mainnet | Patch release that restores OTLP HTTPS telemetry and fixes an epoch-transition consensus race that could incorrectly block straggling peers. Validators that skipped v1.5.2 should upgrade directly to this release. | <Badge variant="yellow">Recommended</Badge> |
@@ -43,8 +43,8 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 | **TIPs** | [TIP-1034: Enshrined TIP-20 Reserve Channel](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1034.md), [TIP-1045: Payment Lane Classification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1045.md), [TIP-1030: Allow Same-Tick Flip Orders](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1030.md), [TIP-1056: Keep Order IDs Across Flips](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1056.md), [TIP-1033: Multihop FeeAMM Routing](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1033.md), [TIP-1026: Optional logoURI Field in TIP-20](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1026.md), [TIP-1035: Implicit Approvals List](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1035.md), [TIP-1053: Witness Digest in Key Authorizations](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1053.md) |
 | **Details** | [T5 network upgrade](/protocol/upgrades/t5) |
 | **Release** | v1.8.0 (targeted for May 27, 2026) |
-| **Testnet** | Moderato: June 3, 2026 16:00 CEST (unix: 1780495200) |
-| **Mainnet** | Presto: June 9, 2026 16:00 CEST (unix: 1781013600) |
+| **Testnet** | June 3, 2026 16:00 CEST (unix: 1780495200) |
+| **Mainnet** | June 9, 2026 16:00 CEST (unix: 1781013600) |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
 ### Who is affected?

--- a/src/pages/guide/node/network-upgrades.mdx
+++ b/src/pages/guide/node/network-upgrades.mdx
@@ -15,6 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
+| v1.8.0 | Targeted for May 27, 2026 | Moderato + Mainnet | Required for T5; introduces the enshrined TIP-20 reserve channel precompile, payment lane classification, DEX flip-order improvements, multihop FeeAMM routing, optional on-chain TIP-20 `logoURI`, implicit approvals, and key authorization witnesses. | <Badge variant="red">Required</Badge> |
 | [v1.7.0](https://github.com/tempoxyz/tempo/releases/tag/v1.7.0) | Mon, May 11, 2026 | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
 | [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) | Apr 16, 2026 | Moderato + Mainnet | Required for T3; implements enhanced access key permissions with periodic limits and call scoping (TIP-1011), the signature verification precompile (TIP-1020), and virtual addresses for TIP-20 deposit forwarding (TIP-1022). | <Badge variant="red">Required</Badge> |
 | [v1.5.3](https://github.com/tempoxyz/tempo/releases/tag/v1.5.3) | Apr 9, 2026 | Moderato + Mainnet | Patch release that restores OTLP HTTPS telemetry and fixes an epoch-transition consensus race that could incorrectly block straggling peers. Validators that skipped v1.5.2 should upgrade directly to this release. | <Badge variant="yellow">Recommended</Badge> |
@@ -31,6 +32,26 @@ For detailed release notes and binaries, see the [Changelog](/changelog).
 :::warning
 `--consensus.fee-recipient` is deprecated as of `v1.5.2` and will be removed in an upcoming release. Validators should migrate fee-recipient management to [update the fee recipient](/guide/node/validator-lifecycle#update-the-fee-recipient).
 :::
+
+---
+
+## T5
+
+| | |
+|---|---|
+| **Scope** | Enshrined TIP-20 reserve channel precompile; payment lane classification; DEX same-tick flip orders and persistent order IDs across flips; multihop FeeAMM routing; optional on-chain TIP-20 `logoURI`; implicit approvals; and key authorization witnesses |
+| **TIPs** | [TIP-1034: Enshrined TIP-20 Reserve Channel](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1034.md), [TIP-1045: Payment Lane Classification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1045.md), [TIP-1030: Allow Same-Tick Flip Orders](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1030.md), [TIP-1056: Keep Order IDs Across Flips](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1056.md), [TIP-1033: Multihop FeeAMM Routing](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1033.md), [TIP-1026: Optional logoURI Field in TIP-20](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1026.md), [TIP-1035: Implicit Approvals List](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1035.md), [TIP-1053: Witness Digest in Key Authorizations](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1053.md) |
+| **Details** | [T5 network upgrade](/protocol/upgrades/t5) |
+| **Release** | v1.8.0 (targeted for May 27, 2026) |
+| **Testnet** | Moderato: June 3, 2026 16:00 CEST (unix: 1780495200) |
+| **Mainnet** | Presto: June 9, 2026 16:00 CEST (unix: 1781013600) |
+| **Priority** | <Badge variant="red">Required</Badge> |
+
+### Who is affected?
+
+All node operators need to upgrade before the T5 activation timestamp. Non-upgraded nodes will fall out of consensus once T5 activates.
+
+Integrators, indexers, wallets, explorers, and SDK maintainers should review the [T5 network upgrade](/protocol/upgrades/t5) page for the post-T5 surfaces and migration notes.
 
 ---
 

--- a/src/pages/protocol/upgrades/t5.mdx
+++ b/src/pages/protocol/upgrades/t5.mdx
@@ -15,8 +15,8 @@ T5 is not yet active on testnet or mainnet. The features described on this page 
 
 | Network | Date | Timestamp |
 |---------|------|-----------|
-| Testnet | June 3, 2026 | TBD |
-| Mainnet | June 9, 2026 | TBD |
+| Testnet (Moderato) | June 3, 2026 16:00 CEST | 1780495200 |
+| Mainnet (Presto) | June 9, 2026 16:00 CEST | 1781013600 |
 
 Node operators must upgrade to the T5-compatible release (v1.8.0, targeted for May 27, 2026) before the testnet activation timestamp.
 

--- a/src/pages/protocol/upgrades/t5.mdx
+++ b/src/pages/protocol/upgrades/t5.mdx
@@ -15,8 +15,8 @@ T5 is not yet active on testnet or mainnet. The features described on this page 
 
 | Network | Date | Timestamp |
 |---------|------|-----------|
-| Testnet (Moderato) | June 3, 2026 16:00 CEST | 1780495200 |
-| Mainnet (Presto) | June 9, 2026 16:00 CEST | 1781013600 |
+| Testnet | June 3, 2026 16:00 CEST | 1780495200 |
+| Mainnet | June 9, 2026 16:00 CEST | 1781013600 |
 
 Node operators must upgrade to the T5-compatible release (v1.8.0, targeted for May 27, 2026) before the testnet activation timestamp.
 


### PR DESCRIPTION
## Summary
- Add concrete Moderato and Presto activation timestamps to the T5 upgrade page
- Add T5 to the node network upgrades overview with the same activation schedule

## Test plan
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm build`

Prompted by: @jenpaff