### PR TITLE
docs: note TIP-1035 gas savings for MPP

### DIFF
--- a/src/pages/protocol/upgrades/t5.mdx
+++ b/src/pages/protocol/upgrades/t5.mdx
@@ -77,7 +77,7 @@ Use an SVG for `logoURI` so it renders crisply at any resolution across wallets 
 
 T5-compatible SDK releases will be listed here as they ship.
 
-These releases should prefer the TIP-1034 reserve precompile over the legacy MPP reserve contract. Besides using the protocol-native reserve surface, that path offers several gas-saving benefits, including packed reserve storage slots and [TIP-1035 implicit approvals](#tip-1035-implicit-approvals-list). With implicit approvals, the precompile calls internal `system_transfer_from` rather than regular `transferFrom`, so users do not need a separate allowance approval and reserve flows avoid the gas cost of the approval write.
+These releases should prefer the TIP-1034 reserve precompile over the legacy MPP reserve contract. Besides using the protocol-native reserve surface, that path offers several gas-saving benefits, including packed reserve storage slots and [implicit approvals](#tip-1035-implicit-approvals-list). With implicit approvals, the precompile calls internal `system_transfer_from` rather than regular `transferFrom`, so users do not need a separate allowance approval and reserve flows avoid the gas cost of the approval write.
 
 ## Feature TIPs
 

--- a/src/pages/protocol/upgrades/t5.mdx
+++ b/src/pages/protocol/upgrades/t5.mdx
@@ -42,6 +42,8 @@ Most of T5 is additive. The notes below cover behaviors that integrators, indexe
 
 Not a breaking change at the contract level — the existing application-level MPP reserve contract continues to work after T5. The new precompile lives at [`0x4D50500000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x4D50500000000000000000000000000000000000) (ASCII `MPP`). To migrate to the precompile path, MPP libraries need to be upgraded to versions that target it; new releases will be linked under [Compatible SDK releases](#compatible-sdk-releases) once published. Tooling that monitors or interacts with MPP reserve should be aware of both surfaces during the transition.
 
+SDKs that target the precompile also benefit from [TIP-1035 implicit approvals](#tip-1035-implicit-approvals-list): reserve can pull TIP-20 tokens with the internal `system_transfer_from` path instead of a public `transferFrom`, avoiding the separate approval transaction and allowance storage write.
+
 ### Payment lane selector allow-list (TIP-1045)
 
 Anything that classifies transactions as "payments" (indexers, explorers, payment processors) should pick up the new selector allow-list. The list covers TIP-20 calls and the new `TIP20ChannelReserve` precompile (TIP-1034).
@@ -74,6 +76,8 @@ Use an SVG for `logoURI` so it renders crisply at any resolution across wallets 
 ## Compatible SDK releases
 
 T5-compatible SDK releases will be listed here as they ship.
+
+These releases should prefer the TIP-1034 reserve precompile over the legacy MPP reserve contract. Besides using the protocol-native reserve surface, that path lets the precompile rely on [TIP-1035 implicit approvals](#tip-1035-implicit-approvals-list): it calls internal `system_transfer_from` rather than regular `transferFrom`, so users do not need a separate allowance approval and reserve flows avoid the gas cost of the approval write.
 
 ## Feature TIPs
 

--- a/src/pages/protocol/upgrades/t5.mdx
+++ b/src/pages/protocol/upgrades/t5.mdx
@@ -77,7 +77,7 @@ Use an SVG for `logoURI` so it renders crisply at any resolution across wallets 
 
 T5-compatible SDK releases will be listed here as they ship.
 
-These releases should prefer the TIP-1034 reserve precompile over the legacy MPP reserve contract. Besides using the protocol-native reserve surface, that path lets the precompile rely on [TIP-1035 implicit approvals](#tip-1035-implicit-approvals-list): it calls internal `system_transfer_from` rather than regular `transferFrom`, so users do not need a separate allowance approval and reserve flows avoid the gas cost of the approval write.
+These releases should prefer the TIP-1034 reserve precompile over the legacy MPP reserve contract. Besides using the protocol-native reserve surface, that path offers several gas-saving benefits, including packed reserve storage slots and [TIP-1035 implicit approvals](#tip-1035-implicit-approvals-list). With implicit approvals, the precompile calls internal `system_transfer_from` rather than regular `transferFrom`, so users do not need a separate allowance approval and reserve flows avoid the gas cost of the approval write.
 
 ## Feature TIPs
 

--- a/src/pages/protocol/upgrades/t5.mdx
+++ b/src/pages/protocol/upgrades/t5.mdx
@@ -42,7 +42,7 @@ Most of T5 is additive. The notes below cover behaviors that integrators, indexe
 
 Not a breaking change at the contract level — the existing application-level MPP reserve contract continues to work after T5. The new precompile lives at [`0x4D50500000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x4D50500000000000000000000000000000000000) (ASCII `MPP`). To migrate to the precompile path, MPP libraries need to be upgraded to versions that target it; new releases will be linked under [Compatible SDK releases](#compatible-sdk-releases) once published. Tooling that monitors or interacts with MPP reserve should be aware of both surfaces during the transition.
 
-SDKs that target the precompile also benefit from [TIP-1035 implicit approvals](#tip-1035-implicit-approvals-list): reserve can pull TIP-20 tokens with the internal `system_transfer_from` path instead of a public `transferFrom`, avoiding the separate approval transaction and allowance storage write.
+SDKs that target the precompile also benefit from extra gas savings thanks to [implicit approvals](#tip-1035-implicit-approvals-list): the channel reserve can pull TIP-20 tokens with the internal `system_transfer_from` path instead of a public `transferFrom`, avoiding the separate approval transaction and allowance storage write.
 
 ### Payment lane selector allow-list (TIP-1045)
 


### PR DESCRIPTION
## Summary
- note that SDKs targeting the TIP-1034 reserve precompile also get TIP-1035 implicit approval benefits
- call out that `system_transfer_from` avoids regular `transferFrom` approvals and allowance write gas in compatible SDK guidance

## Validation
- `corepack pnpm check:types`
- `corepack pnpm build` started but was stopped after Vite transform stayed quiet for ~2 minutes

Prompted by: @0xrusowsky