### PR TITLE
Add HSTS header

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -144,5 +144,16 @@
       "source": "/ingest/:path(.*)",
       "destination": "https://us.i.posthog.com/:path"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add `Strict-Transport-Security: max-age=63072000; includeSubDomains` to all Vercel-served docs pages and redirects

## Test plan
- `jq empty vercel.json`

Prompted by: @samczsun