### PR TITLE
docs: add hosted TIDX indexer docs

### DIFF
--- a/src/components/TidxQuery.tsx
+++ b/src/components/TidxQuery.tsx
@@ -76,7 +76,7 @@ LIMIT 5`,
     network: 'mainnet',
     engine: 'clickhouse',
     signature: 'Transfer(address,address,uint256)',
-    sql: `SELECT "from", "to", value, block_num, tx_hash
+    sql: `SELECT arg0 AS from_address, arg1 AS to_address, arg2 AS value, block_num, tx_hash
 FROM Transfer
 ORDER BY block_num DESC
 LIMIT 5`,

--- a/src/components/TidxQuery.tsx
+++ b/src/components/TidxQuery.tsx
@@ -1,0 +1,276 @@
+'use client'
+
+import * as React from 'react'
+import { Container } from './Container'
+import { SqlEditor } from './SqlEditor'
+
+type Network = {
+  name: string
+  chainId: number
+  endpoint: string
+}
+
+type Preset = {
+  name: string
+  description: string
+  network: 'mainnet' | 'testnet'
+  engine: 'postgres' | 'clickhouse'
+  signature?: string
+  sql: string
+}
+
+type TidxResponse = {
+  columns: string[]
+  rows: Array<Array<string | number | boolean | null>>
+  row_count: number
+  engine: string
+  query_time_ms?: number
+  ok: boolean
+}
+
+const NETWORKS = {
+  mainnet: {
+    name: 'Mainnet',
+    chainId: 4217,
+    endpoint: 'https://indexer.tempo.xyz',
+  },
+  testnet: {
+    name: 'Testnet',
+    chainId: 42431,
+    endpoint: 'https://indexer.testnet.tempo.xyz',
+  },
+} as const satisfies Record<string, Network>
+
+const PRESETS: Preset[] = [
+  {
+    name: 'Latest blocks',
+    description: 'Read the most recent blocks from mainnet.',
+    network: 'mainnet',
+    engine: 'clickhouse',
+    sql: `SELECT num, hash, timestamp
+FROM blocks
+ORDER BY num DESC
+LIMIT 5`,
+  },
+  {
+    name: 'Block count',
+    description: 'Run a simple aggregate over the blocks table.',
+    network: 'mainnet',
+    engine: 'clickhouse',
+    sql: `SELECT count() AS block_count
+FROM blocks`,
+  },
+  {
+    name: 'Recent transactions',
+    description: 'Inspect recent testnet transactions.',
+    network: 'testnet',
+    engine: 'clickhouse',
+    sql: `SELECT block_num, hash, "from", "to"
+FROM txs
+ORDER BY block_num DESC
+LIMIT 5`,
+  },
+  {
+    name: 'Decode Transfer events',
+    description: 'Use a signature to query decoded event logs.',
+    network: 'mainnet',
+    engine: 'clickhouse',
+    signature: 'Transfer(address,address,uint256)',
+    sql: `SELECT "from", "to", value, block_num, tx_hash
+FROM Transfer
+ORDER BY block_num DESC
+LIMIT 5`,
+  },
+]
+
+function shorten(value: string) {
+  if (!value.startsWith('0x') || value.length <= 18) return value
+  return `${value.slice(0, 8)}...${value.slice(-6)}`
+}
+
+function renderValue(value: string | number | boolean | null) {
+  if (value === null) return <span className="text-gray9 italic">null</span>
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'string') return shorten(value)
+  return String(value)
+}
+
+export function TidxQuery() {
+  const [presetIndex, setPresetIndex] = React.useState(0)
+  const activePreset = PRESETS[presetIndex] ?? PRESETS[0]
+  const [networkKey, setNetworkKey] = React.useState<'mainnet' | 'testnet'>(activePreset.network)
+  const [engine, setEngine] = React.useState<'postgres' | 'clickhouse'>(activePreset.engine)
+  const [signature, setSignature] = React.useState(activePreset.signature ?? '')
+  const [sql, setSql] = React.useState(activePreset.sql)
+  const [result, setResult] = React.useState<TidxResponse | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [isLoading, setIsLoading] = React.useState(false)
+
+  const network = NETWORKS[networkKey]
+
+  const applyPreset = (nextIndex: number) => {
+    const next = PRESETS[nextIndex] ?? PRESETS[0]
+    setPresetIndex(nextIndex)
+    setNetworkKey(next.network)
+    setEngine(next.engine)
+    setSignature(next.signature ?? '')
+    setSql(next.sql)
+    setResult(null)
+    setError(null)
+  }
+
+  const runQuery = async () => {
+    const query = sql.trim()
+    if (!query) {
+      setError('Enter a SQL query.')
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+    setResult(null)
+
+    try {
+      const url = new URL('/query', network.endpoint)
+      url.searchParams.set('chainId', String(network.chainId))
+      url.searchParams.set('engine', engine)
+      url.searchParams.set('sql', query)
+      if (signature.trim()) url.searchParams.set('signature', signature.trim())
+
+      const response = await fetch(url)
+      const json = await response.json()
+
+      if (!response.ok || json.ok === false) {
+        const message =
+          typeof json === 'object' && json !== null && 'error' in json
+            ? String((json as { error: unknown }).error)
+            : response.statusText
+        throw new Error(message)
+      }
+
+      setResult(json as TidxResponse)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Query failed.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Container
+      headerLeft={
+        <h4 className="font-normal text-[14px] text-gray12 leading-none">Hosted TIDX Query</h4>
+      }
+      headerRight={
+        <button
+          type="button"
+          onClick={runQuery}
+          disabled={isLoading}
+          className="rounded-md bg-accent px-3 py-1.5 text-sm text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isLoading ? 'Running...' : 'Run query'}
+        </button>
+      }
+    >
+      <div className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-3">
+          <label className="space-y-1 text-sm">
+            <span className="text-gray11">Example</span>
+            <select
+              value={presetIndex}
+              onChange={(event) => applyPreset(Number(event.target.value))}
+              className="w-full rounded-md border border-gray6 bg-gray1 px-3 py-2 text-gray12"
+            >
+              {PRESETS.map((preset, index) => (
+                <option key={preset.name} value={index}>
+                  {preset.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="text-gray11">Network</span>
+            <select
+              value={networkKey}
+              onChange={(event) => setNetworkKey(event.target.value as 'mainnet' | 'testnet')}
+              className="w-full rounded-md border border-gray6 bg-gray1 px-3 py-2 text-gray12"
+            >
+              {Object.entries(NETWORKS).map(([key, value]) => (
+                <option key={key} value={key}>
+                  {value.name} ({value.chainId})
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="text-gray11">Engine</span>
+            <select
+              value={engine}
+              onChange={(event) => setEngine(event.target.value as 'postgres' | 'clickhouse')}
+              className="w-full rounded-md border border-gray6 bg-gray1 px-3 py-2 text-gray12"
+            >
+              <option value="clickhouse">ClickHouse</option>
+              <option value="postgres">PostgreSQL</option>
+            </select>
+          </label>
+        </div>
+
+        <p className="text-gray11 text-sm">{activePreset.description}</p>
+
+        <label className="block space-y-1 text-sm">
+          <span className="text-gray11">Event signature (optional)</span>
+          <input
+            value={signature}
+            onChange={(event) => setSignature(event.target.value)}
+            placeholder="Transfer(address,address,uint256)"
+            className="w-full rounded-md border border-gray6 bg-gray1 px-3 py-2 font-mono text-gray12"
+          />
+        </label>
+
+        <SqlEditor value={sql} onChange={setSql} minHeight="180px" />
+
+        {error && (
+          <div className="rounded-md border border-red6 bg-red2 px-3 py-2 text-red11 text-sm">
+            {error}
+          </div>
+        )}
+
+        {result && (
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2 text-gray11 text-xs">
+              <span>Rows: {result.row_count}</span>
+              <span>Engine: {result.engine}</span>
+              {result.query_time_ms !== undefined && (
+                <span>Query time: {result.query_time_ms.toFixed(1)} ms</span>
+              )}
+            </div>
+            <div className="overflow-x-auto rounded-md border border-gray6">
+              <table className="min-w-full text-left text-sm">
+                <thead className="bg-gray2 text-gray11">
+                  <tr>
+                    {result.columns.map((column) => (
+                      <th key={column} className="px-3 py-2 font-medium">
+                        {column}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.rows.map((row) => (
+                    <tr key={JSON.stringify(row)} className="border-gray5 border-t">
+                      {result.columns.map((column, cellIndex) => (
+                        <td key={column} className="px-3 py-2 font-mono">
+                          {renderValue(row[cellIndex] ?? null)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/src/pages/developer-tools/indexer.mdx
+++ b/src/pages/developer-tools/indexer.mdx
@@ -1,0 +1,138 @@
+---
+title: Indexer (TIDX)
+description: Query Tempo blocks, transactions, logs, token balances, and decoded events through Tempo's hosted TIDX indexer.
+interactive: true
+---
+
+import { Card, Cards } from 'vocs'
+import { TidxQuery } from '../../components/TidxQuery'
+
+# Indexer (TIDX)
+
+Tempo provides a free indexing service built on [TIDX](https://github.com/tempoxyz/tidx). It exposes structured Tempo chain data over SQL, with PostgreSQL for point lookups and ClickHouse for analytics queries.
+
+Use it when you need block, transaction, log, token, holder, or decoded event data without running your own indexing pipeline.
+
+## Hosted endpoints
+
+The public hosted endpoints are unauthenticated, read-only, and CORS-enabled.
+
+| Network | URL | Chain ID |
+| --- | --- | --- |
+| Mainnet | `https://indexer.tempo.xyz` | `4217` |
+| Testnet | `https://indexer.testnet.tempo.xyz` | `42431` |
+
+### Rate limits
+
+The public hosted endpoints are rate-limited. Responses include `X-Ratelimit-Limit`, `X-Ratelimit-Remaining`, and `X-Ratelimit-Reset` headers.
+
+Clients should keep queries bounded, include explicit `LIMIT` clauses, avoid polling expensive aggregates, and back off when remaining quota is low.
+
+## Using in production
+
+The free hosted TIDX endpoints are useful for prototyping, demos, scripts, and low-volume reads. They do not currently come with uptime, latency, support, or data freshness SLAs.
+
+For production systems that need stronger guarantees, dedicated support, custom schemas, or predictable low-cost indexing at scale, use an indexing partner from the [Data & Analytics partners page](/ecosystem/data-analytics).
+
+## Query TIDX
+
+### Latest blocks
+
+```bash
+curl -G "https://indexer.tempo.xyz/query" \
+  --data-urlencode "chainId=4217" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "sql=SELECT num, hash, timestamp FROM blocks ORDER BY num DESC LIMIT 5"
+```
+
+### Decoded events
+
+```bash
+curl -G "https://indexer.tempo.xyz/query" \
+  --data-urlencode "chainId=4217" \
+  --data-urlencode "engine=clickhouse" \
+  --data-urlencode "signature=Transfer(address,address,uint256)" \
+  --data-urlencode 'sql=SELECT "from", "to", value, block_num, tx_hash FROM Transfer ORDER BY block_num DESC LIMIT 5'
+```
+
+### Status
+
+```bash
+curl "https://indexer.tempo.xyz/status"
+```
+
+## Interactive example
+
+Run live SQL against the hosted indexer.
+
+<TidxQuery />
+
+## API reference
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /health` | Health check |
+| `GET /status` | Sync status for indexed chains |
+| `GET /query` | Execute a read-only SQL query |
+| `GET /views?chainId=` | List ClickHouse materialized views |
+| `GET /views/{name}?chainId=` | Get materialized view details |
+
+`/query` accepts these parameters:
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `chainId` | yes | `4217` for mainnet or `42431` for testnet |
+| `sql` | yes | Read-only SQL query |
+| `engine` | no | `postgres` or `clickhouse` |
+| `signature` | no | Event signature for decoded event tables |
+| `live` | no | Enables SSE streaming for PostgreSQL queries |
+
+:::info
+Creating or deleting materialized views is only available from trusted infrastructure. Use the hosted endpoints for read-only queries, or run your own TIDX instance when you need custom view management.
+:::
+
+## Run your own indexer
+
+The [TIDX repository](https://github.com/tempoxyz/tidx) includes Docker, source build, configuration, CLI, schema, and materialized view docs.
+
+```bash
+git clone https://github.com/tempoxyz/tidx
+cd tidx
+docker run -v $(pwd)/config.toml:/config.toml ghcr.io/tempoxyz/tidx up
+```
+
+See the [TIDX README](https://github.com/tempoxyz/tidx) for the full setup guide and CLI reference.
+
+## How it works
+
+TIDX writes chain data into two stores:
+
+- **PostgreSQL** for point lookups such as a single block, transaction, or address range.
+- **ClickHouse** for analytical queries such as aggregates, holder lists, and large scans.
+
+The `/query` endpoint accepts SQL and can expose decoded events on demand through the `signature` query parameter. For example, passing `Transfer(address,address,uint256)` creates a virtual `Transfer` table for that query.
+
+TIDX also maintains ClickHouse materialized tables for expensive common reads, such as token balances, token holders, supply, approvals, and address activity.
+
+## Next steps
+
+<Cards>
+  <Card
+    icon="lucide:search"
+    title="Tempo Explorer"
+    description="Inspect blocks, transactions, accounts, and token activity."
+    to="https://explore.tempo.xyz"
+  />
+  <Card
+    icon="lucide:plug"
+    title="Connection details"
+    description="Find RPC URLs, chain IDs, explorers, and network metadata."
+    to="/quickstart/connection-details"
+  />
+  <Card
+    icon="lucide:package"
+    title="SDKs"
+    description="Build Tempo apps with TypeScript, Go, Rust, Python, and Foundry."
+    to="/sdk"
+  />
+</Cards>

--- a/src/pages/developer-tools/indexer.mdx
+++ b/src/pages/developer-tools/indexer.mdx
@@ -9,7 +9,7 @@ import { TidxQuery } from '../../components/TidxQuery'
 
 # Indexer (TIDX)
 
-Tempo provides a free indexing service built on [TIDX](https://github.com/tempoxyz/tidx). It exposes structured Tempo chain data over SQL, with PostgreSQL for point lookups and ClickHouse for analytics queries.
+For developers building on Tempo, Tempo Labs provides a free indexing service built on [TIDX](https://github.com/tempoxyz/tidx). It exposes structured Tempo chain data over SQL, with PostgreSQL for point lookups and ClickHouse for analytics queries.
 
 Use it when you need block, transaction, log, token, holder, or decoded event data without running your own indexing pipeline.
 

--- a/src/pages/developer-tools/indexer.mdx
+++ b/src/pages/developer-tools/indexer.mdx
@@ -28,9 +28,15 @@ The public hosted endpoints are rate-limited. Responses include `X-Ratelimit-Lim
 
 Clients should keep queries bounded, include explicit `LIMIT` clauses, avoid polling expensive aggregates, and back off when remaining quota is low.
 
+### Pricing
+
+Requests within the public rate limit are free. When a client exceeds the free quota, the hosted indexer returns an MPP challenge for paid overflow access at `$0.001` per request.
+
+Use an MPP-capable client, such as `tempo request`, for paid overflow traffic. Plain `curl` and browser requests can use the free quota, but they will not automatically pay a `402 Payment Required` challenge.
+
 ## Using in production
 
-The free hosted TIDX endpoints are useful for prototyping, demos, scripts, and low-volume reads. They do not currently come with uptime, latency, support, or data freshness SLAs.
+The hosted TIDX endpoints are useful for prototyping, demos, scripts, and low-volume reads. Free requests and MPP paid overflow access do not currently come with uptime, latency, support, or data freshness SLAs.
 
 For production systems that need stronger guarantees, dedicated support, custom schemas, or predictable low-cost indexing at scale, use an indexing partner from the [Data & Analytics partners page](/ecosystem/data-analytics).
 

--- a/src/pages/developer-tools/indexer.mdx
+++ b/src/pages/developer-tools/indexer.mdx
@@ -52,13 +52,13 @@ curl -G "https://indexer.tempo.xyz/query" \
   --data-urlencode "chainId=4217" \
   --data-urlencode "engine=clickhouse" \
   --data-urlencode "signature=Transfer(address,address,uint256)" \
-  --data-urlencode 'sql=SELECT "from", "to", value, block_num, tx_hash FROM Transfer ORDER BY block_num DESC LIMIT 5'
+  --data-urlencode 'sql=SELECT arg0 AS from_address, arg1 AS to_address, arg2 AS value, block_num, tx_hash FROM Transfer ORDER BY block_num DESC LIMIT 5'
 ```
 
-### Status
+### Health check
 
 ```bash
-curl "https://indexer.tempo.xyz/status"
+curl "https://indexer.tempo.xyz/health"
 ```
 
 ## Interactive example
@@ -72,7 +72,6 @@ Run live SQL against the hosted indexer.
 | Endpoint | Description |
 | --- | --- |
 | `GET /health` | Health check |
-| `GET /status` | Sync status for indexed chains |
 | `GET /query` | Execute a read-only SQL query |
 | `GET /views?chainId=` | List ClickHouse materialized views |
 | `GET /views/{name}?chainId=` | Get materialized view details |
@@ -110,7 +109,7 @@ TIDX writes chain data into two stores:
 - **PostgreSQL** for point lookups such as a single block, transaction, or address range.
 - **ClickHouse** for analytical queries such as aggregates, holder lists, and large scans.
 
-The `/query` endpoint accepts SQL and can expose decoded events on demand through the `signature` query parameter. For example, passing `Transfer(address,address,uint256)` creates a virtual `Transfer` table for that query.
+The `/query` endpoint accepts SQL and can expose decoded events on demand through the `signature` query parameter. For example, passing `Transfer(address,address,uint256)` creates a virtual `Transfer` table with decoded arguments such as `arg0`, `arg1`, and `arg2` for that query.
 
 TIDX also maintains ClickHouse materialized tables for expensive common reads, such as token balances, token holders, supply, approvals, and address activity.
 

--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -93,6 +93,12 @@ Get started with the [Squid docs](https://docs.squidrouter.com/) or try the [bri
 
 ## Data & Analytics
 
+### Tempo Indexer (TIDX)
+
+[TIDX](/developer-tools/indexer) is Tempo's hosted indexer for querying blocks, transactions, logs, token balances, and decoded events through SQL. Use the public mainnet endpoint at `https://indexer.tempo.xyz` or the testnet endpoint at `https://indexer.testnet.tempo.xyz`.
+
+The hosted indexer powers explorer-style reads and supports ClickHouse-backed analytical queries for expensive reads like holder lists and token activity. Try the [interactive TIDX example](/developer-tools/indexer#interactive-example) or read the [TIDX README](https://github.com/tempoxyz/tidx) to run your own indexer.
+
 ### Allium
 
 [Allium](https://www.allium.so) is an enterprise blockchain data platform that delivers real-time, analytics-ready datasets through a unified schema across chains. Developers can fetch wallet, token, and price data in milliseconds without managing infrastructure, decoding raw data, or inferring transactions—making it easy to focus on building Tempo applications.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -761,6 +761,10 @@ export default defineConfig({
             link: '/accounts',
           },
           {
+            text: 'Indexer (TIDX)',
+            link: '/developer-tools/indexer',
+          },
+          {
             text: 'CLI',
             collapsed: true,
             items: [


### PR DESCRIPTION
## Summary

Add hosted TIDX indexer documentation under Developer Tools, including endpoint details, API usage, and interactive SQL examples.