### PR TITLE
docs: style tidx as code

### DIFF
--- a/src/components/TidxQuery.tsx
+++ b/src/components/TidxQuery.tsx
@@ -159,7 +159,9 @@ export function TidxQuery() {
   return (
     <Container
       headerLeft={
-        <h4 className="font-normal text-[14px] text-gray12 leading-none">Hosted TIDX Query</h4>
+        <h4 className="font-normal text-[14px] text-gray12 leading-none">
+          Hosted <code>tidx</code> Query
+        </h4>
       }
       headerRight={
         <button

--- a/src/pages/developer-tools/indexer.mdx
+++ b/src/pages/developer-tools/indexer.mdx
@@ -1,15 +1,15 @@
 ---
-title: Indexer (TIDX)
-description: Query Tempo blocks, transactions, logs, token balances, and decoded events through Tempo's hosted TIDX indexer.
+title: Indexer (tidx)
+description: Query Tempo blocks, transactions, logs, token balances, and decoded events through Tempo's hosted tidx indexer.
 interactive: true
 ---
 
 import { Card, Cards } from 'vocs'
 import { TidxQuery } from '../../components/TidxQuery'
 
-# Indexer (TIDX)
+# Indexer (`tidx`)
 
-For developers building on Tempo, Tempo Labs provides a free indexing service built on [TIDX](https://github.com/tempoxyz/tidx). It exposes structured Tempo chain data over SQL, with PostgreSQL for point lookups and ClickHouse for analytics queries.
+For developers building on Tempo, Tempo Labs provides a free indexing service built on [`tidx`](https://github.com/tempoxyz/tidx). It exposes structured Tempo chain data over SQL, with PostgreSQL for point lookups and ClickHouse for analytics queries.
 
 Use it when you need block, transaction, log, token, holder, or decoded event data without running your own indexing pipeline.
 
@@ -36,11 +36,11 @@ Use an MPP-capable client, such as `tempo request`, for paid overflow traffic. P
 
 ## Using in production
 
-The hosted TIDX endpoints are useful for prototyping, demos, scripts, and low-volume reads. Free requests and MPP paid overflow access do not currently come with uptime, latency, support, or data freshness SLAs.
+The hosted `tidx` endpoints are useful for prototyping, demos, scripts, and low-volume reads. Free requests and MPP paid overflow access do not currently come with uptime, latency, support, or data freshness SLAs.
 
 For production systems that need stronger guarantees, dedicated support, custom schemas, or predictable low-cost indexing at scale, use an indexing partner from the [Data & Analytics partners page](/ecosystem/data-analytics).
 
-## Query TIDX
+## Query `tidx`
 
 ### Latest blocks
 
@@ -93,12 +93,12 @@ Run live SQL against the hosted indexer.
 | `live` | no | Enables SSE streaming for PostgreSQL queries |
 
 :::info
-Creating or deleting materialized views is only available from trusted infrastructure. Use the hosted endpoints for read-only queries, or run your own TIDX instance when you need custom view management.
+Creating or deleting materialized views is only available from trusted infrastructure. Use the hosted endpoints for read-only queries, or run your own `tidx` instance when you need custom view management.
 :::
 
 ## Run your own indexer
 
-The [TIDX repository](https://github.com/tempoxyz/tidx) includes Docker, source build, configuration, CLI, schema, and materialized view docs.
+The [`tidx` repository](https://github.com/tempoxyz/tidx) includes Docker, source build, configuration, CLI, schema, and materialized view docs.
 
 ```bash
 git clone https://github.com/tempoxyz/tidx
@@ -106,18 +106,18 @@ cd tidx
 docker run -v $(pwd)/config.toml:/config.toml ghcr.io/tempoxyz/tidx up
 ```
 
-See the [TIDX README](https://github.com/tempoxyz/tidx) for the full setup guide and CLI reference.
+See the [`tidx` README](https://github.com/tempoxyz/tidx) for the full setup guide and CLI reference.
 
 ## How it works
 
-TIDX writes chain data into two stores:
+`tidx` writes chain data into two stores:
 
 - **PostgreSQL** for point lookups such as a single block, transaction, or address range.
 - **ClickHouse** for analytical queries such as aggregates, holder lists, and large scans.
 
 The `/query` endpoint accepts SQL and can expose decoded events on demand through the `signature` query parameter. For example, passing `Transfer(address,address,uint256)` creates a virtual `Transfer` table with decoded arguments such as `arg0`, `arg1`, and `arg2` for that query.
 
-TIDX also maintains ClickHouse materialized tables for expensive common reads, such as token balances, token holders, supply, approvals, and address activity.
+`tidx` also maintains ClickHouse materialized tables for expensive common reads, such as token balances, token holders, supply, approvals, and address activity.
 
 ## Next steps
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -761,7 +761,7 @@ export default defineConfig({
             link: '/accounts',
           },
           {
-            text: 'Indexer (TIDX)',
+            text: 'Indexer (`tidx`)',
             link: '/developer-tools/indexer',
           },
           {

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -761,7 +761,7 @@ export default defineConfig({
             link: '/accounts',
           },
           {
-            text: 'Indexer (`tidx`)',
+            text: 'Indexer (tidx)',
             link: '/developer-tools/indexer',
           },
           {


### PR DESCRIPTION
## Summary

Style tidx as inline code and lowercase on the indexer page, interactive query header, and sidebar.
