### PR TITLE
docs: group tidx under hosted services

### DIFF
--- a/src/pages/hosted-services/index.mdx
+++ b/src/pages/hosted-services/index.mdx
@@ -1,0 +1,25 @@
+---
+title: Hosted Services
+description: Use Tempo-hosted services for managed infrastructure, including fee sponsorship and TIDX SQL access to Tempo network data.
+---
+
+import { Card, Cards } from 'vocs'
+
+# Hosted Services
+
+Tempo-hosted services provide managed infrastructure for common integration needs.
+
+<Cards>
+  <Card
+    icon="lucide:badge-dollar-sign"
+    title="Hosted Fee Payer"
+    description="Sponsor Tempo transaction fees through hosted JSON-RPC relay endpoints."
+    to="/developer-tools/fee-payer"
+  />
+  <Card
+    icon="lucide:database"
+    title="Indexer (tidx)"
+    description="Query Tempo blocks, transactions, logs, token balances, and decoded events through SQL."
+    to="/developer-tools/indexer"
+  />
+</Cards>

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
       sdk: 'SDKs',
       cli: 'CLI',
       ecosystem: 'ECOSYSTEM',
+      'hosted-services': 'HOSTED SERVICES',
       learn: 'LEARN',
       wallet: 'WALLET',
       accounts: 'ACCOUNTS',
@@ -758,21 +759,24 @@ export default defineConfig({
         items: [
           {
             text: 'Hosted Services',
-            collapsed: true,
             items: [
+              {
+                text: 'Overview',
+                link: '/hosted-services',
+              },
               {
                 text: 'Hosted Fee Payer',
                 link: '/developer-tools/fee-payer',
+              },
+              {
+                text: 'Indexer (tidx)',
+                link: '/developer-tools/indexer',
               },
             ],
           },
           {
             text: 'Accounts SDK',
             link: '/accounts',
-          },
-          {
-            text: 'Indexer (tidx)',
-            link: '/developer-tools/indexer',
           },
           {
             text: 'CLI',


### PR DESCRIPTION
## Summary

Group the tidx indexer docs under Hosted Services, keep the section expanded by default, and add a Hosted Services overview page with cards for Hosted Fee Payer and Indexer.