### PR TITLE
Remove tidx production guidance

### DIFF
--- a/src/pages/developer-tools/indexer.mdx
+++ b/src/pages/developer-tools/indexer.mdx
@@ -34,12 +34,6 @@ Requests within the public rate limit are free. When a client exceeds the free q
 
 Use an MPP-capable client, such as `tempo request`, for paid overflow traffic. Plain `curl` and browser requests can use the free quota, but they will not automatically pay a `402 Payment Required` challenge.
 
-## Using in production
-
-The hosted `tidx` endpoints are useful for prototyping, demos, scripts, and low-volume reads. Free requests and MPP paid overflow access do not currently come with uptime, latency, support, or data freshness SLAs.
-
-For production systems that need stronger guarantees, dedicated support, custom schemas, or predictable low-cost indexing at scale, use an indexing partner from the [Data & Analytics partners page](/ecosystem/data-analytics).
-
 ## Query `tidx`
 
 ### Latest blocks


### PR DESCRIPTION
## Summary
- Remove the `Using in production` section from the hosted tidx indexer docs.

## Verification
- `rg -n "Using in production|uptime, latency, support|Data & Analytics partners page" src/pages/developer-tools/indexer.mdx || true`
- `git diff --check`
- Attempted `corepack pnpm build`; dependencies installed with `corepack pnpm install --frozen-lockfile`, but the build hung in the Vite/Vocs production build phase for ~7 minutes and was stopped.

Prompted by: @brendanjryan