### PR TITLE
Refresh stale docs landing pages

### DIFF
--- a/src/pages/guide/issuance/index.mdx
+++ b/src/pages/guide/issuance/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Stablecoin Issuance
 
-Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
+Create and manage your own stablecoin on Tempo. Learn how to deploy a TIP-20 token, mint supply, configure permissions, fund fee payments, and integrate the token with Tempo's payment infrastructure.
 
 <Cards>
   <Card

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # SDKs
 
-Tempo is building clients in multiple languages to make integration as easy as possible.
+Tempo clients are organized by language and toolchain so teams can integrate with the network from the stack they already use. Start with TypeScript for web and backend applications, Foundry for contract development, or the lower-level Go and Rust SDKs when you need direct control over node or protocol interactions.
 
 <Cards>
   <Card


### PR DESCRIPTION
Updates two stale docs landing pages with more specific, useful guidance so their modified timestamps reflect substantive content maintenance.\n\n- Clarifies SDK selection by stack/toolchain\n- Clarifies the stablecoin issuance guide path with TIP-20, permissions, fees, and integration context