### PR TITLE
docs: use cast keychain in Foundry access key example

### DIFF
--- a/src/pages/sdk/foundry/index.mdx
+++ b/src/pages/sdk/foundry/index.mdx
@@ -286,10 +286,9 @@ cast send <CONTRACT_ADDRESS> 'increment()' \
   --tempo.expiring-nonce --tempo.valid-before $VALID_BEFORE
 
 # Send with access key (delegated signing):
-# First authorize the key via Account Keychain precompile
-cast send 0xAAAAAAAA00000000000000000000000000000000 \
-  'authorizeKey(address,uint8,(uint64,bool,(address,uint256,uint64)[],bool,(address,(bytes4,address[])[])[]))' \
-  $ACCESS_KEY_ADDR 0 '(1893456000,false,[],true,[])' \
+# First authorize the key with the Account Keychain CLI
+EXPIRY=$(($(date +%s) + 86400))
+cast keychain authorize $ACCESS_KEY_ADDR secp256k1 $EXPIRY \
   --rpc-url $TEMPO_RPC_URL \
   --private-key $ROOT_PRIVATE_KEY
 # Then send using the access key
@@ -444,4 +443,3 @@ cast call 0xAAAAAAAA00000000000000000000000000000000 \
   <ACCOUNT> <KEY_ID> <TOKEN_ADDRESS> \
   --rpc-url $TEMPO_RPC_URL
 ```
-


### PR DESCRIPTION
## Summary
- update the Foundry access-key example to use `cast keychain authorize` instead of hand-encoding `authorizeKey(...)` calldata
- keeps the example aligned with the current Account Keychain CLI and avoids stale ABI copy-paste paths

## Validation
- `corepack pnpm check:types`
- `corepack pnpm build` was attempted, but Vite hung during search-index/client-reference analysis after dependency installation; stopped after several minutes with no failure output

Prompted by: @DaniPopes