### PR TITLE
Add TRES to ecosystem docs

### DIFF
--- a/src/pages/ecosystem/security-compliance.mdx
+++ b/src/pages/ecosystem/security-compliance.mdx
@@ -30,3 +30,7 @@ Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.el
 [TRM Labs](https://www.trmlabs.com) delivers blockchain intelligence and compliance infrastructure for detecting fraud, money laundering, and financial crime. TRM supports Tempo with transaction monitoring, wallet screening, and risk assessment tools that help platforms operate safely and meet regulatory requirements.
 
 Get started at [trmlabs.com](https://www.trmlabs.com) or explore their [documentation](https://docs.trmlabs.com/).
+
+## TRES
+
+[TRES](https://www.tres.finance) is the accounting and reconciliation layer for digital asset payments. TRES reconciles onchain settlement against internal and custodial records daily, then delivers the output in bank-grade formats such as MT940 and custom formats so finance and treasury teams can keep using their existing TMS and ERP without a rewrite.

--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -359,6 +359,10 @@ Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.el
 
 Get started at [trmlabs.com](https://www.trmlabs.com) or explore their [documentation](https://docs.trmlabs.com/).
 
+### TRES
+
+[TRES](https://www.tres.finance) is the accounting and reconciliation layer for digital asset payments. TRES reconciles onchain settlement against internal and custodial records daily, then delivers the output in bank-grade formats such as MT940 and custom formats so finance and treasury teams can keep using their existing TMS and ERP without a rewrite.
+
 ## Orchestration
 ### Brale
 


### PR DESCRIPTION
## Summary
- Add TRES to Security & Compliance ecosystem docs
- Add TRES to the developer tools Security & Compliance roundup

## Verification
- `corepack pnpm check:types`
- `corepack pnpm check` completed with existing warnings in scripts/lighthouse.ts

Prompted by: @juandolealt