### PR TITLE
Alphabetize TRES ecosystem docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@ Content for step 2.
 
 See https://mpp.dev/guides/multiple-payment-methods for a reference example.
 
+## Ecosystem Pages
+
+When adding or moving ecosystem partners, keep partner entries alphabetized by partner name within each category page under `src/pages/ecosystem/` and within the mirrored category sections in `src/pages/quickstart/developer-tools.mdx`.
+
 ## Project Structure
 
 - `src/pages/` - MDX documentation pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,10 +49,6 @@ Content for step 2.
 
 See https://mpp.dev/guides/multiple-payment-methods for a reference example.
 
-## Ecosystem Pages
-
-When adding or moving ecosystem partners, keep partner entries alphabetized by partner name within each category page under `src/pages/ecosystem/` and within the mirrored category sections in `src/pages/quickstart/developer-tools.mdx`.
-
 ## Project Structure
 
 - `src/pages/` - MDX documentation pages

--- a/src/pages/ecosystem/security-compliance.mdx
+++ b/src/pages/ecosystem/security-compliance.mdx
@@ -25,12 +25,12 @@ Discover how Hexagate supports Tempo [here](https://www.hexagate.com), or reques
 
 Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.elliptic.co) or explore their [developer docs](https://docs.elliptic.co/).
 
+## TRES
+
+[TRES](https://www.tres.finance) is the accounting and reconciliation layer for digital asset payments. TRES reconciles onchain settlement against internal and custodial records daily, then delivers the output in bank-grade formats such as MT940 and custom formats so finance and treasury teams can keep using their existing TMS and ERP without a rewrite.
+
 ## TRM Labs
 
 [TRM Labs](https://www.trmlabs.com) delivers blockchain intelligence and compliance infrastructure for detecting fraud, money laundering, and financial crime. TRM supports Tempo with transaction monitoring, wallet screening, and risk assessment tools that help platforms operate safely and meet regulatory requirements.
 
 Get started at [trmlabs.com](https://www.trmlabs.com) or explore their [documentation](https://docs.trmlabs.com/).
-
-## TRES
-
-[TRES](https://www.tres.finance) is the accounting and reconciliation layer for digital asset payments. TRES reconciles onchain settlement against internal and custodial records daily, then delivers the output in bank-grade formats such as MT940 and custom formats so finance and treasury teams can keep using their existing TMS and ERP without a rewrite.

--- a/src/pages/ecosystem/security-compliance.mdx
+++ b/src/pages/ecosystem/security-compliance.mdx
@@ -30,3 +30,7 @@ Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.el
 [TRM Labs](https://www.trmlabs.com) delivers blockchain intelligence and compliance infrastructure for detecting fraud, money laundering, and financial crime. TRM supports Tempo with transaction monitoring, wallet screening, and risk assessment tools that help platforms operate safely and meet regulatory requirements.
 
 Get started at [trmlabs.com](https://www.trmlabs.com) or explore their [documentation](https://docs.trmlabs.com/).
+
+## TRES
+
+[TRES](https://www.tres.finance) is the accounting and reconciliation layer for digital asset payments. TRES reconciles onchain settlement against internal and custodial records daily, then delivers the output in bank-grade formats such as MT940 and custom formats so finance and treasury teams can keep using their existing TMS and ERP without a rewrite.

--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -353,15 +353,15 @@ Discover how Hexagate supports Tempo [here](https://www.hexagate.com), or reques
 
 Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.elliptic.co) or explore their [developer docs](https://docs.elliptic.co/).
 
+### TRES
+
+[TRES](https://www.tres.finance) is the accounting and reconciliation layer for digital asset payments. TRES reconciles onchain settlement against internal and custodial records daily, then delivers the output in bank-grade formats such as MT940 and custom formats so finance and treasury teams can keep using their existing TMS and ERP without a rewrite.
+
 ### TRM Labs
 
 [TRM Labs](https://www.trmlabs.com) delivers blockchain intelligence and compliance infrastructure for detecting fraud, money laundering, and financial crime. TRM supports Tempo with transaction monitoring, wallet screening, and risk assessment tools that help platforms operate safely and meet regulatory requirements.
 
 Get started at [trmlabs.com](https://www.trmlabs.com) or explore their [documentation](https://docs.trmlabs.com/).
-
-### TRES
-
-[TRES](https://www.tres.finance) is the accounting and reconciliation layer for digital asset payments. TRES reconciles onchain settlement against internal and custodial records daily, then delivers the output in bank-grade formats such as MT940 and custom formats so finance and treasury teams can keep using their existing TMS and ERP without a rewrite.
 
 ## Orchestration
 ### Brale

--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -359,6 +359,10 @@ Learn more about Elliptic's compliance solutions at [elliptic.co](https://www.el
 
 Get started at [trmlabs.com](https://www.trmlabs.com) or explore their [documentation](https://docs.trmlabs.com/).
 
+### TRES
+
+[TRES](https://www.tres.finance) is the accounting and reconciliation layer for digital asset payments. TRES reconciles onchain settlement against internal and custodial records daily, then delivers the output in bank-grade formats such as MT940 and custom formats so finance and treasury teams can keep using their existing TMS and ERP without a rewrite.
+
 ## Orchestration
 ### Brale
 


### PR DESCRIPTION
## Summary
- Moves TRES before TRM Labs in Security & Compliance so ecosystem entries remain alphabetized

Prompted by: @juandolealt

## Validation
- `corepack pnpm run check` (passes; existing `scripts/lighthouse.ts` explicit-any warnings remain)
- `corepack pnpm exec biome check --write --unsafe AGENTS.md src/pages/ecosystem/security-compliance.mdx src/pages/quickstart/developer-tools.mdx` (not applicable: Biome ignores these paths)