### PR TITLE
Refresh stale guide landing pages

### DIFF
--- a/src/pages/guide/issuance/index.mdx
+++ b/src/pages/guide/issuance/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Stablecoin Issuance
 
-Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
+Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, configure operational controls, and integrate your stablecoin with Tempo's payment infrastructure.
 
 <Cards>
   <Card

--- a/src/pages/guide/node/index.mdx
+++ b/src/pages/guide/node/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Tempo Node
 
-Running a Tempo node allows you to interact with the network directly, providing your own RPC access or contributing to network infrastructure. Nodes provide JSON-RPC API access for applications, explorers, and wallets but do not participate in consensus.
+Running a Tempo node allows you to interact with the network directly, provide your own RPC access, and operate network infrastructure with fewer third-party dependencies. RPC nodes serve JSON-RPC API access for applications, explorers, and wallets but do not participate in consensus.
 
 ## Supported Platforms
 

--- a/src/pages/guide/stablecoin-dex/index.mdx
+++ b/src/pages/guide/stablecoin-dex/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Exchange Stablecoins
 
-Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX enables optimal pricing for cross-stablecoin payments while minimizing chain load.
+Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX gives payment flows an onchain path between supported stablecoins while keeping pricing transparent and minimizing chain load.
 
 <Cards>
   <Card


### PR DESCRIPTION
## Summary
- refresh stale issuance, node, and stablecoin DEX guide landing pages with clarifying copy
- keep existing Vocs title/frontmatter behavior unchanged

## Verification
- git diff --check