### PR TITLE
Redirect accounts docs to Accounts site

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -33,6 +33,8 @@ exclude = [
   "^https?://([a-z0-9-]+\\.)*example\\.(com|org|net)",
   # SVG xmlns reference, not a real link.
   "^http://www\\.w3\\.org/2000/svg$",
+  # Vocs/Vercel route template, not a literal URL.
+  "^https://accounts\\.tempo\\.xyz/docs/:path\\*?$",
 ]
 
 # Reuse cached results across runs.

--- a/vercel.json
+++ b/vercel.json
@@ -71,17 +71,27 @@
     },
     {
       "source": "/accounts/server/compose",
-      "destination": "/accounts/server/handler.compose",
+      "destination": "https://accounts.tempo.xyz/docs/server/handler.compose",
       "permanent": true
     },
     {
       "source": "/accounts/server/relay",
-      "destination": "/accounts/server/handler.relay",
+      "destination": "https://accounts.tempo.xyz/docs/server/handler.relay",
       "permanent": true
     },
     {
       "source": "/accounts/server/webAuthn",
-      "destination": "/accounts/server/handler.webAuthn",
+      "destination": "https://accounts.tempo.xyz/docs/server/handler.webAuthn",
+      "permanent": true
+    },
+    {
+      "source": "/accounts",
+      "destination": "https://accounts.tempo.xyz/docs",
+      "permanent": true
+    },
+    {
+      "source": "/accounts/:path*",
+      "destination": "https://accounts.tempo.xyz/docs/:path*",
       "permanent": true
     },
     {

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -776,7 +776,7 @@ export default defineConfig({
           },
           {
             text: 'Accounts SDK',
-            link: '/accounts',
+            link: 'https://accounts.tempo.xyz/docs',
           },
           {
             text: 'CLI',
@@ -1379,27 +1379,37 @@ export default defineConfig({
     },
     {
       source: '/sdk/typescript/server',
-      destination: '/accounts/server',
+      destination: 'https://accounts.tempo.xyz/docs/server',
       status: 301,
     },
     {
       source: '/sdk/typescript/server/handlers',
-      destination: '/accounts/server',
+      destination: 'https://accounts.tempo.xyz/docs/server',
       status: 301,
     },
     {
       source: '/sdk/typescript/server/handler.compose',
-      destination: '/accounts/server/handler.compose',
+      destination: 'https://accounts.tempo.xyz/docs/server/handler.compose',
       status: 301,
     },
     {
       source: '/sdk/typescript/server/handler.feePayer',
-      destination: '/accounts/server/handler.relay',
+      destination: 'https://accounts.tempo.xyz/docs/server/handler.relay',
       status: 301,
     },
     {
       source: '/sdk/typescript/server/handler.keyManager',
-      destination: '/accounts/server/handler.webAuthn',
+      destination: 'https://accounts.tempo.xyz/docs/server/handler.webAuthn',
+      status: 301,
+    },
+    {
+      source: '/accounts',
+      destination: 'https://accounts.tempo.xyz/docs',
+      status: 301,
+    },
+    {
+      source: '/accounts/:path*',
+      destination: 'https://accounts.tempo.xyz/docs/:path*',
       status: 301,
     },
     {


### PR DESCRIPTION
Redirects the legacy Accounts SDK docs paths on docs.tempo.xyz to the dedicated Accounts docs site and updates the sidebar link.

Validation:
- corepack pnpm check:types
- git diff --check

Prompted by: @jxom