### PR TITLE
Fix Tempo Zones spec link

### DIFF
--- a/src/pages/protocol/zones/index.mdx
+++ b/src/pages/protocol/zones/index.mdx
@@ -45,7 +45,7 @@ Tempo Zones are interoperable with Tempo Mainnet and with each other. Deposits a
 
 ### Github and Specifications
 
-The zones repository is available on [github](https://github.com/tempoxyz/zones), which also includes the full Tempo Zones [specifications](https://github.com/tempoxyz/zones/blob/main/docs/specs/zone_spec.md).
+The zones repository is available on [github](https://github.com/tempoxyz/zones), which also includes the full Tempo Zones [specifications](https://github.com/tempoxyz/zones/blob/main/specs/spec.md).
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- Update the Tempo Zones docs link to point at the current spec path in tempoxyz/zones

## Testing
- Searched docs repo for remaining zone_spec.md references

Prompted by: @joshitzko