### PR TITLE
docs: position Tempo as its own L1, not just another EVM chain

### DIFF
--- a/src/pages/quickstart/connection-details.mdx
+++ b/src/pages/quickstart/connection-details.mdx
@@ -9,7 +9,7 @@ import { ConnectWallet } from '../../components/ConnectWallet.tsx'
 
 # Connect to the Network
 
-You can connect with Tempo like you would with any other EVM chain.
+Tempo is its own Layer 1, and you connect to it using standard EVM tooling and wallets.
 
 ## Connect using a Browser Wallet
 
@@ -18,7 +18,7 @@ Click on your browser wallet below to automatically connect it to the Tempo netw
 <ConnectWallet network="mainnet" />
 
 :::warning
-Note that on some wallets, you might see an unusually high "balance". This is because, historically, blockchain wallets have always assumed that a blockchain has a "native gas token". On Tempo, there is no native gas token, and so the value shown is a placeholder. See [EVM Differences](/quickstart/evm-compatibility#handling-eth-balance-checks) for more information on this quirk.
+On Tempo, gas is denominated in USD and paid in stablecoins — there is no native gas token. Because most wallets assume every chain has one, some may display a placeholder "balance". This is expected. See [EVM compatibility](/quickstart/evm-compatibility#handling-eth-balance-checks) for details.
 :::
 
 ## Connect via CLI

--- a/src/pages/quickstart/evm-compatibility.mdx
+++ b/src/pages/quickstart/evm-compatibility.mdx
@@ -1,14 +1,14 @@
 ---
-description: Learn how Tempo differs from Ethereum. Understand wallet behavior, fee token selection, VM layer changes, and fast finality consensus.
+description: Tempo is a payments-first Layer 1 that runs the EVM. Learn what works out of the box and the behaviors that differ by design — USD gas, fee tokens, and fast finality.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# EVM Differences
+# EVM Compatibility
 
-Tempo is fully compatible with the Ethereum Virtual Machine (EVM), targeting the **Osaka** EVM hard fork. Developers can deploy and interact with smart contracts using the same tools, languages, and frameworks they use on Ethereum, such as Solidity, Foundry, and Hardhat. All Ethereum JSON-RPC methods work out of the box. 
+Tempo is a payments-first Layer 1 that runs the Ethereum Virtual Machine (EVM) as its execution engine, targeting the **Osaka** hard fork. You can deploy and interact with smart contracts using the same languages and tools you use on Ethereum — Solidity, Foundry, and Hardhat — and standard JSON-RPC methods work out of the box.
 
-While the execution environment mirrors Ethereum's, Tempo introduces some differences optimized for payments, described below.
+Tempo is its own chain, not an Ethereum network. It has its own consensus, sub-second deterministic finality, and — most importantly for payments — no native gas token. Gas is denominated in USD and paid in stablecoins. The sections below cover the behaviors that differ from Ethereum by design, and how to build with them.
 
 <Cards>
   <Card
@@ -39,7 +39,7 @@ While the execution environment mirrors Ethereum's, Tempo introduces some differ
 
 ## Wallet Differences
 
-By default, all existing functionality will work for EVM-compatible wallets, with only a few quirks. For developers of wallets, we strongly encourage you to implement support for Tempo Transactions over regular EVM transactions. See the [transaction differences](#transaction-differences) for more.
+EVM-compatible wallets work with Tempo out of the box. Because Tempo has no native gas token, a few behaviors differ by design, covered below. For the best experience, we strongly encourage wallet developers to implement support for Tempo Transactions over regular EVM transactions. See the [transaction differences](#transaction-differences) for more.
 
 :::tip
 If you are building a wallet, read our [guide for wallet developers](/quickstart/wallet-developers).
@@ -47,9 +47,9 @@ If you are building a wallet, read our [guide for wallet developers](/quickstart
 
 ### Handling ETH (native token) Balance Checks
 
-Remember that on Tempo, there is no native gas token.
+On Tempo, gas is denominated in USD and paid in stablecoins. There is no native gas token, by design.
 
-Many wallets and applications check a user's "native account balance" before letting them complete some action. In this scenario, you might see an error message like "Insufficient balance".
+Many wallets and applications check a user's "native account balance" before letting them complete some action. Because Tempo has no native token, you might see an error message like "Insufficient balance".
 
 This stems from the return value of the `eth_getBalance` RPC method. When a wallet calls this method, it expects a hex string representing the "native token balance", hard-coded to be represented as an 18-decimal place number.
 
@@ -93,7 +93,7 @@ If a wallet wants to submit a non-TIP20 transaction without having to submit the
 
 ## VM Layer Differences
 
-At the VM layer, all opcodes are supported out of the box. Due to the lack of a native token, native token balance is always returning zero balances.
+At the VM layer, all opcodes are supported out of the box. Because Tempo has no native token, opcodes that read a native balance return zero. Tempo also prices state creation differently from Ethereum to keep payments cheap and protect against state growth. Both are deliberate design choices, detailed below.
 
 ### State Creation Costs
 

--- a/src/pages/quickstart/integrate-tempo.mdx
+++ b/src/pages/quickstart/integrate-tempo.mdx
@@ -9,7 +9,9 @@ import { Cards, Card } from 'vocs'
 
 # Integrate Tempo
 
-Tempo is fully compatible with the Ethereum Virtual Machine (EVM), targeting the **Osaka** EVM hard fork. So, everything you'd expect to work with Ethereum works on Tempo, with only a few exceptions which we detail on the [EVM Differences](/quickstart/evm-compatibility) page. 
+Tempo is a payments-first Layer 1 with its own consensus, sub-second deterministic finality, and USD-denominated gas. It runs the Ethereum Virtual Machine (EVM) as its execution engine, targeting the **Osaka** hard fork, so you can build with the languages and tools you already know — Solidity, Foundry, and Hardhat — and standard JSON-RPC methods work out of the box.
+
+Because Tempo is purpose-built for payments, a few behaviors differ from Ethereum by design. See [EVM compatibility](/quickstart/evm-compatibility) for the details.
 
 
 <Cards>

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -431,7 +431,7 @@ export default defineConfig({
             link: '/quickstart/faucet',
           },
           {
-            text: 'EVM Differences',
+            text: 'EVM Compatibility',
             link: '/quickstart/evm-compatibility',
           },
           {


### PR DESCRIPTION
Updates the wording on the quickstart pages so they describe Tempo as its own Layer 1 that runs the EVM, rather than as another EVM chain. Tone and framing only, no behavior changes.

The `learn/` pages already describe Tempo as a payments-first L1, but the quickstart pages led with "fully compatible with the EVM, everything works" and "connect like you would with any other EVM chain." That undersells what Tempo is and oversells how much works unchanged. The fact that gas is in USD and there is no native token was tucked away as the reason a balance check looks odd, when it is one of the main things that makes Tempo distinct.

Changes:
- integrate-tempo: open with Tempo as a payments-first L1 (own consensus, sub-second finality, USD gas) that runs the EVM as its execution engine.
- connection-details: "like any other EVM chain" becomes "standard EVM tooling"; the wallet balance note now explains USD gas instead of calling it a quirk.
- evm-compatibility: retitled "EVM Differences" to "EVM Compatibility"; says plainly that Tempo is its own chain, not an Ethereum network; presents the differences (no native token, state-creation costs) as design choices.
- vocs.config: sidebar label follows the retitle.

Page URLs and section anchors are unchanged, so existing links still work. `bun run build` and `bun run check` pass locally.
