### PR TITLE
Refresh stale docs index copy

### DIFF
--- a/src/pages/guide/issuance/index.mdx
+++ b/src/pages/guide/issuance/index.mdx
@@ -8,6 +8,8 @@ import { Cards, Card } from 'vocs'
 
 Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
 
+These guides cover the full lifecycle from token creation through minting, fee support, and operational controls.
+
 <Cards>
   <Card
     description="Create your own stablecoin using the TIP-20 token standard with built-in compliance features"

--- a/src/pages/guide/node/index.mdx
+++ b/src/pages/guide/node/index.mdx
@@ -8,6 +8,8 @@ import { Cards, Card } from 'vocs'
 
 Running a Tempo node allows you to interact with the network directly, providing your own RPC access or contributing to network infrastructure. Nodes provide JSON-RPC API access for applications, explorers, and wallets but do not participate in consensus.
 
+Start with the system requirements and installation guide, then use the RPC guide when you are ready to expose an endpoint for application traffic.
+
 ## Supported Platforms
 
 Prebuilt binaries are available for:

--- a/src/pages/guide/stablecoin-dex/index.mdx
+++ b/src/pages/guide/stablecoin-dex/index.mdx
@@ -8,6 +8,8 @@ import { Cards, Card } from 'vocs'
 
 Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX enables optimal pricing for cross-stablecoin payments while minimizing chain load.
 
+Use these guides when you need to route payments across stablecoins, inspect liquidity, or provide orders directly on the native exchange.
+
 <Cards>
   <Card
     description="Learn about pathUSD, the root quote token that powers stablecoin interoperability"

--- a/src/pages/learn/index.mdx
+++ b/src/pages/learn/index.mdx
@@ -10,6 +10,8 @@ Tempo is a general-purpose blockchain optimized for payments. Tempo is designed 
 
 Tempo was designed in close collaboration with an exceptional group of [design partners](https://tempo.xyz/ecosystem) who are helping to validate the system against real payment workloads. Here, we have written about what stablecoins are and how Tempo is designed from the ground up for the use cases they enable.
 
+If you are new to Tempo, start with the stablecoin primer and then use the case studies below to map the architecture to concrete payment flows.
+
 <Cards>
   <Card
     description="Learn what stablecoins are, how they work, and the real-world use cases they enable"

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -8,6 +8,8 @@ import { Cards, Card } from 'vocs'
 
 Tempo is building clients in multiple languages to make integration as easy as possible.
 
+Use the SDK for your application language, or pair these guides with the protocol references when you need lower-level transaction or token behavior.
+
 <Cards>
   <Card
     description="Build on Tempo using TypeScript"


### PR DESCRIPTION
## Summary
- Refresh copy on stale docs index pages with small useful guidance
- Covers node, learn, SDK, stablecoin issuance, and stablecoin DEX hubs

## Verification
- git diff --check
- combined-seo-guides merge-tree: clean
- pnpm build via Corepack started but Vite became idle with no output after the RSC build/search-index phase; stopped after confirming the node process was at 0% CPU