### PR TITLE
Refresh stale docs index copy

### DIFF
--- a/src/pages/guide/stablecoin-dex/index.mdx
+++ b/src/pages/guide/stablecoin-dex/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Exchange Stablecoins
 
-Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX enables optimal pricing for cross-stablecoin payments while minimizing chain load.
+Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX lets applications route between supported stablecoins through pathUSD, with onchain orderbook liquidity for quoting, swaps, and fee-token conversion.
 
 <Cards>
   <Card

--- a/src/pages/protocol/fees/index.mdx
+++ b/src/pages/protocol/fees/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Transaction Fees
 
-Tempo has no native token. Instead, transaction fees—including both gas fees and priority fees—can be paid directly in stablecoins. When you send a transaction, you can choose which supported stablecoin to use for fees.
+Tempo has no native token. Instead, transaction fees—including both gas fees and priority fees—can be paid directly in stablecoins. When you send a transaction, you can choose which supported stablecoin to use for fees, and the protocol converts the fee token through native liquidity when needed.
 
 For a stablecoin to be accepted, it must be USD-denominated, issued as a native TIP-20 contract, and have sufficient liquidity on the native Fee AMM.
 

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # SDKs
 
-Tempo is building clients in multiple languages to make integration as easy as possible.
+Tempo provides SDKs and tooling for common application stacks. Start with the language your service already uses, then pair the SDK with the payment, account, and protocol guides for the workflow you are building.
 
 <Cards>
   <Card


### PR DESCRIPTION
## Summary
- refresh stale copy on the stablecoin DEX guide index
- clarify SDK landing-page guidance
- clarify stablecoin fee conversion wording

## Verification
- `git diff --check`
- `pnpm build` not run: `pnpm` is not installed in the sandbox, and `corepack pnpm` could not reach registry.npmjs.org to download it.