### PR TITLE
docs: add receive policies learn page

### DIFF
--- a/src/pages/learn/tempo/index.mdx
+++ b/src/pages/learn/tempo/index.mdx
@@ -24,6 +24,12 @@ Explore the key features that make Tempo purpose-built for payments:
     title="Native Stablecoins"
   />
   <Card
+    description="Account controls for accepted tokens, allowed senders, and recovery paths for held sends"
+    to="/learn/tempo/receive-policies"
+    icon="lucide:shield-check"
+    title="Receive Policies"
+  />
+  <Card
     description="Batch transactions, fee sponsorship, scheduled payments, and passkey authentication"
     to="/learn/tempo/modern-transactions"
     icon="lucide:repeat"

--- a/src/pages/learn/tempo/receive-policies.mdx
+++ b/src/pages/learn/tempo/receive-policies.mdx
@@ -56,7 +56,7 @@ Receive policies make inbound payment status more explicit:
 - **Held** means the transaction succeeded, but the receiver's policy prevented the funds from being credited.
 - **Recovered** means the designated recovery authority moved held funds to an approved destination.
 
-The recovery authority is chosen by the receiver's policy. Depending on the use case, held funds can be controlled by the receiver, returned through a sender-controlled path, or routed through a third-party address or smart contract.
+The recovery authority is chosen by the receiver's policy. This could be the sender (default), the receiver, or a designated third-party address or smart contract.
 
 ## Common use cases
 

--- a/src/pages/learn/tempo/receive-policies.mdx
+++ b/src/pages/learn/tempo/receive-policies.mdx
@@ -13,6 +13,8 @@ Account-level receive policies give Tempo accounts a way to define which TIP-20 
 This page describes a feature planned for the T6 network upgrade. Check the [T6 upgrade docs](https://docs.tempo.xyz/protocol/upgrades/t6) for current activation status.
 ::::
 
+Try the [receive policies demo](https://tempo.xyz/receive-policies) to see credited, held, and recovery flows in practice.
+
 ## Why receiving needs policy
 
 On most blockchains, an address can receive almost any compatible token. That flexibility is useful, but it creates operational problems for payment and financial applications:
@@ -97,6 +99,12 @@ Together, these controls make Tempo more practical for payment applications that
 ## Related reading
 
 <Cards>
+  <Card
+    title="Receive policies demo"
+    description="See how accepted, held, and recovered sends work in a live flow."
+    to="https://tempo.xyz/receive-policies"
+    icon="lucide:play-circle"
+  />
   <Card
     title="T6 upgrade docs"
     description="Activation status and implementation notes for the network upgrade that includes receive policies."

--- a/src/pages/learn/tempo/receive-policies.mdx
+++ b/src/pages/learn/tempo/receive-policies.mdx
@@ -17,24 +17,23 @@ Try the [receive policies demo](https://tempo.xyz/receive-policies) to see credi
 
 ## Why receiving needs policy
 
-On most blockchains, an address can receive almost any compatible token. That flexibility is useful, but it creates operational problems for payment and financial applications:
+On most blockchains, an address can send a compatible token to any other address without the recipient's permission. That flexibility is useful, but it creates operational problems for payment and financial applications:
 
 - A customer deposit address may receive a token that the platform does not support.
 - A treasury or settlement wallet may receive funds from an address it is not allowed to interact with.
 - A stablecoin orchestrator may need to prevent users from sending one issuer's token to a deposit address meant for another asset.
 - A support team may need a clear way to identify, review, and recover funds that should not have landed in a user's balance.
 
-Receive policies move those controls to the account level. Instead of only letting token issuers decide who can send or receive a token, the receiver can also define what it is willing to accept.
+Receive policies provide a means to express for receivers to express such preferences at account level. Instead of only letting token issuers decide who can send or receive a token, a user can also define what it is willing to accept and from whom.
 
 ## What a receive policy controls
 
-An account-level receive policy can define:
+An account-level receive policy has three parts:
 
 - **Tokens**: an allowlist or blocklist of TIP-20 tokens the account can receive.
 - **Senders**: an allowlist or blocklist of addresses that can send to the account.
-- **Recovery authority**: who is allowed to move funds when an inbound send is held instead of credited.
+- **Recovery authority**: who is allowed to move funds when an inbound send is held instead of credited. This could be the sender (default), the receiver, or a designated third-party address or smart contract.
 
-All three pieces matter. The token and sender rules decide whether the account accepts an inbound transfer or mint. The recovery authority defines what happens when the account does not accept it.
 
 ## How inbound sends work
 
@@ -46,17 +45,7 @@ If those checks fail, the transaction reverts as usual. If they pass, Tempo chec
 - **Policy accepts the token and sender**: the transfer or mint is credited normally.
 - **Policy rejects the token or sender**: the transfer or mint can succeed, but the funds are held for recovery instead of being credited to the receiver.
 
-That held state is the key difference. A blocked inbound send does not have to become a confusing lost-deposit incident. The protocol records the details needed to review and recover the funds later, including the token, amount, sender, intended receiver, and reason the send was held.
-
-## Credited, held, and recovered
-
-Receive policies make inbound payment status more explicit:
-
-- **Credited** means the receiver accepted the token and sender, and the funds landed in the receiver's balance.
-- **Held** means the transaction succeeded, but the receiver's policy prevented the funds from being credited.
-- **Recovered** means the designated recovery authority moved held funds to an approved destination.
-
-The recovery authority is chosen by the receiver's policy. This could be the sender (default), the receiver, or a designated third-party address or smart contract.
+That held state is the key difference. The protocol records the details needed to review and recover the funds later, including the token, amount, sender, intended receiver, and reason the send was held.
 
 ## Common use cases
 
@@ -77,10 +66,6 @@ Receivers can limit inbound funds to known assets or known counterparties. That 
 Platforms that route between stablecoins can reduce user error by preventing sends to deposit addresses that are not meant to receive a particular asset.
 
 ## What builders should plan for
-
-Applications that expose receive policies should make the policy visible before a user sends funds. A good user experience should help senders understand whether a token and destination are likely to be credited or held.
-
-For receiver-side operations, dashboards and support tools should treat held sends as their own delivery state. They are not the same as failed transactions, because the transaction can succeed while delivery is redirected for recovery.
 
 Builders should plan to:
 

--- a/src/pages/learn/tempo/receive-policies.mdx
+++ b/src/pages/learn/tempo/receive-policies.mdx
@@ -1,0 +1,118 @@
+---
+title: Account-Level Receive Policies
+description: Learn how Tempo account-level receive policies help wallets, custodians, and stablecoin platforms control accepted tokens, senders, and recovery paths.
+---
+
+import { Cards, Card } from 'vocs'
+
+# Account-level receive policies [Control what accounts can receive]
+
+Account-level receive policies give Tempo accounts a way to define which TIP-20 tokens they are willing to receive and which addresses are allowed to send to them. They are designed for teams that need more control over inbound funds: wallets, custodians, exchanges, on/off-ramps, payment processors, treasury systems, and stablecoin orchestration platforms.
+
+::::info[Planned for T6]
+This page describes a feature planned for the T6 network upgrade. Check the [T6 upgrade docs](https://docs.tempo.xyz/protocol/upgrades/t6) for current activation status.
+::::
+
+## Why receiving needs policy
+
+On most blockchains, an address can receive almost any compatible token. That flexibility is useful, but it creates operational problems for payment and financial applications:
+
+- A customer deposit address may receive a token that the platform does not support.
+- A treasury or settlement wallet may receive funds from an address it is not allowed to interact with.
+- A stablecoin orchestrator may need to prevent users from sending one issuer's token to a deposit address meant for another asset.
+- A support team may need a clear way to identify, review, and recover funds that should not have landed in a user's balance.
+
+Receive policies move those controls to the account level. Instead of only letting token issuers decide who can send or receive a token, the receiver can also define what it is willing to accept.
+
+## What a receive policy controls
+
+An account-level receive policy can define:
+
+- **Tokens**: an allowlist or blocklist of TIP-20 tokens the account can receive.
+- **Senders**: an allowlist or blocklist of addresses that can send to the account.
+- **Recovery authority**: who is allowed to move funds when an inbound send is held instead of credited.
+
+All three pieces matter. The token and sender rules decide whether the account accepts an inbound transfer or mint. The recovery authority defines what happens when the account does not accept it.
+
+## How inbound sends work
+
+A sender still starts a normal TIP-20 transfer or mint. Tempo first runs the usual token checks: balance, allowance, pause status, and issuer-level policies such as TIP-403 allowlists or blocklists.
+
+If those checks fail, the transaction reverts as usual. If they pass, Tempo checks whether the receiver has an account-level receive policy:
+
+- **No receive policy**: the transfer or mint is credited normally.
+- **Policy accepts the token and sender**: the transfer or mint is credited normally.
+- **Policy rejects the token or sender**: the transfer or mint can succeed, but the funds are held for recovery instead of being credited to the receiver.
+
+That held state is the key difference. A blocked inbound send does not have to become a confusing lost-deposit incident. The protocol records the details needed to review and recover the funds later, including the token, amount, sender, intended receiver, and reason the send was held.
+
+## Credited, held, and recovered
+
+Receive policies make inbound payment status more explicit:
+
+- **Credited** means the receiver accepted the token and sender, and the funds landed in the receiver's balance.
+- **Held** means the transaction succeeded, but the receiver's policy prevented the funds from being credited.
+- **Recovered** means the designated recovery authority moved held funds to an approved destination.
+
+The recovery authority is chosen by the receiver's policy. Depending on the use case, held funds can be controlled by the receiver, returned through a sender-controlled path, or routed through a third-party address or smart contract.
+
+## Common use cases
+
+### Exchanges and custodians
+
+Deposit infrastructure can accept only supported assets for each customer or deposit flow. If a user sends an unsupported token, the platform can surface the held transfer and provide a structured support or recovery process instead of manually investigating a mismatch.
+
+### Wallets and wallet-as-a-service providers
+
+Wallet providers can offer business customers controls over which tokens and counterparties their accounts accept. This is useful for internal wallets, customer wallets, treasury wallets, and accounts that need to avoid unwanted tokens.
+
+### On/off-ramps and payment processors
+
+Receivers can limit inbound funds to known assets or known counterparties. That helps operational teams align onchain receipt behavior with compliance, risk, and reconciliation workflows.
+
+### Stablecoin orchestrators
+
+Platforms that route between stablecoins can reduce user error by preventing sends to deposit addresses that are not meant to receive a particular asset.
+
+## What builders should plan for
+
+Applications that expose receive policies should make the policy visible before a user sends funds. A good user experience should help senders understand whether a token and destination are likely to be credited or held.
+
+For receiver-side operations, dashboards and support tools should treat held sends as their own delivery state. They are not the same as failed transactions, because the transaction can succeed while delivery is redirected for recovery.
+
+Builders should plan to:
+
+- Let receivers configure token and sender allowlists or blocklists.
+- Show recovery authority choices in plain language.
+- Warn senders when a transfer is likely to be held.
+- Index held-send events so support and operations teams can find them.
+- Build recovery workflows for sender, receiver, or third-party controlled funds.
+
+## How this fits with TIP-20
+
+Receive policies complement the issuer controls already built into TIP-20 and TIP-403. Token issuers can still enforce their own policies for regulated assets. Account-level receive policies add a receiver-side layer for businesses and users that need to decide what their own accounts are willing to accept.
+
+Together, these controls make Tempo more practical for payment applications that need the flexibility of open stablecoin rails and the operational safeguards expected by financial platforms.
+
+## Related reading
+
+<Cards>
+  <Card
+    title="T6 upgrade docs"
+    description="Activation status and implementation notes for the network upgrade that includes receive policies."
+    to="https://docs.tempo.xyz/protocol/upgrades/t6"
+    icon="lucide:file-text"
+  />
+  <Card
+    title="TIP-20 Tokens"
+    description="Tempo's native stablecoin standard with payment lanes, memos, fees, and policy support."
+    to="/learn/tempo/native-stablecoins"
+    icon="lucide:coins"
+  />
+  <Card
+    title="Build on Tempo"
+    description="Start integrating with Tempo's payment, account, and stablecoin developer guides."
+    to="/quickstart/integrate-tempo"
+    icon="lucide:rocket"
+  />
+</Cards>

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1290,6 +1290,10 @@ export default defineConfig({
             link: '/learn/tempo/native-stablecoins',
           },
           {
+            text: 'Receive Policies',
+            link: '/learn/tempo/receive-policies',
+          },
+          {
             text: 'Modern Transactions',
             link: '/learn/tempo/modern-transactions',
           },


### PR DESCRIPTION
Adds a customer-facing Learn page for account-level receive policies and links it from the Tempo Learn overview and Learn sidebar.