### PR TITLE
docs(t5): list T5-compatible SDK releases

### DIFF
--- a/src/pages/protocol/upgrades/t5.mdx
+++ b/src/pages/protocol/upgrades/t5.mdx
@@ -109,9 +109,13 @@ Read the technical specification at [TIP-1057](https://tips.sh/1057).
 
 ## Compatible SDK releases
 
-T5-compatible SDK releases will be listed here as they ship.
+The following releases support the full T5 feature set. New integrations should prefer the `TIP20ChannelReserve` precompile over the legacy MPP reserve contract.
 
-These releases should prefer the `TIP20ChannelReserve` precompile over the legacy MPP reserve contract for new integrations.
+| Ecosystem  | T5-compatible releases |
+| ---------- | ---------------------- |
+| TypeScript | [`mppx@0.7.0`](https://www.npmjs.com/package/mppx/v/0.7.0), [`viem@2.52.2`](https://www.npmjs.com/package/viem/v/2.52.2), [`accounts@0.14.9`](https://www.npmjs.com/package/accounts/v/0.14.9) |
+| Rust       | [`tempo-alloy@1.8.0`](https://crates.io/crates/tempo-alloy/1.8.0), [`tempo-primitives@1.8.0`](https://crates.io/crates/tempo-primitives/1.8.0), [`tempo-contracts@1.8.0`](https://crates.io/crates/tempo-contracts/1.8.0) |
+| Foundry    | [nightly](https://getfoundry.sh) (T5 hardfork-aware decoding) |
 
 ## What operators and integrators should know
 

--- a/src/pages/protocol/upgrades/t5.mdx
+++ b/src/pages/protocol/upgrades/t5.mdx
@@ -113,8 +113,8 @@ The following releases support the full T5 feature set. New integrations should 
 
 | Ecosystem  | T5-compatible releases |
 | ---------- | ---------------------- |
-| TypeScript | [`mppx@0.7.0`](https://www.npmjs.com/package/mppx/v/0.7.0), [`viem@2.52.2`](https://www.npmjs.com/package/viem/v/2.52.2), [`accounts@0.14.9`](https://www.npmjs.com/package/accounts/v/0.14.9) |
-| Rust       | [`tempo-alloy@1.8.0`](https://crates.io/crates/tempo-alloy/1.8.0), [`tempo-primitives@1.8.0`](https://crates.io/crates/tempo-primitives/1.8.0), [`tempo-contracts@1.8.0`](https://crates.io/crates/tempo-contracts/1.8.0) |
+| TypeScript | [`mppx@0.7.0`](https://github.com/wevm/mppx/releases/tag/mppx%400.7.0), [`viem@2.52.2`](https://github.com/wevm/viem/releases/tag/viem%402.52.2), [`accounts@0.14.9`](https://github.com/tempoxyz/accounts/releases/tag/accounts%400.14.9) |
+| Rust       | [`tempo-alloy@1.8.0`](https://github.com/tempoxyz/tempo/releases/tag/tempo-alloy%401.8.0), [`tempo-primitives@1.8.0`](https://github.com/tempoxyz/tempo/releases/tag/tempo-primitives%401.8.0), [`tempo-contracts@1.8.0`](https://github.com/tempoxyz/tempo/releases/tag/tempo-contracts%401.8.0) |
 | Foundry    | [nightly](https://getfoundry.sh) (T5 hardfork-aware decoding) |
 
 ## What operators and integrators should know


### PR DESCRIPTION
## Summary
Fills in the placeholder in the **Compatible SDK releases** section of the T5 upgrade page with the shipped, T5-compatible releases, grouped by ecosystem.

| Ecosystem  | Releases |
| ---------- | -------- |
| TypeScript | `mppx@0.7.0`, `viem@2.52.2`, `accounts@0.14.9` |
| Rust       | `tempo-alloy@1.8.0`, `tempo-primitives@1.8.0`, `tempo-contracts@1.8.0` |
| Foundry    | nightly (T5 hardfork-aware decoding) |

## Links
Each package links to its **GitHub release tag** (e.g. `github.com/wevm/viem/releases/tag/viem@2.52.2`, `github.com/tempoxyz/tempo/releases/tag/tempo-alloy@1.8.0`), matching the convention already used on the T3/T4 upgrade pages — not npm/crates.io version pages.

## Versions
Pinned to the releases contemporaneous with the T5 activation, matching the node `v1.8.0` release — consistent with T4 (`1.7.0`) and T3 (`1.5.1`). All tags/releases verified live. Retains the existing guidance to prefer the `TIP20ChannelReserve` precompile for new integrations.