### PR TITLE
Explain USDC.e bridge routing

### DIFF
--- a/src/pages/guide/bridge-layerzero.mdx
+++ b/src/pages/guide/bridge-layerzero.mdx
@@ -14,6 +14,22 @@ There are two flavors of OFT on Tempo:
 
 Both use the same underlying LayerZero endpoint on Tempo.
 
+## USDC.e and native USDC
+
+USDC.e is the bridged representation of USDC on Tempo. It is backed 1:1 by native USDC in Stargate liquidity infrastructure.
+
+When USDC is bridged to Tempo through Stargate, native USDC is deposited into a Stargate pool and the equivalent amount of USDC.e is minted on Tempo. When USDC.e is bridged out, USDC.e is burned on Tempo and USDC is released through Stargate.
+
+The zero-transfer-fee path is between Tempo and Ethereum:
+
+| Route | Asset received | Stargate transfer fee |
+|-------|----------------|----------------------:|
+| Ethereum to Tempo | USDC.e on Tempo | 0 bps |
+| Tempo to Ethereum | Native USDC on Ethereum | 0 bps |
+| Tempo to or from other chains | Route-dependent | Quote before execution |
+
+Routes between Tempo and other chains can carry standard Stargate route fees. If an integrator needs native USDC on another chain, the preferred settlement path is to bridge USDC.e from Tempo to native USDC on Ethereum, then move USDC onward using CCTP or another supported route. The [LayerZero Value Transfer API](https://docs.layerzero.network/v2/developers/value-transfer-api/overview) can help discover and execute available routes.
+
 ## Bridged tokens on Tempo
 
 | Token | Address | Bridge |

--- a/src/pages/guide/getting-funds.mdx
+++ b/src/pages/guide/getting-funds.mdx
@@ -54,7 +54,7 @@ codex exec "Read https://tempo.xyz/SKILL.md and fund my Tempo Wallet"
 
 Use one of these supported bridges to move assets to Tempo:
 
-When bridging USDC with LayerZero (Stargate), USDC arrives on Tempo as USDC.e. The zero-transfer-fee Stargate route is between Ethereum and Tempo; routes involving other chains can vary, so review the route quote before sending.
+When you bridge USDC with LayerZero (Stargate), it appears on Tempo as USDC.e. Stargate does not charge its transfer fee on the direct route between Ethereum and Tempo, but other routes can vary, so check the quote before sending.
 
 - **[LayerZero (Stargate)](/guide/bridge-layerzero)**: Bridge USDC to and from Tempo via Stargate. See the [full bridging guide](/guide/bridge-layerzero) for contract addresses, code examples, and EndpointDollar details.
 - **[Squid](https://app.squidrouter.com/)**: Swap and bridge assets to Tempo in one flow.

--- a/src/pages/guide/getting-funds.mdx
+++ b/src/pages/guide/getting-funds.mdx
@@ -54,6 +54,8 @@ codex exec "Read https://tempo.xyz/SKILL.md and fund my Tempo Wallet"
 
 Use one of these supported bridges to move assets to Tempo:
 
+When bridging USDC with LayerZero (Stargate), USDC arrives on Tempo as USDC.e. The zero-transfer-fee Stargate route is between Ethereum and Tempo; routes involving other chains can vary, so review the route quote before sending.
+
 - **[LayerZero (Stargate)](/guide/bridge-layerzero)**: Bridge USDC to and from Tempo via Stargate. See the [full bridging guide](/guide/bridge-layerzero) for contract addresses, code examples, and EndpointDollar details.
 - **[Squid](https://app.squidrouter.com/)**: Swap and bridge assets to Tempo in one flow.
 - **[Relay](https://relay.link/)**: Bridge assets to Tempo with low fees.


### PR DESCRIPTION
## Summary

- Adds a short conceptual section to the LayerZero bridge guide explaining what USDC.e represents on Tempo.
- Clarifies the difference between 1:1 backing and the zero-transfer-fee Tempo/Ethereum route.
- Notes that routes between Tempo and other chains should be quoted, and points integrators to Ethereum settlement plus CCTP or the LayerZero Value Transfer API for onward native USDC routing.

## Why

The bridge guide previously jumped from LayerZero/Stargate mechanics into token tables and code examples. That left integrators to infer the USDC.e asset model, backing, and preferred native-USDC settlement route from implementation details.

## Validation

- `git diff --check`
- `pnpm build`