### PR TITLE
docs: add Tempo MCP agent install packaging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "claude",
+  "metadata": {
+    "description": "Tempo Claude Code plugin marketplace."
+  },
+  "owner": {
+    "name": "Tempo",
+    "email": "support@tempo.xyz"
+  },
+  "plugins": [
+    {
+      "name": "tempo",
+      "description": "Tempo MCP and skills for Tempo docs, developer workflows, wallet, and MPP payments.",
+      "source": "./ai/providers/claude/plugin",
+      "category": "development",
+      "homepage": "https://docs.tempo.xyz/guide/using-tempo-with-ai"
+    }
+  ]
+}

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,33 @@
+# Tempo AI
+
+Agent and editor integration metadata for Tempo.
+
+This directory contains the plugin payloads and skills referenced by the root-level AI marketplace manifests.
+
+Root-level manifests:
+
+- `marketplace.json` for the `codex` marketplace
+- `.claude-plugin/marketplace.json` for the `claude` marketplace
+
+## Remote MCP
+
+Use the hosted MCP server:
+
+```txt
+https://mcp.tempo.xyz
+```
+
+The current server exposes docs search, page discovery, and cleaned page reads. Wallet and paid-request workflows are handled by the `tempo-wallet` skill using the Tempo CLI.
+
+## Codex
+
+The Codex plugin lives in `plugins/tempo`.
+
+## Claude
+
+The Claude plugin lives in `providers/claude/plugin`.
+
+## Skills
+
+- `tempo`: generic Tempo developer skill placeholder.
+- `tempo-wallet`: wallet setup, service discovery, and paid HTTP requests with `tempo wallet` and `tempo request`.

--- a/ai/plugins/tempo/.codex-plugin/plugin.json
+++ b/ai/plugins/tempo/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "tempo",
+  "version": "0.1.0",
+  "description": "Tempo MCP and skills for Tempo docs, developer workflows, wallet, and MPP payments.",
+  "author": {
+    "name": "Tempo",
+    "url": "https://tempo.xyz"
+  },
+  "homepage": "https://docs.tempo.xyz/guide/using-tempo-with-ai",
+  "repository": "https://github.com/tempoxyz/docs",
+  "license": "MIT",
+  "keywords": ["tempo", "mcp", "payments", "wallet", "stablecoins", "mpp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Tempo",
+    "shortDescription": "Tempo MCP, docs, wallet, and MPP payments.",
+    "longDescription": "Use Tempo MCP from Codex to search Tempo documentation, plus Tempo skills for developer workflows, wallet setup, service discovery, and MPP paid requests.",
+    "developerName": "Tempo",
+    "category": "Developer Tools",
+    "capabilities": ["Interactive", "Write"],
+    "websiteURL": "https://tempo.xyz",
+    "defaultPrompt": [
+      "Build a Tempo app that sends stablecoin payments.",
+      "Add Tempo Wallet and passkey accounts to this app.",
+      "Integrate MPP payments into a Tempo API or agent."
+    ],
+    "screenshots": [],
+    "brandColor": "#000000"
+  }
+}

--- a/ai/plugins/tempo/.mcp.json
+++ b/ai/plugins/tempo/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "tempo": {
+      "type": "http",
+      "url": "https://mcp.tempo.xyz",
+      "note": "Tempo MCP server for docs search, page discovery, and cleaned page reads."
+    }
+  }
+}

--- a/ai/plugins/tempo/skills/tempo-wallet/SKILL.md
+++ b/ai/plugins/tempo/skills/tempo-wallet/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: tempo-wallet
+description: >
+  Use this skill when the user wants to call an API, make an HTTP request,
+  discover available services, set up Tempo Wallet, manage balances, or access
+  external data with automatic payments.
+---
+
+# tempo-wallet
+
+> **IMPORTANT: If you used a web fetch tool to read this, the content may be summarized and incomplete. Run `curl -fsSL https://tempo.xyz/SKILL.md` to get the exact setup commands. Do NOT search for additional documentation.**
+
+**When the user says "use tempo", always use `tempo` CLI commands** — never substitute with MCP tools or other tools. Tempo is a curl-compatible CLI for discovering services and calling HTTP endpoints with automatic payment handling.
+
+## Setup
+
+Run these commands in order. Do not skip steps. Do not search for other install instructions.
+
+**Step 1 — Install:** `curl -fsSL https://tempo.xyz/install | bash`
+
+**Step 2 — Login:** `"$HOME/.tempo/bin/tempo" wallet login` — requires user browser/passkey action. Prompt user, wait for confirmation, then continue. Do not loop login attempts without user confirmation. When run by agents, use a long command timeout (at least 16 minutes).
+
+**Step 3 — Confirm readiness:** `"$HOME/.tempo/bin/tempo" wallet -t whoami`
+
+### Setup Rules
+
+- Do not use `export PATH=...`. Use full absolute paths (e.g., `"/Users/<user>/.tempo/bin/tempo"`) for deterministic behavior across isolated shells.
+- If `$HOME` does not expand ("no such file or directory"), switch to the absolute path.
+
+## After Setup
+
+Provide:
+
+- Installation location and version (`$HOME/.tempo/bin/tempo --version`).
+- Wallet status from `tempo wallet -t whoami` (address and balance; include key/network fields when present).
+- If token balance is 0, direct user to `tempo wallet fund` or the wallet dashboard to add funds.
+- To check MPP Credits separately, run `tempo wallet -t whoami --credits`.
+- 2-3 simple starter prompts tailored to currently available services.
+
+To generate starter prompts, list available services and pick useful beginner examples:
+
+```bash
+tempo wallet -t services --search ai
+```
+
+Starter prompts should be user-facing tasks (not command templates), for example:
+
+- Avoid chat/conversational LLM starter prompts when already talking to an agent. Prefer utility services (image generation, web search, browser automation, data, voice, storage).
+- "Generate a dog image with a blue background and save it as `dog.png`."
+- "Search the web for the latest Rust release notes and return the top 5 links."
+- "Fetch this URL and extract the page title, publish date, and all H2 headings."
+
+## Use Services
+
+```bash
+tempo wallet -t whoami
+tempo wallet -t services --search <query>
+tempo wallet -t services <SERVICE_ID>
+tempo request -t -X POST --json '{"input":"..."}' <SERVICE_URL>/<ENDPOINT_PATH>
+```
+
+- Select `SERVICE_ID` from search results that best matches user intent. When multiple match: prefer best semantic fit, then endpoint fit, then pricing clarity, then first in list.
+- **Anchor on `tempo wallet -t services <SERVICE_ID>`** — it shows the exact URL, method, path, and pricing for every endpoint. Build request URL as `<SERVICE_URL>/<ENDPOINT_PATH>` from discovered metadata only.
+- If service details include `supportsCredits: true`, MPP Credits may be used for one-time `tempo.charge` payments. Credits are separate from token balances; check them with `tempo wallet -t whoami --credits` and buy them with `tempo wallet fund --credits`.
+- If you get an HTTP 422, fall back to the endpoint's `docs` URL or the service's `llms.txt` for exact field names.
+- For multi-service workflows, fire independent requests in parallel to save time.
+
+### Request Templates
+
+```bash
+# JSON POST
+tempo request -t --dry-run -X POST --json '{"input":"..."}' <SERVICE_URL>/<ENDPOINT_PATH>
+tempo request -t -X POST --json '{"input":"..."}' <SERVICE_URL>/<ENDPOINT_PATH>
+
+# GET
+tempo request -t -X GET <SERVICE_URL>/<ENDPOINT_PATH>
+```
+
+### Response Handling
+
+- Return result payload to user directly when request succeeds.
+- If response contains a file URL (e.g., image generation), download it locally: `curl -fsSL "<url>" -o <filename>`.
+- If response is a usage/auth readiness error, run `tempo wallet login` and retry once.
+- If response indicates payment/funding limit issues, report clearly and stop. For token funding use `tempo wallet fund`; for MPP Credits use `tempo wallet fund --credits` only when service details show `supportsCredits: true`.
+- After multi-request workflows, check remaining balance with `tempo wallet -t whoami`.
+
+### Rules
+
+- Always discover URL/path before request; never guess endpoint paths.
+- `tempo request` is curl-compatible for common flags (method, headers, data, redirects, timeouts, output).
+- Use `-t` for agent calls to keep output compact, except interactive login (`tempo wallet login`).
+- Use `--dry-run` before potentially expensive requests.
+- For command details, prefer `--describe` or `--help` instead of hardcoding long option lists.
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|---|---|---|
+| `tempo: command not found` | CLI not installed | Run `curl -fsSL https://tempo.xyz/install \| bash`, then retry using `"$HOME/.tempo/bin/tempo" ...`. |
+| "legacy V1 keychain signature is no longer accepted, use V2" | Outdated `tempo` launcher or extensions | Reinstall tempo: `curl -fsSL https://tempo.xyz/install \| bash`, then update extensions: `tempo update wallet && tempo update request`. Log out and back in: `tempo wallet logout --yes && tempo wallet login`. |
+| "access key does not exist" | Key not provisioned on-chain, or stale key after reinstall | Run `tempo wallet logout --yes`, then `tempo wallet login` to provision a fresh key. |
+| `ready=false` or `No wallet configured` | Wallet not logged in | Run `tempo wallet login`, wait for user completion, then rerun `tempo wallet -t whoami`. |
+| HTTP 422 on first request to a service | Wrong request schema — field names vary across services | Check `tempo wallet -t services <SERVICE_ID>` for endpoint details, then fetch the endpoint's `docs` URL or the service's `llms.txt` for exact field names and types. |
+| Balance is 0, insufficient funds, or spending limit exceeded | Wallet needs funding or limit hit | Run `tempo wallet fund` or direct user to the wallet dashboard. Report clearly and stop if limit is exceeded. |
+| Token balance is 0 but MPP Credits may be available | Credits are separate from token balances | Run `tempo wallet -t whoami --credits`. If the service shows `supportsCredits: true`, credits can be used for one-time charge payments. |
+| Need to buy MPP Credits | User wants to fund with card-based credits for eligible services | Run `tempo wallet fund --credits`, complete checkout in the wallet app, then recheck with `tempo wallet -t whoami --credits`. |
+| Credits are not accepted by a service | MPP Credits only work for eligible Tempo-proxied services | Inspect `tempo wallet -t services <SERVICE_ID>` and use credits only when `supportsCredits: true` is present. Otherwise use token funding with `tempo wallet fund`. |
+| Service uses sessions | MPP Credits currently support one-time charges, not sessions | Use token funding for session-based services. |
+| Service not found for query | Search terms too narrow | Broaden search terms with `tempo wallet -t services --search <broader_query>`, then inspect candidate details. |
+| Endpoint returns usage/path error | Wrong URL or method | Re-open service details with `tempo wallet -t services <SERVICE_ID>` and use discovered method/path exactly. |
+| Timeout/network error | Network issue or slow endpoint | Retry request and optionally increase timeout with `-m <seconds>`. |

--- a/ai/plugins/tempo/skills/tempo/SKILL.md
+++ b/ai/plugins/tempo/skills/tempo/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: tempo
+description: >
+  Use this skill when building applications on Tempo, integrating Tempo into an
+  app, writing or reviewing Tempo code, or answering Tempo developer questions
+  about accounts, wallets, passkeys, stablecoin payments, fee sponsorship,
+  MPP, hosted services, indexer queries, stablecoin issuance, the Stablecoin
+  DEX, contract verification, SDKs, or Tempo protocol concepts. For agent
+  wallet setup, service discovery, or paid HTTP requests, use the tempo-wallet
+  skill.
+---
+
+# Tempo Developer Skill
+
+Use this skill to build applications on Tempo. Prefer Tempo docs from the
+hosted MCP server first; if MCP is unavailable, read the relevant page from
+`https://docs.tempo.xyz` or append `.md` to the docs URL. Do not guess current
+RPC URLs, contract addresses, chain IDs, package APIs, or protocol details;
+verify them from docs before writing code.
+
+## Routing
+
+| User is building... | Start with |
+|---|---|
+| A new Tempo app or network setup | `/quickstart/integrate-tempo`, `/quickstart/connection-details`, `/sdk` |
+| Account or wallet UX | `/guide/use-accounts`, `/accounts`, `/quickstart/wallet-developers` |
+| Stablecoin payments | `/guide/payments`, especially send, accept, virtual addresses, memos, fees, sponsorship, and parallel transactions |
+| Sponsored or gasless transactions | `/guide/payments/sponsor-user-fees`, `/developer-tools/fee-payer`, `/accounts/server/handler.relay` |
+| MPP or paid APIs | `/guide/machine-payments`, then `/guide/machine-payments/client`, `/server`, or `/agent` |
+| Agent-paid service calls | Use the `tempo-wallet` skill for wallet login, service discovery, and `tempo request` |
+| Hosted indexer queries | `/developer-tools/indexer` |
+| Stablecoin issuance | `/guide/issuance`, `/protocol/tip20/overview`, `/protocol/tip20/spec` |
+| Stablecoin DEX swaps or liquidity | `/guide/stablecoin-dex`, `/protocol/exchange` |
+| Contract deployment or verification | `/quickstart/verify-contracts` |
+| Low-level protocol behavior | `/protocol`, then the relevant transactions, fees, TIP-20, exchange, or zones spec |
+
+Read the relevant page before answering an integration question or changing
+code. Use the docs page’s linked examples when available.
+
+## Implementation Defaults
+
+- Prefer TypeScript examples for web apps, using the Tempo SDK pages and the
+  repo’s existing Wagmi/Viem patterns.
+- Prefer Foundry examples for Solidity contracts and contract verification.
+- Use Tempo Testnet examples unless the user explicitly asks for mainnet.
+- For production-oriented changes, check the production, security, or hosted
+  service docs before recommending defaults.
+
+## Critical Rules
+
+- Never invent Tempo addresses, fee tokens, RPC endpoints, sponsor URLs, or
+  verifier URLs. Fetch them from docs.
+- For transfer memos, preserve the documented 32-byte memo constraint and use
+  them for reconciliation metadata such as invoice IDs or payment references.
+- For access keys, keep scopes and spending limits narrow. Do not use access
+  keys for contract deployment flows unless the docs explicitly support it.
+
+## Useful Docs
+
+- Getting started: `https://docs.tempo.xyz/quickstart/integrate-tempo`
+- Connection details: `https://docs.tempo.xyz/quickstart/connection-details`
+- Accounts: `https://docs.tempo.xyz/guide/use-accounts`
+- Payments: `https://docs.tempo.xyz/guide/payments`
+- Machine payments: `https://docs.tempo.xyz/guide/machine-payments`
+- Hosted services: `https://docs.tempo.xyz/hosted-services`
+- SDKs: `https://docs.tempo.xyz/sdk`
+- Protocol specs: `https://docs.tempo.xyz/protocol`

--- a/ai/providers/claude/plugin/.claude-plugin/plugin.json
+++ b/ai/providers/claude/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "tempo",
+  "description": "Tempo development plugin for Claude",
+  "version": "0.1.0",
+  "author": {
+    "name": "Tempo",
+    "url": "https://tempo.xyz"
+  },
+  "homepage": "https://docs.tempo.xyz",
+  "repository": "https://github.com/tempoxyz/docs",
+  "license": "MIT",
+  "keywords": ["tempo", "stablecoins", "mcp", "payments", "mpp"]
+}

--- a/ai/providers/claude/plugin/.mcp.json
+++ b/ai/providers/claude/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tempo": {
+      "type": "http",
+      "url": "https://mcp.tempo.xyz"
+    }
+  }
+}

--- a/ai/providers/claude/plugin/skills/tempo-wallet/SKILL.md
+++ b/ai/providers/claude/plugin/skills/tempo-wallet/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../plugins/tempo/skills/tempo-wallet/SKILL.md

--- a/ai/providers/claude/plugin/skills/tempo/SKILL.md
+++ b/ai/providers/claude/plugin/skills/tempo/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../plugins/tempo/skills/tempo/SKILL.md

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "docs",
+  "interface": {
+    "displayName": "Tempo"
+  },
+  "plugins": [
+    {
+      "name": "tempo",
+      "source": {
+        "source": "local",
+        "path": "./ai/plugins/tempo"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/scripts/download-og.sh
+++ b/scripts/download-og.sh
@@ -33,7 +33,7 @@ download_og "Issue Stablecoins" "BUILD" "" "build--issuance"
 download_og "Exchange Stablecoins" "BUILD" "" "build--stablecoin-dex"
 download_og "Make Machine Payments" "BUILD" "" "build--machine-payments"
 download_og "Use Tempo Transactions" "BUILD" "" "build--tempo-transaction"
-download_og "Using Tempo with AI" "BUILD" "" "build--ai"
+download_og "Developing with LLMs" "BUILD" "" "build--ai"
 
 download_og "Overview" "INTEGRATE" "" "integrate--overview"
 download_og "Connect to the Network" "INTEGRATE" "" "integrate--connection-details"

--- a/src/components/DocsLinkButton.tsx
+++ b/src/components/DocsLinkButton.tsx
@@ -1,0 +1,24 @@
+import type * as React from 'react'
+import { cx } from '../../cva.config'
+
+export function DocsLinkButton({
+  children,
+  className,
+  href,
+}: {
+  children: React.ReactNode
+  className?: string
+  href: string
+}) {
+  return (
+    <a
+      className={cx(
+        'relative my-6 flex h-[32px] w-fit cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md border bg-invert px-[14px] font-normal text-[14px] text-invert no-underline transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring dark:border-dashed',
+        className,
+      )}
+      href={href}
+    >
+      {children}
+    </a>
+  )
+}

--- a/src/pages/guide/using-tempo-with-ai.mdx
+++ b/src/pages/guide/using-tempo-with-ai.mdx
@@ -1,44 +1,106 @@
 ---
-title: Using Tempo with AI
-description: Give your AI coding agent Tempo documentation context and a wallet for autonomous transactions.
+title: Developing with LLMs
+description: Give your AI coding agent Tempo documentation context with skills, Markdown pages, and MCP.
 ---
 
-import { Cards, Card } from 'vocs'
+import { Tabs, Tab } from 'vocs'
+import { DocsLinkButton } from '../../components/DocsLinkButton.tsx'
 
-# Using Tempo with AI
+# Developing with LLMs
 
-<Cards>
-  <Card
-    description="Give your agent a wallet with spend controls to discover and pay for services on demand."
-    to="#tempo-wallet"
-    icon="lucide:wallet"
-    title="Tempo Wallet"
-  />
-  <Card
-    description="Feed your agent Tempo docs via skills, llms.txt, Markdown pages, and MCP."
-    to="#tempo-docs"
-    icon="lucide:blocks"
-    title="Tempo Docs"
-  />
-</Cards>
+## Connect to Tempo's MCP server
 
-## Tempo Wallet
+The Tempo MCP server gives agents programmatic access to Tempo documentation and related developer resources.
 
-The [Tempo CLI](/cli) gives agents a wallet with built-in spend controls and service discovery. Agents use [`tempo wallet`](/cli/wallet) to manage keys and balances, and [`tempo request`](/cli/request) to pay for services on demand.
+<Tabs stateKey="tempo-mcp-client">
+  <Tab title="Cursor">
 
-Paste this into your agent to set up a Tempo Wallet:
+<DocsLinkButton href="cursor://anysphere.cursor-deeplink/mcp/install?name=tempo&config=eyJ1cmwiOiJodHRwczovL21jcC50ZW1wby54eXoifQ%3D%3D">Install in Cursor</DocsLinkButton>
 
-:::code-group
-```bash [Claude Code]
-claude -p "Read https://tempo.xyz/SKILL.md and set up Tempo Wallet"
+To open Cursor and automatically add the Tempo MCP server, click install. Alternatively, add the following to your `~/.cursor/mcp.json` file. To learn more, see the Cursor [documentation](https://docs.cursor.com/context/model-context-protocol).
+
+```json
+{
+  "mcpServers": {
+    "tempo": {
+      "url": "https://mcp.tempo.xyz"
+    }
+  }
+}
 ```
-```bash [Amp]
-amp --execute "Read https://tempo.xyz/SKILL.md and set up Tempo Wallet"
+
+  </Tab>
+  <Tab title="VS Code">
+
+<DocsLinkButton href="https://vscode.dev/redirect/mcp/install?name=tempo&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tempo.xyz%22%7D">Install in VS Code</DocsLinkButton>
+
+To open VS Code and automatically add the Tempo MCP server, click install. Alternatively, add the following to your `.vscode/mcp.json` file in your workspace. To learn more, see the VS Code [documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
+
+```json
+{
+  "servers": {
+    "tempo": {
+      "type": "http",
+      "url": "https://mcp.tempo.xyz"
+    }
+  }
+}
 ```
-```bash [Codex CLI]
-codex exec "Read https://tempo.xyz/SKILL.md and set up Tempo Wallet"
+
+  </Tab>
+  <Tab title="Codex">
+
+To add Tempo MCP to Codex, run the following command.
+
+```bash
+codex mcp add tempo --url https://mcp.tempo.xyz
 ```
-:::
+
+  </Tab>
+  <Tab title="Claude Code">
+
+To add Tempo MCP to Claude Code, run the following command. To learn more, see the Claude Code [documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
+
+```bash
+claude mcp add --transport http tempo https://mcp.tempo.xyz
+```
+
+  </Tab>
+  <Tab title="Other">
+
+MCP is an open protocol supported by many clients. Use the server URL below with HTTP transport in any MCP-compatible client.
+
+```text
+https://mcp.tempo.xyz
+```
+
+<br />
+
+  </Tab>
+</Tabs>
+
+## Install Tempo plugins
+
+The MCP server above works on its own. Plugin bundles package that MCP server with Tempo skills and editor metadata so agents can install Tempo as a single integration.
+
+<Tabs stateKey="tempo-plugin-install">
+  <Tab title="Codex">
+
+```bash
+codex plugin marketplace add tempoxyz/docs
+codex plugin add tempo@docs
+```
+
+  </Tab>
+  <Tab title="Claude Code">
+
+```bash
+claude plugin marketplace add tempoxyz/docs
+claude plugin install tempo@claude
+```
+
+  </Tab>
+</Tabs>
 
 ## Tempo Docs
 
@@ -66,31 +128,3 @@ For LLM consumption, two [`llms.txt`](https://llmstxt.org/) files are served at 
 |---|---|
 | [`/llms.txt`](https://docs.tempo.xyz/llms.txt) | Concise index of all pages with titles and descriptions |
 | [`/llms-full.txt`](https://docs.tempo.xyz/llms-full.txt) | Complete documentation in a single file |
-
-### MCP server
-
-The docs include a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for programmatic navigation of documentation and source code.
-
-:::code-group
-```bash [Claude Code]
-claude mcp add --transport http tempo https://docs.tempo.xyz/api/mcp
-```
-```bash [Codex CLI]
-codex mcp add tempo --url https://docs.tempo.xyz/api/mcp
-```
-```bash [Amp]
-amp mcp add tempo https://docs.tempo.xyz/api/mcp
-```
-:::
-
-Or configure manually:
-
-```json
-{
-  "mcpServers": {
-    "tempo-docs": {
-      "url": "https://docs.tempo.xyz/api/mcp"
-    }
-  }
-}
-```

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -139,7 +139,7 @@ export default defineConfig({
         link: '/',
       },
       {
-        text: 'Using Tempo with AI',
+        text: 'Developing with LLMs',
         link: '/guide/using-tempo-with-ai',
       },
       {


### PR DESCRIPTION
## Summary

- Add Tempo MCP install tabs to the AI guide
- Add static agent integration metadata for MCP clients and editors
- Add generic Tempo and Tempo Wallet agent skills