### PR TITLE
docs: add ai tab code spacing

### DIFF
--- a/src/pages/guide/using-tempo-with-ai.mdx
+++ b/src/pages/guide/using-tempo-with-ai.mdx
@@ -19,6 +19,8 @@ The Tempo MCP server gives agents programmatic access to Tempo documentation and
 
 To open Cursor and automatically add the Tempo MCP server, click install. Alternatively, add the following to your `~/.cursor/mcp.json` file. To learn more, see the Cursor [documentation](https://docs.cursor.com/context/model-context-protocol).
 
+<br />
+
 ```json
 {
   "mcpServers": {
@@ -36,6 +38,8 @@ To open Cursor and automatically add the Tempo MCP server, click install. Altern
 
 To open VS Code and automatically add the Tempo MCP server, click install. Alternatively, add the following to your `.vscode/mcp.json` file in your workspace. To learn more, see the VS Code [documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
 
+<br />
+
 ```json
 {
   "servers": {
@@ -52,6 +56,8 @@ To open VS Code and automatically add the Tempo MCP server, click install. Alter
 
 To add Tempo MCP to Codex, run the following command.
 
+<br />
+
 ```bash
 codex mcp add tempo --url https://mcp.tempo.xyz
 ```
@@ -60,6 +66,8 @@ codex mcp add tempo --url https://mcp.tempo.xyz
   <Tab title="Claude Code">
 
 To add Tempo MCP to Claude Code, run the following command. To learn more, see the Claude Code [documentation](https://docs.anthropic.com/en/docs/claude-code/mcp).
+
+<br />
 
 ```bash
 claude mcp add --transport http tempo https://mcp.tempo.xyz
@@ -70,11 +78,11 @@ claude mcp add --transport http tempo https://mcp.tempo.xyz
 
 MCP is an open protocol supported by many clients. Use the server URL below with HTTP transport in any MCP-compatible client.
 
+<br />
+
 ```text
 https://mcp.tempo.xyz
 ```
-
-<br />
 
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

- Add spacing between AI setup tab descriptions and code examples