### PR TITLE
docs: clarify Tempo plugin docs

### DIFF
--- a/src/pages/guide/using-tempo-with-ai.mdx
+++ b/src/pages/guide/using-tempo-with-ai.mdx
@@ -74,22 +74,11 @@ claude mcp add --transport http tempo https://mcp.tempo.xyz
 ```
 
   </Tab>
-  <Tab title="Other">
-
-MCP is an open protocol supported by many clients. Use the server URL below with HTTP transport in any MCP-compatible client.
-
-<br />
-
-```text
-https://mcp.tempo.xyz
-```
-
-  </Tab>
 </Tabs>
 
 ## Install Tempo plugins
 
-The MCP server above works on its own. Plugin bundles package that MCP server with Tempo skills and editor metadata so agents can install Tempo as a single integration.
+The Tempo plugin installs a complete agent integration: the Tempo MCP server, workflow skills for using Tempo APIs and docs, and editor metadata that helps agents discover the right Tempo tools without manual setup.
 
 <Tabs stateKey="tempo-plugin-install">
   <Tab title="Codex">


### PR DESCRIPTION
## Summary

- Clarify that the Tempo plugin provides the MCP server, workflow skills, and editor metadata
- Remove the generic Other MCP client tab