### PR TITLE
docs: add network upgrade sidebar badges

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -239,6 +239,11 @@
   min-height: 200px;
 }
 
+[data-v-sidebar] a[data-v-sidebar-item][href$="/protocol/upgrades/t7"] [data-v-sidebar-item-badge],
+[data-v-sidebar] a[data-v-sidebar-item][href$="/protocol/upgrades/t6"] [data-v-sidebar-item-badge] {
+  background: var(--color-gray4);
+}
+
 /* ---------------------------------------------------------------------------
  * Terminal theme — scoped color variables for the embedded terminal demo.
  * --------------------------------------------------------------------------- */

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -731,15 +731,18 @@ export default defineConfig({
             collapsed: true,
             items: [
               {
-                text: 'T7 (Planned)',
+                text: 'T7',
+                badge: { text: 'Planned', variant: 'note' },
                 link: '/protocol/upgrades/t7',
               },
               {
-                text: 'T6 (Next)',
+                text: 'T6',
+                badge: { text: 'Next', variant: 'note' },
                 link: '/protocol/upgrades/t6',
               },
               {
-                text: 'T5 (Latest)',
+                text: 'T5',
+                badge: { text: 'Latest', variant: 'info' },
                 link: '/protocol/upgrades/t5',
               },
               {


### PR DESCRIPTION
## Summary

- Add sidebar chips for T7 Planned, T6 Next, and T5 Latest network upgrade labels.
- Use a blue chip for Latest and darker gray chips for Planned and Next.