### PR TITLE
fix: stabilize private zone CI auth

### DIFF
--- a/e2e/deposit-to-a-zone.test.ts
+++ b/e2e/deposit-to-a-zone.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { waitForEnabledAction } from './private-zone-actions'
+import { authorizeAndWaitForEnabledAction } from './private-zone-actions'
 
 test('prepare zone access and deposit to Zone A', async ({ page }) => {
   test.setTimeout(180000)
@@ -29,17 +29,17 @@ test('prepare zone access and deposit to Zone A', async ({ page }) => {
   const authorizeButton = page
     .getByRole('button', { name: /^Authoriz(?:e|ing) Zone A reads$/i })
     .first()
-  await expect(authorizeButton).toBeVisible({ timeout: 30000 })
-  await expect(authorizeButton).toBeEnabled({ timeout: 90000 })
-  await authorizeButton.click()
 
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const depositButton = page.getByRole('button', { name: /^Deposit 100 pathUSD$/i }).first()
 
-  const initialAction = await waitForEnabledAction([
-    { locator: getFundsButton, name: 'fund' },
-    { locator: depositButton, name: 'deposit' },
-  ])
+  const initialAction = await authorizeAndWaitForEnabledAction(
+    { locator: authorizeButton, name: 'authorize' },
+    [
+      { locator: getFundsButton, name: 'fund' },
+      { locator: depositButton, name: 'deposit' },
+    ],
+  )
 
   if (initialAction.name === 'fund') {
     await initialAction.locator.click()

--- a/e2e/private-zone-actions.ts
+++ b/e2e/private-zone-actions.ts
@@ -31,3 +31,48 @@ export async function waitForEnabledAction(actions: Action[], timeout = 120000) 
 
   throw new Error('No enabled action found')
 }
+
+export async function authorizeAndWaitForEnabledAction(
+  authorizeAction: Action,
+  actions: Action[],
+  timeout = 120000,
+) {
+  const deadline = Date.now() + timeout
+
+  await expect(authorizeAction.locator).toBeVisible({ timeout: 30000 })
+  await expect(authorizeAction.locator).toBeEnabled({
+    timeout: Math.min(90000, timeout),
+  })
+
+  while (Date.now() < deadline) {
+    const enabledAction = await getEnabledAction(actions)
+    if (enabledAction) return enabledAction
+
+    const authorizeVisible = await authorizeAction.locator.isVisible().catch(() => false)
+    const authorizeEnabled = await authorizeAction.locator.isEnabled().catch(() => false)
+    if (authorizeVisible && authorizeEnabled) await authorizeAction.locator.click()
+
+    await sleep(Math.min(1000, Math.max(deadline - Date.now(), 0)))
+  }
+
+  const enabledAction = await getEnabledAction(actions)
+  if (enabledAction) return enabledAction
+
+  throw new Error('No enabled action found after authorizing zone reads')
+}
+
+async function getEnabledAction(actions: Action[]) {
+  for (const action of actions) {
+    const visible = await action.locator.isVisible().catch(() => false)
+    if (!visible) continue
+
+    const enabled = await action.locator.isEnabled().catch(() => false)
+    if (enabled) return action
+  }
+
+  return undefined
+}
+
+async function sleep(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/e2e/send-tokens-across-zones.test.ts
+++ b/e2e/send-tokens-across-zones.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { waitForEnabledAction } from './private-zone-actions'
+import { authorizeAndWaitForEnabledAction } from './private-zone-actions'
 
 test('send pathUSD from Zone A into Zone B', async ({ page }) => {
   test.setTimeout(240000)
@@ -29,17 +29,17 @@ test('send pathUSD from Zone A into Zone B', async ({ page }) => {
   const authorizeSourceButton = page
     .getByRole('button', { name: /^Authoriz(?:e|ing) Zone A reads$/i })
     .first()
-  await expect(authorizeSourceButton).toBeVisible({ timeout: 30000 })
-  await expect(authorizeSourceButton).toBeEnabled({ timeout: 90000 })
-  await authorizeSourceButton.click()
 
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const topUpButton = page.getByRole('button', { name: /^Approve \+ top up Zone A$/i }).first()
 
-  const initialAction = await waitForEnabledAction([
-    { locator: getFundsButton, name: 'fund' },
-    { locator: topUpButton, name: 'top-up' },
-  ])
+  const initialAction = await authorizeAndWaitForEnabledAction(
+    { locator: authorizeSourceButton, name: 'authorize-source' },
+    [
+      { locator: getFundsButton, name: 'fund' },
+      { locator: topUpButton, name: 'top-up' },
+    ],
+  )
 
   if (initialAction.name === 'fund') {
     await initialAction.locator.click()

--- a/e2e/send-tokens-within-a-zone.test.ts
+++ b/e2e/send-tokens-within-a-zone.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { waitForEnabledAction } from './private-zone-actions'
+import { authorizeAndWaitForEnabledAction } from './private-zone-actions'
 
 test('prepare zone balance and send tokens within Zone A', async ({ page }) => {
   test.setTimeout(180000)
@@ -29,17 +29,17 @@ test('prepare zone balance and send tokens within Zone A', async ({ page }) => {
   const authorizeButton = page
     .getByRole('button', { name: /^Authoriz(?:e|ing) Zone A reads$/i })
     .first()
-  await expect(authorizeButton).toBeVisible({ timeout: 30000 })
-  await expect(authorizeButton).toBeEnabled({ timeout: 90000 })
-  await authorizeButton.click()
 
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const topUpButton = page.getByRole('button', { name: /^Approve \+ top up Zone A$/i }).first()
 
-  const initialAction = await waitForEnabledAction([
-    { locator: getFundsButton, name: 'fund' },
-    { locator: topUpButton, name: 'top-up' },
-  ])
+  const initialAction = await authorizeAndWaitForEnabledAction(
+    { locator: authorizeButton, name: 'authorize' },
+    [
+      { locator: getFundsButton, name: 'fund' },
+      { locator: topUpButton, name: 'top-up' },
+    ],
+  )
 
   if (initialAction.name === 'fund') {
     await initialAction.locator.click()

--- a/e2e/swap-across-zones.test.ts
+++ b/e2e/swap-across-zones.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { waitForEnabledAction } from './private-zone-actions'
+import { authorizeAndWaitForEnabledAction } from './private-zone-actions'
 
 test('swap pathUSD from Zone A into betaUSD on Zone B', async ({ page }) => {
   test.setTimeout(240000)
@@ -29,17 +29,17 @@ test('swap pathUSD from Zone A into betaUSD on Zone B', async ({ page }) => {
   const authorizeSourceButton = page
     .getByRole('button', { name: /^Authoriz(?:e|ing) Zone A reads$/i })
     .first()
-  await expect(authorizeSourceButton).toBeVisible({ timeout: 30000 })
-  await expect(authorizeSourceButton).toBeEnabled({ timeout: 90000 })
-  await authorizeSourceButton.click()
 
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const topUpButton = page.getByRole('button', { name: /^Approve \+ top up Zone A$/i }).first()
 
-  const initialAction = await waitForEnabledAction([
-    { locator: getFundsButton, name: 'fund' },
-    { locator: topUpButton, name: 'top-up' },
-  ])
+  const initialAction = await authorizeAndWaitForEnabledAction(
+    { locator: authorizeSourceButton, name: 'authorize-source' },
+    [
+      { locator: getFundsButton, name: 'fund' },
+      { locator: topUpButton, name: 'top-up' },
+    ],
+  )
 
   if (initialAction.name === 'fund') {
     await initialAction.locator.click()

--- a/e2e/withdraw-from-a-zone.test.ts
+++ b/e2e/withdraw-from-a-zone.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { waitForEnabledAction } from './private-zone-actions'
+import { authorizeAndWaitForEnabledAction } from './private-zone-actions'
 
 test.describe.configure({ retries: 0, timeout: 120000 })
 
@@ -31,17 +31,17 @@ test('prepare zone balance and withdraw from Zone A', async ({ page }) => {
   const authorizeButton = page
     .getByRole('button', { name: /^Authoriz(?:e|ing) Zone A reads$/i })
     .first()
-  await expect(authorizeButton).toBeVisible({ timeout: 30000 })
-  await expect(authorizeButton).toBeEnabled({ timeout: 90000 })
-  await authorizeButton.click()
 
   const getFundsButton = page.getByRole('button', { name: /^Get testnet pathUSD$/i }).first()
   const topUpButton = page.getByRole('button', { name: /^Approve \+ top up Zone A$/i }).first()
 
-  const initialAction = await waitForEnabledAction([
-    { locator: getFundsButton, name: 'fund' },
-    { locator: topUpButton, name: 'top-up' },
-  ])
+  const initialAction = await authorizeAndWaitForEnabledAction(
+    { locator: authorizeButton, name: 'authorize' },
+    [
+      { locator: getFundsButton, name: 'fund' },
+      { locator: topUpButton, name: 'top-up' },
+    ],
+  )
 
   if (initialAction.name === 'fund') {
     await initialAction.locator.click()

--- a/src/lib/useZoneAuthorization.ts
+++ b/src/lib/useZoneAuthorization.ts
@@ -100,16 +100,25 @@ export function useZoneAuthorization(parameters: {
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
+  let timeout: ReturnType<typeof setTimeout>
+
   return Promise.race([
-    promise,
+    promise.then(
+      (value) => {
+        clearTimeout(timeout)
+        return value
+      },
+      (error) => {
+        clearTimeout(timeout)
+        throw error
+      },
+    ),
     new Promise<never>((_, reject) => {
-      const timeout = setTimeout(() => {
+      timeout = setTimeout(() => {
         const error = new Error('zone authorization info request timed out')
         error.name = 'TimeoutError'
         reject(error)
       }, timeoutMs)
-
-      promise.finally(() => clearTimeout(timeout))
     }),
   ])
 }


### PR DESCRIPTION
## Summary

- Add a private-zone e2e helper that retries authorization until the next enabled action appears.
- Use the helper across private-zone tests that depend on Zone A read authorization.
- Prevent handled zone authorization status failures from leaking as unhandled page errors.

## Motivation

Private-zone CI could time out after clicking Zone A authorization when testnet auth briefly bounced back to the authorize action instead of advancing to the funding or top-up action.

## Key design considerations

- Keep retry behavior inside the e2e helper so individual tests stay focused on the user flow.
- Preserve existing test timeouts and action selection behavior.
- Keep the app-side timeout wrapper scoped to clearing timers without changing authorization semantics.
