### PR TITLE
Update T6 mainnet status message

### DIFF
--- a/src/pages/protocol/upgrades/t6.mdx
+++ b/src/pages/protocol/upgrades/t6.mdx
@@ -8,7 +8,7 @@ description: Partner-focused overview and integration notes for the T6 network u
 T6 gives partners more control over account safety and user key management. It adds account-level receive policies so users can prevent unwanted TIP-20 deposits to their account, and it adds admin access keys so users and apps can manage passkeys and delegated keys without relying on the root wallet for every change.
 
 :::info[T6 status]
-T6 is not yet active on testnet or mainnet. The features described on this page become live at the activation timestamps below.
+T6 is not yet active on mainnet. The features described on this page become live at the activation timestamps below.
 :::
 
 ## Timeline


### PR DESCRIPTION
## Summary
- Update the T6 upgrade status copy to say T6 is not yet active on mainnet.

## Validation
- `git diff --check`
- `pnpm exec biome check src/pages/protocol/upgrades/t6.mdx` could not process this MDX path because it is ignored by Biome config.
- `pnpm build` started successfully but hung with no new output after Vite began transforming; stopped after ~2 minutes.

Prompted by: @shekhirin