### PR TITLE
Remove protocol scheduler mention from scheduled transactions docs

### DIFF
--- a/src/pages/guide/use-accounts/scheduled-transactions.mdx
+++ b/src/pages/guide/use-accounts/scheduled-transactions.mdx
@@ -65,8 +65,6 @@ When you create a scheduled transaction, you have several options for storage:
 - **Third-party services**: Work with a company that specializes in holding and submitting scheduled transactions at the appropriate time
 - **Smart contracts**: Store the signed transaction onchain in a contract that can submit it when the time window is valid
 
-The Tempo team is actively exploring the design of a protocol-level scheduled transaction feature that would eliminate the need for off-chain storage. If this capability is valuable to your use case, please contact us to share your requirements and help inform the design.
-
 ## Mempool Behavior
 
 Validators will reject transactions that are outside their validity window:


### PR DESCRIPTION
## Summary
- Remove the scheduled transactions docs mention that Tempo is actively exploring a protocol-level scheduler that would eliminate off-chain storage

## Test plan
- bun run check (passes with existing warnings in scripts/lighthouse.ts)
- ./node_modules/.bin/biome check src/pages/guide/use-accounts/scheduled-transactions.mdx (MDX path is ignored by Biome)

Prompted by: @struong