### PR TITLE
docs: rename Tempo Tokens to TIP-20 Tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Vocs-powered documentation site for Tempo protocol.
 ## Protocol Concept Naming
 
 - Use literal concept names in user-facing docs. Add the TIP number in parentheses only in the sidebar and when first introducing a concept if it helps disambiguate.
-- Use `Tempo Tokens (TIP-20)` in sidebar/first-introduction contexts; use `Tempo Tokens` after that.
+- Use `TIP-20 Tokens` for sidebar labels, page titles, headings, and first-introduction contexts; use `TIP-20 tokens` in sentence-case prose after that.
 - Use `Tempo Token Rewards` in sidebar, concept introductions, and rewards-specific resource cards. Do not append `(TIP-20)`.
 - Keep raw TIP references for technical/spec contexts, e.g. `TIP-20 ABI`, `TIP-403 policy check`, or links titled `TIP-20 Specification`.
 

--- a/src/pages/ecosystem/index.mdx
+++ b/src/pages/ecosystem/index.mdx
@@ -7,7 +7,7 @@ import { Cards, Card } from 'vocs'
 
 # Tempo Ecosystem Infrastructure
 
-Integrating with Tempo is easy by leveraging services provided by our infrastructure partners. These partners take advantage of Tempo Transactions, Tempo Tokens (TIP-20), and more. Visit their documentation for more information on how to get started.
+Integrating with Tempo is easy by leveraging services provided by our infrastructure partners. These partners take advantage of Tempo Transactions, TIP-20 tokens, and more. Visit their documentation for more information on how to get started.
 
 <Cards>
   <Card

--- a/src/pages/guide/bridge-bungee.mdx
+++ b/src/pages/guide/bridge-bungee.mdx
@@ -26,7 +26,7 @@ Query the Bungee supported chains API to confirm current Tempo route support:
 curl "https://public-backend.bungee.exchange/api/v1/supported-chains"
 ```
 
-Query Tempo tokens from Bungee's token list when building token selectors:
+Query TIP-20 tokens from Bungee's token list when building token selectors:
 
 ```bash
 curl "https://public-backend.bungee.exchange/api/v1/tokens/list?chainIds=4217&list=full"

--- a/src/pages/guide/issuance/create-a-stablecoin.mdx
+++ b/src/pages/guide/issuance/create-a-stablecoin.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create your own stablecoin on Tempo using Tempo Tokens (TIP-20). Deploy tokens with built-in compliance features and role-based permissions.
+description: Create your own stablecoin on Tempo using TIP-20 tokens. Deploy tokens with built-in compliance features and role-based permissions.
 interactive: true
 ---
 
@@ -11,8 +11,8 @@ import { CreateToken } from '../../../components/guides/steps/issuance/CreateTok
 
 # Create a Stablecoin
 
-Create your own stablecoin on Tempo using [Tempo Tokens (TIP-20)](/protocol/tip20/overview). 
-Tempo Tokens are designed specifically for payments with built-in compliance features, role-based permissions, 
+Create your own stablecoin on Tempo using [TIP-20 Tokens](/protocol/tip20/overview).
+TIP-20 tokens are designed specifically for payments with built-in compliance features, role-based permissions,
 and integration with Tempo's payment infrastructure.
 
 ## Demo
@@ -329,6 +329,6 @@ export function CreateStablecoin() {
     description="Learn more about TIP-20 tokens on Tempo"
     to="/protocol/tip20/overview"
     icon="lucide:coins"
-    title="Tempo Tokens (TIP-20)"
+    title="TIP-20 Tokens"
   />
 </Cards>

--- a/src/pages/guide/issuance/index.mdx
+++ b/src/pages/guide/issuance/index.mdx
@@ -10,7 +10,7 @@ Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manag
 
 <Cards>
   <Card
-    description="Create your own stablecoin using Tempo Tokens (TIP-20) with built-in compliance features"
+    description="Create your own stablecoin using TIP-20 tokens with built-in compliance features"
     to="/guide/issuance/create-a-stablecoin"
     icon="lucide:coins"
     title="Create a Stablecoin"

--- a/src/pages/guide/issuance/manage-stablecoin.mdx
+++ b/src/pages/guide/issuance/manage-stablecoin.mdx
@@ -21,7 +21,7 @@ import { Cards, Card } from 'vocs'
 
 Configure your stablecoin's permissions, supply limits, and compliance policies after deployment. This guide covers granting roles to manage token operations, setting supply caps, configuring transfer policies, and controlling token transfers through pause/unpause functionality.
 
-Tempo Tokens (TIP-20) use a role-based access control system that allows you to delegate different administrative functions to different addresses. For detailed information about the role system, see the [TIP-20 specification](/protocol/tip20/spec#role-based-access-control).
+TIP-20 tokens use a role-based access control system that allows you to delegate different administrative functions to different addresses. For detailed information about the role system, see the [TIP-20 specification](/protocol/tip20/spec#role-based-access-control).
 
 ## Steps
 

--- a/src/pages/guide/issuance/mint-stablecoins.mdx
+++ b/src/pages/guide/issuance/mint-stablecoins.mdx
@@ -429,7 +429,7 @@ Assign the issuer role to dedicated treasury or minting addresses separate from 
     description="Learn more about TIP-20 tokens on Tempo"
     to="/protocol/tip20/overview"
     icon="lucide:coins"
-    title="Tempo Tokens (TIP-20)"
+    title="TIP-20 Tokens"
   />
   <Card
     description="Learn about role-based access control and token management"

--- a/src/pages/learn/stablecoins.mdx
+++ b/src/pages/learn/stablecoins.mdx
@@ -44,13 +44,13 @@ Stablecoins open the door to programmable money. Smart contracts can execute pay
 
 For example, a global enterprise can use a smart contract to automatically top up or sweep subsidiary wallets based on balance thresholds. Routine treasury actions run automatically onchain, replacing custom integrations with multiple banking partners.
 
-On Tempo, stablecoins use [Tempo Tokens (TIP-20)](/protocol/tip20/overview), which adds transfer memos, compliance controls, and reward distribution to standard token functionality.
+On Tempo, stablecoins use [TIP-20 Tokens](/protocol/tip20/overview), which adds transfer memos, compliance controls, and reward distribution to standard token functionality.
 
 ## Stablecoins on Tempo
 
 Tempo is purpose-built for stablecoin payments and issuance. Key resources:
 
-- [Tempo Tokens (TIP-20)](/protocol/tip20/overview): How stablecoins and other tokens behave on Tempo, including transfer memos and compliance policies
+- [TIP-20 Tokens](/protocol/tip20/overview): How stablecoins and other tokens behave on Tempo, including transfer memos and compliance policies
 - [Native stablecoins](/learn/tempo/native-stablecoins): How Tempo approaches stablecoin design, settlement, and fee payment
 - [Stablecoin DEX](/guide/stablecoin-dex): On-chain exchange for stablecoin-to-stablecoin swaps
 - [Mint stablecoins](/guide/issuance/mint-stablecoins): Create custom stablecoins with built-in compliance features

--- a/src/pages/learn/tempo/modern-transactions.mdx
+++ b/src/pages/learn/tempo/modern-transactions.mdx
@@ -60,7 +60,7 @@ Fee sponsorship removes gas from the user experience entirely. Combined with pas
 
 As stablecoin adoption grows, platforms need flexibility in how fees are paid. Configurable fee tokens allow transaction fees to be paid in any USD stablecoin, while fee sponsorship enables merchants to offer seamless checkout experiences for users.
 
-See: [Tempo Tokens (TIP-20)](/learn/tempo/native-stablecoins) for stable fees and payment memos.
+See: [TIP-20 Tokens](/learn/tempo/native-stablecoins) for stable fees and payment memos.
 
 ### Subscriptions
 

--- a/src/pages/learn/tempo/native-stablecoins.mdx
+++ b/src/pages/learn/tempo/native-stablecoins.mdx
@@ -4,7 +4,7 @@ description: Tempo's stablecoin token standard with payment lanes, stable fees, 
 
 import { Cards, Card } from 'vocs'
 
-# Tempo Tokens (TIP-20) [Tempo's native stablecoin token standard]
+# TIP-20 Tokens [Tempo's native stablecoin token standard]
 
 Tempo extends the [ERC-20 standard](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) used on EVM chains (Ethereum, Base, Arbitrum) with additional features, and enshrines them in protocol as the TIP-20 contract suite. These features are purpose-built for payment use cases at scale.
 

--- a/src/pages/learn/tempo/receive-policies.mdx
+++ b/src/pages/learn/tempo/receive-policies.mdx
@@ -97,7 +97,7 @@ Together, these controls make Tempo more practical for payment applications that
     icon="lucide:file-text"
   />
   <Card
-    title="Tempo Tokens (TIP-20)"
+    title="TIP-20 Tokens"
     description="Tempo's native stablecoin standard with payment lanes, memos, fees, and policy support."
     to="/learn/tempo/native-stablecoins"
     icon="lucide:coins"

--- a/src/pages/learn/use-cases/global-payouts.mdx
+++ b/src/pages/learn/use-cases/global-payouts.mdx
@@ -56,7 +56,7 @@ Companies can also choose to distribute funds through their subsidiaries. In thi
   />
 </Cards>
 
-For structured payment references (invoice IDs, customer IDs), see [Tempo Tokens (TIP-20)](/learn/tempo/native-stablecoins).
+For structured payment references (invoice IDs, customer IDs), see [TIP-20 Tokens](/learn/tempo/native-stablecoins).
 
 <Cards>
   <Card
@@ -184,7 +184,7 @@ Yes, increasingly so. Since the passage of the GENIUS Act in the United States, 
     icon="lucide:layers"
   />
   <Card
-    title="Tempo Tokens (TIP-20)"
+    title="TIP-20 Tokens"
     description="Reconciliation memos and stable fee mechanics."
     to="/learn/tempo/native-stablecoins"
     icon="lucide:tag"

--- a/src/pages/learn/use-cases/payroll.mdx
+++ b/src/pages/learn/use-cases/payroll.mdx
@@ -130,7 +130,7 @@ The stablecoin you pay employees with is only as reliable as the infrastructure 
     icon="lucide:book-open"
   />
   <Card
-    title="Tempo Tokens (TIP-20)"
+    title="TIP-20 Tokens"
     description="Reconciliation memos and stable fee mechanics."
     to="/learn/tempo/native-stablecoins"
     icon="lucide:tag"

--- a/src/pages/learn/use-cases/tokenized-deposits.mdx
+++ b/src/pages/learn/use-cases/tokenized-deposits.mdx
@@ -31,7 +31,7 @@ Each wallet can hold stablecoins, tokenized deposits, and even tokenized money m
 - **Idle balances can be deployed more efficiently**, improving working-capital usage and enabling immediate access to interest-bearing tokenized assets;
 - **Treasury workflows such as approvals, sweeps, and controls can be automated** with smart contracts, reducing manual processes and operational overhead.
 
-See also: [Global payouts with stablecoins](/learn/use-cases/global-payouts) for the outbound payments use case. For payment references and structured metadata, see [Tempo Tokens (TIP-20)](/learn/tempo/native-stablecoins). For batching and scheduled treasury movements, see [Tempo Transactions](/learn/tempo/modern-transactions).
+See also: [Global payouts with stablecoins](/learn/use-cases/global-payouts) for the outbound payments use case. For payment references and structured metadata, see [TIP-20 Tokens](/learn/tempo/native-stablecoins). For batching and scheduled treasury movements, see [Tempo Transactions](/learn/tempo/modern-transactions).
 
 ## How stablecoins fit into treasury workflows
 
@@ -55,7 +55,7 @@ Stablecoins complement bank accounts rather than replace them. Key constraints t
 
 ### Automated GL reconciliation
 
-Fast settlement only matters if transactions reconcile cleanly. Use transfer metadata (e.g., invoice ID, cost center, GL code) so treasury movements can auto-post back into ERP/TMS. Tempo Tokens (TIP-20) support native transfer memos designed for reconciliation: see [Tempo Tokens (TIP-20)](/learn/tempo/native-stablecoins).
+Fast settlement only matters if transactions reconcile cleanly. Use transfer metadata (e.g., invoice ID, cost center, GL code) so treasury movements can auto-post back into ERP/TMS. TIP-20 tokens support native transfer memos designed for reconciliation: see [TIP-20 Tokens](/learn/tempo/native-stablecoins).
 
 ### Controls and auditability
 
@@ -174,7 +174,7 @@ Tempo provides the neutral, high-performance infrastructure required for tokeniz
     icon="lucide:send"
   />
   <Card
-    title="Tempo Tokens (TIP-20)"
+    title="TIP-20 Tokens"
     description="Transfer memos and compliance features that make reconciliation easier."
     to="/learn/tempo/native-stablecoins"
     icon="lucide:tag"

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -17,7 +17,7 @@ This section provides details on the Tempo Protocol specifications, and serves a
     description="Core token standard with native stablecoin features and policy registry integration"
     to="/protocol/tip20/overview"
     icon="lucide:coins"
-    title="Tempo Tokens (TIP-20)"
+    title="TIP-20 Tokens"
   />
   <Card
     description="Reward distribution system for token holders with automated yield mechanisms"

--- a/src/pages/protocol/tip20/overview.mdx
+++ b/src/pages/protocol/tip20/overview.mdx
@@ -1,12 +1,12 @@
 ---
-description: Tempo Tokens (TIP-20) are Tempo's native token standard for stablecoins with built-in fee payment, payment lanes, transfer memos, and compliance policies.
+description: TIP-20 tokens are Tempo's native token standard for stablecoins with built-in fee payment, payment lanes, transfer memos, and compliance policies.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Tempo Tokens (TIP-20)
+# TIP-20 Tokens
 
-Tempo Tokens (TIP-20) are Tempo's native token standard for stablecoins and payment tokens. They are designed for stablecoin payments, and are the foundation for many token-related functions on Tempo including transaction fees, payment lanes, DEX quote tokens, optimized routing for DEX liquidity, optional on-chain token `logoURI` metadata, implicit approvals for listed precompiles, and enshrined payment-channel reserve flows.
+TIP-20 tokens are Tempo's native token standard for stablecoins and payment tokens. They are designed for stablecoin payments, and are the foundation for many token-related functions on Tempo including transaction fees, payment lanes, DEX quote tokens, optimized routing for DEX liquidity, optional on-chain token `logoURI` metadata, implicit approvals for listed precompiles, and enshrined payment-channel reserve flows.
 
 :::info[Live on testnet with T6]
 The [T6 network upgrade](/protocol/upgrades/t6) adds account-level receive policies for TIP-20 transfers and mints ([TIP-1028](https://tips.sh/1028)). A receiver can choose which tokens and senders they accept, helping wallets and deposit addresses avoid unsupported assets, unwanted counterparties, and wrong-token deposits. If a receive policy blocks delivery, the transfer or mint still succeeds, but funds are redirected to `ReceivePolicyGuard` so they can be claimed later.
@@ -16,7 +16,7 @@ See the [T5 → T6 migration appendix on the TIP-20 spec](/protocol/tip20/spec#t
 
 All TIP-20 tokens are created by interacting with the [TIP-20 Factory contract](/protocol/tip20/spec#tip20factory), calling the `createToken` function. If you're issuing a stablecoin on Tempo, we **strongly recommend** using the TIP-20 standard. Learn more about the benefits, or follow the guide on issuance [here](/guide/issuance).
 
-## Benefits & Features of Tempo Tokens
+## Benefits & Features of TIP-20 Tokens
 
 Below are some of the key benefits and features of TIP-20 tokens:
 

--- a/src/pages/protocol/tip20/spec.mdx
+++ b/src/pages/protocol/tip20/spec.mdx
@@ -1,11 +1,11 @@
 ---
-description: Technical specification for Tempo Tokens (TIP-20), the optimized token standard extending ERC-20 with memos, rewards distribution, and policy integration.
+description: Technical specification for TIP-20 tokens, the optimized token standard extending ERC-20 with memos, rewards distribution, and policy integration.
 ---
 
-# Tempo Tokens (TIP-20) Specification
+# TIP-20 Tokens Specification
 
 ## Abstract
-Tempo Tokens (TIP-20) are a suite of precompiles that provide a built-in optimized token implementation in the core protocol. They extend the ERC-20 token standard with built-in functionality like memo fields and reward distribution.
+TIP-20 tokens are a suite of precompiles that provide a built-in optimized token implementation in the core protocol. They extend the ERC-20 token standard with built-in functionality like memo fields and reward distribution.
 
 ## Motivation
 All major stablecoins today use the ERC-20 token standard. While ERC-20 provides a solid foundation for fungible tokens, it lacks features critical for stablecoin issuers today such as memos, transfer policies, and rewards distribution. Additionally, since each ERC-20 token has its own implementation, integrators can't depend on consistent behavior across tokens.

--- a/src/pages/protocol/tip403/spec.mdx
+++ b/src/pages/protocol/tip403/spec.mdx
@@ -223,7 +223,7 @@ interface ITIP403Registry {
 }
 ```
 
-## Usage with Tempo Tokens
+## Usage with TIP-20 Tokens
 
 TIP-20 tokens store the current TIP403 registry policy ID they adhere to in their storage. On any token transfer, they perform a TIP-403 policy check by calling `isAuthorized()` for both sender and recipient addresses. The policy to use for the token can only be set by the admin of the token.
 

--- a/src/pages/quickstart/developer-tools.mdx
+++ b/src/pages/quickstart/developer-tools.mdx
@@ -6,7 +6,7 @@ import { Cards, Card } from 'vocs'
 
 # Developer Tools
 
-Integrating with Tempo is easy by leveraging services provided by our infrastructure partners. These partners take advantage of Tempo Transactions, Tempo Tokens (TIP-20), and more. Visit their documentation for more information on how to get started.
+Integrating with Tempo is easy by leveraging services provided by our infrastructure partners. These partners take advantage of Tempo Transactions, TIP-20 tokens, and more. Visit their documentation for more information on how to get started.
 
 <Cards>
   <Card

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -524,7 +524,7 @@ export default defineConfig({
             link: '/protocol',
           },
           {
-            text: 'Tempo Tokens (TIP-20)',
+            text: 'TIP-20 Tokens',
             collapsed: true,
             items: [
               {


### PR DESCRIPTION
## Summary

- Rename Tempo Tokens docs labels to TIP-20 Tokens.
- Update prose references to sentence-case TIP-20 tokens.
- Update protocol naming guidance for future docs changes.

## Motivation

Align docs naming with current TIP-20 token presentation in navigation, cards, and protocol pages.

## Key design considerations

- Kept sidebar, page, heading, card, and link labels as TIP-20 Tokens.
- Kept normal prose references as TIP-20 tokens.
- Left existing raw technical TIP-20 references unchanged.