### PR TITLE
Document AllUnity stablecoin assets

### DIFF
--- a/src/pages/ecosystem/orchestration.mdx
+++ b/src/pages/ecosystem/orchestration.mdx
@@ -7,6 +7,12 @@ description: Move money globally between local currencies and stablecoins. Issue
 
 Move money globally between local currencies and stablecoins. Issue, transfer, and manage stablecoins.
 
+## AllUnity
+
+[AllUnity](https://allunity.com) is a BaFin-regulated e-money institute providing institutional-grade infrastructure for seamless, secure, real-time digital currency transactions, with full reserve backing and regulatory transparency.
+
+AllUnity assets live on Tempo include EURAU, SEKAU, and CHFAU.
+
 ## Brale
 
 [Brale](https://brale.xyz) provides infrastructure for issuing, transferring, and managing stablecoins across chains. Developers can create new stablecoins or work with existing issued assets using Brale's APIs to support on- and off-ramps, payouts, and cross-ecosystem stablecoin movement.

--- a/src/pages/learn/tempo/native-stablecoins.mdx
+++ b/src/pages/learn/tempo/native-stablecoins.mdx
@@ -97,7 +97,7 @@ Use the Tempo Policy Registry (TIP-403) so multiple tokens can share a policy an
 
 Work with infrastructure partners who are rolling out TIP-20 support to accelerate your development:
 
-- [AllUnity](https://allunity.com/) - Regulated euro stablecoins for European corporates
+- [AllUnity](https://allunity.com/) - Regulated euro, Swedish krona, and Swiss franc stablecoins for European corporates
 - [Bridge](https://www.bridge.xyz/) - Custom regulated stablecoin issuance with off-the-shelf templates
 - [LayerZero](https://layerzero.network/) - Cross-chain token extensions for Tempo's payment ecosystem
 


### PR DESCRIPTION
## Summary
- add a bundled AllUnity entry to the docs ecosystem page
- list live AllUnity assets as the euro stablecoin, SEKAU, and CHFAU
- update the native stablecoins partner blurb

## Tests
- pnpm check:types

Prompted by: @juandolealt