### PR TITLE
Add agent logos to AI menu

### DIFF
--- a/src/components/AgentLogos.tsx
+++ b/src/components/AgentLogos.tsx
@@ -1,0 +1,31 @@
+import type { SVGProps } from 'react'
+import SimpleIconsClaude from '~icons/simple-icons/claude'
+import SimpleIconsOpenai from '~icons/simple-icons/openai'
+
+export function ClaudeLogo(props: SVGProps<SVGSVGElement>) {
+  return <SimpleIconsClaude {...props} />
+}
+
+export function CodexLogo(props: SVGProps<SVGSVGElement>) {
+  return <SimpleIconsOpenai {...props} />
+}
+
+export function AmpLogo(props: SVGProps<SVGSVGElement>) {
+  return (
+    // biome-ignore lint/a11y/noSvgWithoutTitle: Decorative product mark paired with visible tab text.
+    <svg viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        d="M3.76879 18.3015L8.49839 13.505L10.2196 20.0399L12.72 19.3561L10.2288 9.86749L0.890876 7.33844L0.22594 9.89331L6.65134 11.6388L1.94138 16.4282L3.76879 18.3015Z"
+        fill="currentColor"
+      />
+      <path
+        d="M17.4074 12.7414L19.9078 12.0575L17.4167 2.56897L8.07873 0.0399246L7.4138 2.5948L15.2992 4.73685L17.4074 12.7414Z"
+        fill="currentColor"
+      />
+      <path
+        d="M13.8184 16.3883L16.3188 15.7044L13.8276 6.21588L4.48971 3.68683L3.82477 6.24171L11.7101 8.38376L13.8184 16.3883Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}

--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useConfig } from 'vocs'
+import { AmpLogo, ClaudeLogo, CodexLogo } from './AgentLogos'
 
 type MegaLink = {
   label: string
@@ -525,9 +526,21 @@ function CheckIcon() {
 }
 
 const mcpCommands = [
-  { label: 'Claude', prefix: 'claude mcp add --transport http tempo ' },
-  { label: 'Codex', prefix: 'codex mcp add tempo --url ' },
-  { label: 'Amp', prefix: 'amp mcp add --transport http tempo ' },
+  {
+    label: 'Claude',
+    logo: <ClaudeLogo aria-hidden="true" className="size-3.5 shrink-0" />,
+    prefix: 'claude mcp add --transport http tempo ',
+  },
+  {
+    label: 'Codex',
+    logo: <CodexLogo aria-hidden="true" className="size-3.5 shrink-0" />,
+    prefix: 'codex mcp add tempo --url ',
+  },
+  {
+    label: 'Amp',
+    logo: <AmpLogo aria-hidden="true" className="size-3.5 shrink-0" />,
+    prefix: 'amp mcp add --transport http tempo ',
+  },
 ]
 
 function AgentMenuItem(props: {
@@ -617,13 +630,14 @@ function AgentsPanel({
                       setActiveCommandIndex(index)
                       setCopied(false)
                     }}
-                    className={`rounded-[4px] px-2.5 py-1.5 font-sans text-[12px] tracking-[0] transition-colors ${
+                    className={`inline-flex items-center gap-1.5 rounded-[4px] px-2.5 py-1.5 font-sans text-[12px] tracking-[0] transition-colors ${
                       active
                         ? 'bg-foreground/[0.06] text-foreground'
                         : 'text-foreground/40 hover:bg-foreground/[0.03] hover:text-foreground/70'
                     }`}
                   >
-                    {item.label}
+                    {item.logo}
+                    <span>{item.label}</span>
                   </button>
                 )
               })}

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -6,6 +6,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { type ReactNode, useLayoutEffect, useRef, useState } from 'react'
+import { AmpLogo, ClaudeLogo, CodexLogo } from '../../../components/AgentLogos'
 import { featurePath } from '../_lib/featurePaths'
 import { TEMPO_SDK_DOCS_URL } from '../_lib/links'
 import ArrowUpRight from './ArrowUpRight'
@@ -227,9 +228,21 @@ function Chevron({ open }: { open: boolean }) {
 
 // The server URL is appended at render time so it can be color-highlighted.
 const mcpCommands = [
-  { label: 'Claude', prefix: 'claude mcp add --transport http tempo ' },
-  { label: 'Codex', prefix: 'codex mcp add tempo --url ' },
-  { label: 'Amp', prefix: 'amp mcp add --transport http tempo ' },
+  {
+    label: 'Claude',
+    logo: <ClaudeLogo aria-hidden="true" className="size-3.5 shrink-0" />,
+    prefix: 'claude mcp add --transport http tempo ',
+  },
+  {
+    label: 'Codex',
+    logo: <CodexLogo aria-hidden="true" className="size-3.5 shrink-0" />,
+    prefix: 'codex mcp add tempo --url ',
+  },
+  {
+    label: 'Amp',
+    logo: <AmpLogo aria-hidden="true" className="size-3.5 shrink-0" />,
+    prefix: 'amp mcp add --transport http tempo ',
+  },
 ]
 
 function CopyIcon() {
@@ -366,13 +379,14 @@ function AgentsPanel({
                       setActiveCommandIndex(index)
                       setCopied(false)
                     }}
-                    className={`rounded-[4px] px-2.5 py-1.5 font-sans text-[12px] tracking-[0] transition-colors ${
+                    className={`inline-flex items-center gap-1.5 rounded-[4px] px-2.5 py-1.5 font-sans text-[12px] tracking-[0] transition-colors ${
                       active
                         ? 'bg-foreground/[0.06] text-foreground'
                         : 'text-foreground/40 hover:bg-foreground/[0.03] hover:text-foreground/70'
                     }`}
                   >
-                    {item.label}
+                    {item.logo}
+                    <span>{item.label}</span>
                   </button>
                 )
               })}


### PR DESCRIPTION
## Summary
- add shared monochrome Claude, Codex, and Amp logo components
- show those logos in the AI install command tabs for docs and marketing headers

## Validation
- bun run check
- bun run check:types
- bun run build