### PR TITLE
Scope homepage code toggles per showcase

### DIFF
--- a/src/marketing/app/_components/HomeShowcases.tsx
+++ b/src/marketing/app/_components/HomeShowcases.tsx
@@ -1,20 +1,16 @@
 'use client'
 
-import { useState } from 'react'
-import type { ShowcaseMode } from './ModeToggle'
 import TokensShowcase from './TokensShowcase'
 import TransactionsShowcase from './TransactionsShowcase'
 
 export default function HomeShowcases() {
-  const [mode, setMode] = useState<ShowcaseMode>('visual')
-
   return (
     <>
       <div id="tokens" className="mt-[140px] scroll-mt-12">
-        <TokensShowcase mode={mode} setMode={setMode} />
+        <TokensShowcase />
       </div>
       <div id="transactions" className="-mt-px scroll-mt-12">
-        <TransactionsShowcase mode={mode} setMode={setMode} />
+        <TransactionsShowcase />
       </div>
     </>
   )

--- a/src/marketing/app/_components/TokensShowcase.tsx
+++ b/src/marketing/app/_components/TokensShowcase.tsx
@@ -256,14 +256,9 @@ function VisualMock({ active }: { active: Row }) {
   )
 }
 
-export default function TokensShowcase({
-  mode,
-  setMode,
-}: {
-  mode: ShowcaseMode
-  setMode: (mode: ShowcaseMode) => void
-}) {
+export default function TokensShowcase() {
   const [active, setActive] = useState(0)
+  const [mode, setMode] = useState<ShowcaseMode>('visual')
   const selectRow = (index: number) => {
     if (index !== active) {
       setActive(index)

--- a/src/marketing/app/_components/TransactionsShowcase.tsx
+++ b/src/marketing/app/_components/TransactionsShowcase.tsx
@@ -90,14 +90,9 @@ function VisualMock({ active }: { active: Row }) {
   )
 }
 
-export default function TransactionsShowcase({
-  mode,
-  setMode,
-}: {
-  mode: ShowcaseMode
-  setMode: (mode: ShowcaseMode) => void
-}) {
+export default function TransactionsShowcase() {
   const [active, setActive] = useState(0)
+  const [mode, setMode] = useState<ShowcaseMode>('visual')
   const selectRow = (index: number) => {
     if (index !== active) {
       setActive(index)


### PR DESCRIPTION
## Summary
- Move homepage showcase Diagram/Code mode state into each showcase component
- Stop the Tokens and Transactions sections from sharing one global mode toggle

## Verification
- pnpm check:types
- pnpm build (exited 0; emitted existing dependency/network warnings)

Prompted by: @brendanjryan