### PR TITLE
fix: preload pilat font

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import type { PropsWithChildren } from 'react'
 
 export default function Layout(
@@ -8,5 +6,16 @@ export default function Layout(
     frontmatter?: { interactive?: boolean; mipd?: boolean }
   }>,
 ) {
-  return <>{props.children}</>
+  return (
+    <>
+      <link
+        rel="preload"
+        href="/fonts/pilat/Pilat-Book.woff2"
+        as="font"
+        type="font/woff2"
+        crossOrigin="anonymous"
+      />
+      {props.children}
+    </>
+  )
 }

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -495,9 +495,9 @@
   color-scheme: dark;
 
   --font-hbset: "HBSet";
-  --font-pilat-book: "Pilat";
+  --font-pilat-book: "Pilat", ui-sans-serif, system-ui, sans-serif;
   --font-jetbrains-mono: "JetBrains Mono";
-  --vocs-font-family: var(--font-pilat-book), ui-sans-serif, system-ui, sans-serif;
+  --vocs-font-family: var(--font-pilat-book);
   --vocs-font-family-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
 
   --color-background: #111111;
@@ -763,7 +763,7 @@ html {
 
 body {
   user-select: text;
-  font-family: var(--font-pilat-book), ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-pilat-book);
 }
 
 :where(


### PR DESCRIPTION
Preloads the Pilat body font from the root layout while keeping swap behavior enabled.

The Pilat font variable now includes an explicit sans serif fallback chain, so text can render in a sans face while the real font is loading instead of falling through to a browser default.