### PR TITLE
fix: improve `docs.tempo.xyz` page speed

### DIFF
--- a/src/marketing/MarketingRoute.tsx
+++ b/src/marketing/MarketingRoute.tsx
@@ -43,6 +43,8 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
 }
 
 const prefetchedPaths = new Set<string>()
+const ANALYTICS_DELAY_MS = 15_000
+const ANALYTICS_IDLE_TIMEOUT_MS = 20_000
 
 function prefetchPath(href: string) {
   if (!href.startsWith('/') || prefetchedPaths.has(href)) return
@@ -53,6 +55,22 @@ function prefetchPath(href: string) {
   link.href = href
   link.as = 'document'
   document.head.appendChild(link)
+}
+
+function scheduleIdleAnalytics(callback: () => void) {
+  let idleId: number | undefined
+  const timeoutId = globalThis.setTimeout(() => {
+    if ('requestIdleCallback' in window) {
+      idleId = window.requestIdleCallback(callback, { timeout: ANALYTICS_IDLE_TIMEOUT_MS })
+    } else {
+      callback()
+    }
+  }, ANALYTICS_DELAY_MS)
+
+  return () => {
+    globalThis.clearTimeout(timeoutId)
+    if (idleId !== undefined) window.cancelIdleCallback(idleId)
+  }
 }
 
 function applyRouteMetadata(route: string) {
@@ -75,17 +93,10 @@ export default function MarketingRoute({
   }, [route])
 
   useEffect(() => {
-    if ('requestIdleCallback' in window) {
-      const idleId = window.requestIdleCallback(() => setAnalyticsReady(true), { timeout: 2_000 })
-      return () => window.cancelIdleCallback(idleId)
-    }
-    const timeoutId = globalThis.setTimeout(() => setAnalyticsReady(true), 1)
-    return () => globalThis.clearTimeout(timeoutId)
+    return scheduleIdleAnalytics(() => setAnalyticsReady(true))
   }, [])
 
   useEffect(() => {
-    prefetchPath('/docs')
-
     const prefetchAnchor = (event: Event) => {
       const target = event.target
       if (!(target instanceof Element)) return

--- a/src/marketing/app/_components/Footer.tsx
+++ b/src/marketing/app/_components/Footer.tsx
@@ -102,10 +102,10 @@ export default function Footer() {
       <Reveal>
         <div className="grid gap-12 px-5 py-12 lg:grid-cols-[minmax(220px,1fr)_2fr] lg:gap-16 lg:px-8 lg:py-16">
           <div className="flex max-w-[320px] flex-col gap-4">
-            <Link href="/" className="flex items-center gap-2">
+            <Link href="/" aria-label="Tempo home" className="flex items-center gap-2">
               <TempoLogo className="h-[18px] w-[80px] text-foreground" />
             </Link>
-            <p className="font-sans text-[15px] text-foreground/45 leading-[1.6] tracking-[0]">
+            <p className="font-sans text-[15px] text-foreground/55 leading-[1.6] tracking-[0]">
               Stablecoin payments infrastructure for developers, apps, and agents building on Tempo.
             </p>
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2 font-sans text-[14px] text-foreground/50 tracking-[0]">

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -617,7 +617,12 @@ export default function Header() {
   return (
     <header ref={headerRef} className="relative z-20 border-line border-b">
       <nav ref={navRef} className="flex items-center justify-between px-5 py-4">
-        <Link href="/" onClick={close} className="group flex items-center gap-3">
+        <Link
+          href="/"
+          onClick={close}
+          aria-label="Tempo home"
+          className="group flex items-center gap-3"
+        >
           <TempoLogo className="h-[18px] w-[80px] text-foreground" />
         </Link>
 

--- a/src/marketing/app/_components/HomeBelowFold.tsx
+++ b/src/marketing/app/_components/HomeBelowFold.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react'
+import { fetchPerfRuns } from '../performance/_lib/runs'
+import Footer from './Footer'
+import HomeShowcases from './HomeShowcases'
+import OpenSourceSection from './OpenSourceSection'
+import PerfSection from './PerfSection'
+import { stats as fallbackStats, fetchStats } from './stats'
+
+export default function HomeBelowFold() {
+  const [stats, setStats] = useState(fallbackStats)
+  const [runs, setRuns] = useState<Awaited<ReturnType<typeof fetchPerfRuns>>>([])
+  const [loadPerfData, setLoadPerfData] = useState(false)
+  const perfSectionRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const section = perfSectionRef.current
+    if (!section || loadPerfData) return
+    if (!('IntersectionObserver' in window)) {
+      const timeoutId = globalThis.setTimeout(() => setLoadPerfData(true), 4_000)
+      return () => globalThis.clearTimeout(timeoutId)
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return
+        setLoadPerfData(true)
+        observer.disconnect()
+      },
+      { rootMargin: '600px 0px' },
+    )
+    observer.observe(section)
+    return () => observer.disconnect()
+  }, [loadPerfData])
+
+  useEffect(() => {
+    if (!loadPerfData) return
+    let active = true
+    Promise.all([fetchStats(), fetchPerfRuns()]).then(([perfData, perfRuns]) => {
+      if (!active) return
+      setStats(perfData.stats)
+      setRuns(perfRuns)
+    })
+    return () => {
+      active = false
+    }
+  }, [loadPerfData])
+
+  return (
+    <>
+      <HomeShowcases />
+      <div ref={perfSectionRef} id="performance" className="mt-[140px] scroll-mt-12">
+        <PerfSection stats={stats} runs={runs} />
+      </div>
+      <div id="open-source" className="mt-[140px] scroll-mt-12">
+        <OpenSourceSection />
+      </div>
+      <Footer />
+    </>
+  )
+}

--- a/src/marketing/app/_components/ModeToggle.tsx
+++ b/src/marketing/app/_components/ModeToggle.tsx
@@ -26,7 +26,7 @@ export default function ModeToggle({
             className={`h-8 border-line border-r px-3 font-mono text-[10px] uppercase tracking-[0.12em] transition-colors last:border-r-0 ${
               mode === option
                 ? 'bg-surface-card-elev text-foreground'
-                : 'text-foreground/40 hover:bg-surface-block hover:text-foreground/70'
+                : 'text-foreground/55 hover:bg-surface-block hover:text-foreground/70'
             }`}
           >
             {labels[option]}

--- a/src/marketing/app/_components/PerfSection.tsx
+++ b/src/marketing/app/_components/PerfSection.tsx
@@ -235,7 +235,7 @@ export default function PerfSection({ stats, runs }: { stats: Stat[]; runs: Perf
           Pushing the frontier of blockchain performance.
         </h2>
         <Button href={PERFORMANCE_PAGE} arrow className="mt-9">
-          Learn more
+          Explore performance
         </Button>
       </Reveal>
 

--- a/src/marketing/app/_components/TokensShowcase.tsx
+++ b/src/marketing/app/_components/TokensShowcase.tsx
@@ -295,7 +295,7 @@ export default function TokensShowcase() {
                   <span className="block font-sans text-[20px] leading-[1.2] tracking-[0]">
                     {row.title}
                   </span>
-                  <span className="mt-2 block max-w-[560px] font-sans text-[14px] text-foreground/40 leading-[1.45] tracking-[0] group-hover:text-foreground/50">
+                  <span className="mt-2 block max-w-[560px] font-sans text-[14px] text-foreground/55 leading-[1.45] tracking-[0] group-hover:text-foreground/65">
                     {row.desc}
                   </span>
                 </span>

--- a/src/marketing/app/_components/TransactionsShowcase.tsx
+++ b/src/marketing/app/_components/TransactionsShowcase.tsx
@@ -124,7 +124,7 @@ export default function TransactionsShowcase() {
                   <span className="block font-sans text-[20px] leading-[1.2] tracking-[0]">
                     {row.title}
                   </span>
-                  <span className="mt-2 block max-w-[420px] font-sans text-[14px] text-foreground/40 leading-[1.45] tracking-[0] group-hover:text-foreground/50">
+                  <span className="mt-2 block max-w-[420px] font-sans text-[14px] text-foreground/55 leading-[1.45] tracking-[0] group-hover:text-foreground/65">
                     {row.desc}
                   </span>
                 </span>

--- a/src/marketing/app/page.tsx
+++ b/src/marketing/app/page.tsx
@@ -1,42 +1,18 @@
-import { useEffect, useState } from 'react'
-import Footer from './_components/Footer'
+import { lazy, Suspense } from 'react'
 import Header from './_components/Header'
 import Hero from './_components/Hero'
-import HomeShowcases from './_components/HomeShowcases'
-import OpenSourceSection from './_components/OpenSourceSection'
-import PerfSection from './_components/PerfSection'
-import { stats as fallbackStats, fetchStats } from './_components/stats'
-import { fetchPerfRuns } from './performance/_lib/runs'
+
+const HomeBelowFold = lazy(() => import('./_components/HomeBelowFold'))
 
 export default function Home() {
-  const [stats, setStats] = useState(fallbackStats)
-  const [runs, setRuns] = useState<Awaited<ReturnType<typeof fetchPerfRuns>>>([])
-
-  useEffect(() => {
-    let active = true
-    Promise.all([fetchStats(), fetchPerfRuns()]).then(([perfData, perfRuns]) => {
-      if (!active) return
-      setStats(perfData.stats)
-      setRuns(perfRuns)
-    })
-    return () => {
-      active = false
-    }
-  }, [])
-
   return (
     <main className="min-h-screen w-full bg-surface-page">
       <div className="mx-auto w-full max-w-7xl border-line border-x bg-surface-shell">
         <Header />
         <Hero />
-        <HomeShowcases />
-        <div id="performance" className="mt-[140px] scroll-mt-12">
-          <PerfSection stats={stats} runs={runs} />
-        </div>
-        <div id="open-source" className="mt-[140px] scroll-mt-12">
-          <OpenSourceSection />
-        </div>
-        <Footer />
+        <Suspense fallback={null}>
+          <HomeBelowFold />
+        </Suspense>
       </div>
     </main>
   )

--- a/src/marketing/index.html
+++ b/src/marketing/index.html
@@ -16,6 +16,7 @@
     <meta property="twitter:image" content="/api/og?title=Tempo&description=The%20only%20blockchain%20designed%20for%20payments.%20Sub-second%20transactions%2C%20sub-cent%20fees.&section=BUILD" />
     <link rel="icon" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)" type="image/svg+xml" />
     <link rel="icon" href="/favicon-light.svg" media="(prefers-color-scheme: light)" type="image/svg+xml" />
+    <link rel="preload" href="/fonts/pilat/Pilat-Book.woff2" as="font" type="font/woff2" crossorigin />
     <script>let theme;let resolved;try{theme=localStorage.getItem("vocs-theme");resolved=theme==="light"||theme==="dark"?theme:window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";document.documentElement.setAttribute("data-vocs-theme",resolved);if(resolved==="light"){document.documentElement.dataset.theme="light";}else{delete document.documentElement.dataset.theme;}document.documentElement.style.colorScheme=resolved;}catch(_e){document.documentElement.setAttribute("data-vocs-theme","dark");document.documentElement.style.colorScheme="dark";}</script>
     <style>html,body,#root{min-height:100%;background:#111;color:#f1f1f1}html[data-vocs-theme="light"],html[data-vocs-theme="light"] body,html[data-vocs-theme="light"] #root{background:#fafafa;color:#111}</style>
   </head>

--- a/src/marketing/main.tsx
+++ b/src/marketing/main.tsx
@@ -39,6 +39,8 @@ function normalizeRoutePath(pathname: string) {
 }
 
 const prefetchedPaths = new Set<string>()
+const ANALYTICS_DELAY_MS = 15_000
+const ANALYTICS_IDLE_TIMEOUT_MS = 20_000
 
 function prefetchPath(href: string) {
   if (!href.startsWith('/') || prefetchedPaths.has(href)) return
@@ -49,6 +51,22 @@ function prefetchPath(href: string) {
   link.href = href
   link.as = 'document'
   document.head.appendChild(link)
+}
+
+function scheduleIdleAnalytics(callback: () => void) {
+  let idleId: number | undefined
+  const timeoutId = globalThis.setTimeout(() => {
+    if ('requestIdleCallback' in window) {
+      idleId = window.requestIdleCallback(callback, { timeout: ANALYTICS_IDLE_TIMEOUT_MS })
+    } else {
+      callback()
+    }
+  }, ANALYTICS_DELAY_MS)
+
+  return () => {
+    globalThis.clearTimeout(timeoutId)
+    if (idleId !== undefined) window.cancelIdleCallback(idleId)
+  }
 }
 
 const routeMetadata: Record<string, { title: string; description: string }> = {
@@ -194,17 +212,10 @@ function MarketingApp() {
 
   useEffect(() => {
     setAnalyticsReady(false)
-    if ('requestIdleCallback' in window) {
-      const idleId = window.requestIdleCallback(() => setAnalyticsReady(true), { timeout: 2_000 })
-      return () => window.cancelIdleCallback(idleId)
-    }
-    const timeoutId = globalThis.setTimeout(() => setAnalyticsReady(true), 1)
-    return () => globalThis.clearTimeout(timeoutId)
+    return scheduleIdleAnalytics(() => setAnalyticsReady(true))
   }, [])
 
   useEffect(() => {
-    prefetchPath('/docs')
-
     const update = () => {
       startTransition(() => setRoute(currentRoute()))
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,6 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       marketingPages(),
-      crossAppPrefetch(),
       vocs(),
       Icons({ compiler: 'jsx', jsx: 'react' }),
       react(),
@@ -85,20 +84,6 @@ function marketingPages(): Plugin {
         res.setHeader('Content-Type', 'text/html')
         res.end(html)
       })
-    },
-  }
-}
-
-function crossAppPrefetch(): Plugin {
-  return {
-    name: 'tempo-cross-app-prefetch',
-    enforce: 'post',
-    transformIndexHtml(html, context) {
-      const pathname = context.path?.replace(/\/$/, '') || '/'
-      const href = pathname === '/docs' || pathname.startsWith('/docs/') ? '/' : '/docs'
-      const prefetchLink = `<link href="${href}" rel="prefetch" as="document" />`
-      if (html.includes(`href="${href}" rel="prefetch"`)) return html
-      return html.replace('</head>', `  ${prefetchLink}\n  </head>`)
     },
   }
 }

--- a/vite.marketing.config.ts
+++ b/vite.marketing.config.ts
@@ -25,10 +25,7 @@ function marketingRouteCopies(): Plugin {
         await fs.writeFile(rootHtml, nested)
         return nested
       })
-      const marketingHtml = applyMarketingMetadata(
-        injectHeadTags(html, ['<link href="/docs" rel="prefetch" as="document" />']),
-        '/',
-      )
+      const marketingHtml = applyMarketingMetadata(html, '/')
       await fs.writeFile(rootHtml, marketingHtml)
 
       await Promise.all(
@@ -152,14 +149,9 @@ function marketingOgImage(route: string, metadata: { title: string; description:
   }).toString()}`
 }
 
-function injectHeadTags(html: string, tags: string[]) {
-  const missing = tags.filter((tag) => !html.includes(tag))
-  if (missing.length === 0) return html
-  return html.replace('</head>', `  ${missing.join('\n  ')}\n  </head>`)
-}
-
 export default defineConfig({
   root: 'src/marketing',
+  publicDir: path.resolve(process.cwd(), 'public'),
   plugins: [
     tailwindcss(),
     Icons({ compiler: 'jsx', jsx: 'react' }),


### PR DESCRIPTION
Optimizes the marketing homepage served at `docs.tempo.xyz` by moving below-fold sections out of the initial chunk, delaying analytics, and loading benchmark data only when the performance section is near view.

Also removes eager cross-app document prefetching, preloads the primary display font, and fixes Lighthouse accessibility and SEO blockers from unlabeled logo links, low-contrast muted copy, and generic CTA text.