### PR TITLE
Add search to docs homepage

### DIFF
--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -430,7 +430,7 @@ function MenuIcon() {
   )
 }
 
-function SearchIcon({ className }: { className?: string }) {
+export function SearchIcon({ className }: { className?: string }) {
   return (
     // biome-ignore lint/a11y/noSvgWithoutTitle: Button provides the accessible label.
     <svg
@@ -457,7 +457,7 @@ function SearchIcon({ className }: { className?: string }) {
 // importing that internal, unexported component, we re-expose the affordance by
 // dispatching the same shortcut Vocs already handles. See src/pages/_root.css
 // where the gutter is hidden, and node_modules/vocs Search.tsx for the listener.
-function openDocsSearch() {
+export function openDocsSearch() {
   if (typeof document === 'undefined') return
   const event = new KeyboardEvent('keydown', {
     key: 'k',

--- a/src/components/DocsHomeSearch.tsx
+++ b/src/components/DocsHomeSearch.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { openDocsSearch, SearchIcon } from './DocsHeader'
+
+export default function DocsHomeSearch() {
+  return (
+    <button
+      type="button"
+      onClick={openDocsSearch}
+      aria-label="Search documentation"
+      aria-keyshortcuts="Meta+K Control+K"
+      className="mt-8 flex min-h-13 w-full max-w-2xl items-center gap-3 rounded-[6px] border border-line bg-foreground/[0.03] px-4 font-sans text-[15px] text-foreground/60 tracking-[0] transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+    >
+      <SearchIcon className="size-[18px]" />
+      <span className="flex-1 text-left">Search documentation</span>
+      <kbd className="hidden rounded-[3px] border border-line px-1.5 py-0.5 font-sans text-[11px] text-foreground/45 sm:inline-block">
+        ⌘K
+      </kbd>
+    </button>
+  )
+}

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -3,6 +3,7 @@ description: Explore Tempo's blockchain documentation, integration guides, and p
 ---
 
 import { Cards, Card } from 'vocs'
+import DocsHomeSearch from '../../components/DocsHomeSearch'
 
 # Tempo [Documentation, integration guides, and protocol specifications]
 
@@ -13,6 +14,8 @@ Tempo is a general-purpose blockchain optimized for payments. Tempo is designed 
 Tempo was designed in close collaboration with an exceptional group of [design partners](https://tempo.xyz/ecosystem) who are helping to validate the system against real payment workloads.
 
 These docs cover everything from creating a wallet to building payment systems on Tempo.
+
+<DocsHomeSearch />
 
 <Cards>
   <Card


### PR DESCRIPTION
## Summary
- add a docs homepage search button below the intro copy
- reuse the existing Vocs search dialog trigger used by the custom docs header

## Verification
- bun run check
- bun run check:types
- bun run build (completed; logged an existing GitHub changelog fetch timeout during SSG)

Prompted by: @brendanjryan