### PR TITLE
feat: homepage search + fix Shiki sol crash

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -24,8 +24,3 @@ interface ImportMetaEnv extends EnvironmentVariables {}
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
-
-declare module 'virtual:marketing/search-index' {
-  /** Returns the serialized MiniSearch index JSON for the docs search. */
-  export function getSearchIndex(): Promise<string>
-}

--- a/env.d.ts
+++ b/env.d.ts
@@ -24,3 +24,8 @@ interface ImportMetaEnv extends EnvironmentVariables {}
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+declare module 'virtual:marketing/search-index' {
+  /** Returns the serialized MiniSearch index JSON for the docs search. */
+  export function getSearchIndex(): Promise<string>
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "cva": "1.0.0-beta.4",
     "hono": "^4.12.26",
     "mermaid": "^11.14.0",
+    "minisearch": "7.2.0",
     "monaco-editor": "^0.55.1",
     "ox": "0.14.20",
     "posthog-js": "^1.367.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
+      minisearch:
+        specifier: 7.2.0
+        version: 7.2.0
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1

--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useConfig } from 'vocs'
+import { DOCS_SEARCH_PARAM } from '../lib/docs-search'
 import { AmpLogo, ClaudeLogo, CodexLogo } from './AgentLogos'
 
 type MegaLink = {
@@ -339,6 +340,7 @@ const menu: MenuItem[] = [
   { label: 'Build', href: '/#protocol', mega: protocolMenu },
   { label: 'Resources', href: `${DOCS_BASE_PATH}/guide`, mega: developersMenu },
   { label: 'Performance', href: '/performance' },
+  { label: 'Blog', href: '/blog' },
   { label: 'Docs', href: DOCS_BASE_PATH },
 ]
 
@@ -457,8 +459,12 @@ function SearchIcon({ className }: { className?: string }) {
 // importing that internal, unexported component, we re-expose the affordance by
 // dispatching the same shortcut Vocs already handles. See src/pages/_root.css
 // where the gutter is hidden, and node_modules/vocs Search.tsx for the listener.
-function openDocsSearch() {
-  if (typeof document === 'undefined') return
+//
+// Returns true when Vocs handled the shortcut (it calls `preventDefault`, so
+// `dispatchEvent` returns false). The shortcut *toggles* the dialog, so callers
+// must only dispatch once per intended open.
+function dispatchDocsSearchShortcut() {
+  if (typeof document === 'undefined') return false
   const event = new KeyboardEvent('keydown', {
     key: 'k',
     code: 'KeyK',
@@ -468,12 +474,30 @@ function openDocsSearch() {
     metaKey: true,
     ctrlKey: true,
   })
-  const handled = !document.dispatchEvent(event)
-  if (!handled && import.meta.env.DEV) {
+  return !document.dispatchEvent(event)
+}
+
+function openDocsSearch() {
+  if (!dispatchDocsSearchShortcut() && import.meta.env.DEV) {
     console.warn(
       'Vocs search did not handle Cmd/Ctrl+K. Verify the hidden Vocs top-nav search is still mounted (showTopNav/showSearch).',
     )
   }
+}
+
+// Used when arriving from the marketing site via `?search` (see lib/docs-search):
+// the Vocs Search instance may not have attached its keydown listener yet on the
+// first paint, so retry across a few frames until the dialog opens. We stop on
+// the first success to avoid the toggle re-closing it.
+function openDocsSearchWhenReady(attempt = 0) {
+  if (dispatchDocsSearchShortcut()) return
+  if (attempt >= 30) {
+    if (import.meta.env.DEV) {
+      console.warn('Vocs search did not open after navigation; the search instance never mounted.')
+    }
+    return
+  }
+  requestAnimationFrame(() => openDocsSearchWhenReady(attempt + 1))
 }
 
 function CloseIcon() {
@@ -1033,12 +1057,29 @@ export default function DocsHeader() {
     warmMarketingApp()
   }, [])
 
+  // Open the search dialog when arriving from the marketing site's search CTA
+  // (which navigates to `/docs?search=1`). Strip the param so refresh/back
+  // doesn't reopen it.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    if (!params.has(DOCS_SEARCH_PARAM)) return
+    params.delete(DOCS_SEARCH_PARAM)
+    const query = params.toString()
+    window.history.replaceState(
+      {},
+      '',
+      `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`,
+    )
+    openDocsSearchWhenReady()
+  }, [])
+
   return (
     <header className="docs-site-header fixed top-0 right-0 left-0 z-[60] bg-background">
       <div className="w-full border-line border-x bg-surface-shell">
         <nav
           ref={headerRef}
-          className="flex items-center justify-between border-line border-b px-5 py-4"
+          className="relative flex items-center justify-between border-line border-b px-5 py-4"
         >
           <a
             href="/"
@@ -1051,7 +1092,7 @@ export default function DocsHeader() {
             <TempoLogo className="h-[18px] w-[80px]" />
           </a>
 
-          <ul className="hidden items-center gap-16 lg:flex">
+          <ul className="hidden items-center gap-16 lg:absolute lg:top-1/2 lg:left-1/2 lg:flex lg:-translate-x-1/2 lg:-translate-y-1/2">
             {menu.map((item) => {
               const active = isActiveMenuItem(pathname, item)
               const triggerContent = (

--- a/src/lib/docs-search.ts
+++ b/src/lib/docs-search.ts
@@ -1,0 +1,12 @@
+// Shared contract between the marketing SPA and the Vocs docs app for opening
+// the documentation search dialog.
+//
+// The marketing site (homepage etc.) has no Vocs runtime, so it can't open the
+// search dialog itself. Instead it navigates to the docs with this query param,
+// and `DocsHeader` detects it on mount and opens the (Vocs-owned) search dialog.
+export const DOCS_SEARCH_PARAM = 'search'
+
+/** URL that opens the docs search dialog on arrival (handled by DocsHeader). */
+export function docsSearchUrl(): string {
+  return `/docs?${DOCS_SEARCH_PARAM}=1`
+}

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -5,8 +5,9 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { type ReactNode, useLayoutEffect, useRef, useState } from 'react'
+import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { AmpLogo, ClaudeLogo, CodexLogo } from '../../../components/AgentLogos'
+import { docsSearchUrl } from '../../../lib/docs-search'
 import { featurePath } from '../_lib/featurePaths'
 import { TEMPO_SDK_DOCS_URL } from '../_lib/links'
 import ArrowUpRight from './ArrowUpRight'
@@ -171,6 +172,34 @@ function MenuIcon() {
       <path d="M3 7h14M3 13h14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
     </svg>
   )
+}
+
+function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={`shrink-0 ${className ?? ''}`}
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  )
+}
+
+// The marketing SPA has no Vocs search runtime, so its search affordance just
+// navigates to the docs, which open the search dialog on arrival (see
+// lib/docs-search and DocsHeader).
+function goToDocsSearch() {
+  if (typeof window === 'undefined') return
+  window.location.assign(docsSearchUrl())
 }
 
 function CloseIcon() {
@@ -603,6 +632,19 @@ export default function Header() {
     }
   }, [open])
 
+  // Cmd/Ctrl+K opens search from anywhere on the marketing site (parity with
+  // the docs). There's no in-page search here, so navigate to the docs search.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        goToDocsSearch()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [])
+
   const dropdowns: { key: string; panel: ReactNode }[] = [
     ...menu.flatMap((item) =>
       item.mega ? [{ key: item.label, panel: <MegaMenu data={item.mega} /> }] : [],
@@ -617,7 +659,7 @@ export default function Header() {
 
   return (
     <header ref={headerRef} className="relative z-20 border-line border-b">
-      <nav ref={navRef} className="flex items-center justify-between px-5 py-4">
+      <nav ref={navRef} className="relative flex items-center justify-between px-5 py-4">
         <Link
           href="/"
           onClick={close}
@@ -628,7 +670,7 @@ export default function Header() {
         </Link>
 
         {/* Desktop nav */}
-        <ul className="hidden items-center gap-16 lg:flex">
+        <ul className="hidden items-center gap-16 lg:absolute lg:top-1/2 lg:left-1/2 lg:flex lg:-translate-x-1/2 lg:-translate-y-1/2">
           {menu.map((item) => {
             const external = isExternal(item.href)
             const active = isActiveMenuItem(pathname, item)
@@ -700,6 +742,18 @@ export default function Header() {
         </ul>
 
         <div className="hidden items-center gap-3 lg:flex">
+          <a
+            href={docsSearchUrl()}
+            aria-label="Search documentation"
+            aria-keyshortcuts="Meta+K Control+K"
+            className="flex h-9 items-center gap-2 rounded-[4px] border border-line px-4 font-sans text-[14px] text-foreground/60 tracking-[0] transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
+          >
+            <SearchIcon />
+            Search
+            <kbd className="ml-1 rounded-[3px] border border-line px-1.5 py-0.5 font-sans text-[11px] text-foreground/45">
+              ⌘K
+            </kbd>
+          </a>
           <button
             ref={(el) => {
               if (el) triggerRefs.current.set('For agents', el)
@@ -737,16 +791,26 @@ export default function Header() {
           </button>
         </div>
 
-        {/* Mobile toggle */}
-        <button
-          type="button"
-          onClick={() => setOpen((o) => !o)}
-          aria-label={open ? 'Close menu' : 'Open menu'}
-          aria-expanded={open}
-          className="grid size-8 place-items-center text-foreground lg:hidden"
-        >
-          {open ? <CloseIcon /> : <MenuIcon />}
-        </button>
+        {/* Mobile actions */}
+        <div className="flex items-center gap-1 lg:hidden">
+          <a
+            href={docsSearchUrl()}
+            aria-label="Search documentation"
+            aria-keyshortcuts="Meta+K Control+K"
+            className="grid size-8 place-items-center text-foreground"
+          >
+            <SearchIcon className="size-[18px]" />
+          </a>
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            aria-label={open ? 'Close menu' : 'Open menu'}
+            aria-expanded={open}
+            className="grid size-8 place-items-center text-foreground"
+          >
+            {open ? <CloseIcon /> : <MenuIcon />}
+          </button>
+        </div>
       </nav>
 
       {/* Desktop dropdowns: one shared surface that slides & resizes between

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -746,13 +746,10 @@ export default function Header() {
             href={docsSearchUrl()}
             aria-label="Search documentation"
             aria-keyshortcuts="Meta+K Control+K"
-            className="flex h-9 items-center gap-2 rounded-[4px] border border-line px-4 font-sans text-[14px] text-foreground/60 tracking-[0] transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
+            title="Search documentation (⌘K)"
+            className="grid size-9 place-items-center rounded-[4px] border border-line text-foreground/60 transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
           >
             <SearchIcon />
-            Search
-            <kbd className="ml-1 rounded-[3px] border border-line px-1.5 py-0.5 font-sans text-[11px] text-foreground/45">
-              ⌘K
-            </kbd>
           </a>
           <button
             ref={(el) => {

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { AmpLogo, ClaudeLogo, CodexLogo } from '../../../components/AgentLogos'
-import { docsSearchUrl } from '../../../lib/docs-search'
 import { featurePath } from '../_lib/featurePaths'
 import { TEMPO_SDK_DOCS_URL } from '../_lib/links'
 import ArrowUpRight from './ArrowUpRight'
@@ -22,6 +21,7 @@ import {
   TransactionsIcon,
   WalletIcon,
 } from './menuIcons'
+import SearchDialog from './SearchDialog'
 import TempoLogo from './TempoLogo'
 
 const protocolMenu: MegaMenuData = {
@@ -192,14 +192,6 @@ function SearchIcon({ className }: { className?: string }) {
       <path d="m21 21-4.3-4.3" />
     </svg>
   )
-}
-
-// The marketing SPA has no Vocs search runtime, so its search affordance just
-// navigates to the docs, which open the search dialog on arrival (see
-// lib/docs-search and DocsHeader).
-function goToDocsSearch() {
-  if (typeof window === 'undefined') return
-  window.location.assign(docsSearchUrl())
 }
 
 function CloseIcon() {
@@ -556,6 +548,7 @@ function AgentsPanel({
 export default function Header() {
   const pathname = usePathname()
   const [open, setOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
   const [expanded, setExpanded] = useState<string | null>(null)
   // The mobile menu is a fixed overlay anchored just below the nav bar, so we
   // track the bar's height to offset it (and keep it correct across resizes).
@@ -632,13 +625,13 @@ export default function Header() {
     }
   }, [open])
 
-  // Cmd/Ctrl+K opens search from anywhere on the marketing site (parity with
-  // the docs). There's no in-page search here, so navigate to the docs search.
+  // Cmd/Ctrl+K toggles the in-page search dialog from anywhere on the marketing
+  // site (parity with the docs).
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
         event.preventDefault()
-        goToDocsSearch()
+        setSearchOpen((s) => !s)
       }
     }
     document.addEventListener('keydown', onKeyDown)
@@ -742,15 +735,16 @@ export default function Header() {
         </ul>
 
         <div className="hidden items-center gap-3 lg:flex">
-          <a
-            href={docsSearchUrl()}
+          <button
+            type="button"
+            onClick={() => setSearchOpen(true)}
             aria-label="Search documentation"
             aria-keyshortcuts="Meta+K Control+K"
             title="Search documentation (⌘K)"
             className="grid size-9 place-items-center rounded-[4px] border border-line text-foreground/60 transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
           >
             <SearchIcon />
-          </a>
+          </button>
           <button
             ref={(el) => {
               if (el) triggerRefs.current.set('For agents', el)
@@ -790,14 +784,18 @@ export default function Header() {
 
         {/* Mobile actions */}
         <div className="flex items-center gap-1 lg:hidden">
-          <a
-            href={docsSearchUrl()}
+          <button
+            type="button"
+            onClick={() => {
+              close()
+              setSearchOpen(true)
+            }}
             aria-label="Search documentation"
             aria-keyshortcuts="Meta+K Control+K"
             className="grid size-8 place-items-center text-foreground"
           >
             <SearchIcon className="size-[18px]" />
-          </a>
+          </button>
           <button
             type="button"
             onClick={() => setOpen((o) => !o)}
@@ -963,6 +961,8 @@ export default function Header() {
           </div>
         </div>
       </div>
+
+      <SearchDialog open={searchOpen} onClose={() => setSearchOpen(false)} />
     </header>
   )
 }

--- a/src/marketing/app/_components/SearchDialog.tsx
+++ b/src/marketing/app/_components/SearchDialog.tsx
@@ -1,0 +1,294 @@
+// biome-ignore-all lint/a11y/noSvgWithoutTitle: Dialog SVGs are decorative; controls carry their own labels.
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { loadSearchIndex, type SearchResult, searchDocs } from '../../search'
+
+function SearchIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className="shrink-0"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  )
+}
+
+function PageIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className="mt-0.5 shrink-0 text-foreground/40"
+    >
+      <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+      <path d="M5 3h9l5 5v11a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z" />
+    </svg>
+  )
+}
+
+function HashIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className="mt-0.5 shrink-0 text-foreground/40"
+    >
+      <path d="M4 9h16M4 15h16M10 3 8 21M16 3l-2 18" />
+    </svg>
+  )
+}
+
+function breadcrumbFor(result: SearchResult): string | null {
+  return [result.category, ...(result.titles ?? [])].filter(Boolean).join(' › ') || null
+}
+
+function ResultRow({
+  result,
+  selected,
+  onSelect,
+  onHover,
+}: {
+  result: SearchResult
+  selected: boolean
+  onSelect: () => void
+  onHover: () => void
+}) {
+  const breadcrumb = breadcrumbFor(result)
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: rows are pointer affordances; Enter is handled on the dialog input.
+    <div
+      role="option"
+      tabIndex={-1}
+      aria-selected={selected}
+      data-selected={selected}
+      onMouseMove={onHover}
+      onClick={onSelect}
+      className={`group flex cursor-pointer items-start gap-3 px-4 py-2.5 transition-colors ${
+        selected ? 'bg-foreground/[0.06]' : ''
+      }`}
+    >
+      {result.type === 'page' ? <PageIcon /> : <HashIcon />}
+      <span className="flex min-w-0 flex-col gap-0.5">
+        {breadcrumb ? (
+          <span className="truncate font-sans text-[12px] text-foreground/45 tracking-[0]">
+            {breadcrumb}
+          </span>
+        ) : null}
+        <span className="truncate font-sans text-[14px] text-foreground tracking-[0]">
+          {result.title}
+        </span>
+        {result.text ? (
+          <span className="line-clamp-2 font-sans text-[13px] text-foreground/45 leading-[1.4] tracking-[0]">
+            {result.text}
+          </span>
+        ) : null}
+      </span>
+    </div>
+  )
+}
+
+export default function SearchDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [loadError, setLoadError] = useState(false)
+  const indexRef = useRef<Awaited<ReturnType<typeof loadSearchIndex>> | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // Load the index the first time the dialog opens.
+  useEffect(() => {
+    if (!open || indexRef.current) return
+    let cancelled = false
+    loadSearchIndex()
+      .then((index) => {
+        if (cancelled) return
+        indexRef.current = index
+        // Re-run the current query against the freshly loaded index.
+        setQuery((q) => {
+          setResults(q.trim() ? searchDocs(index, q) : [])
+          return q
+        })
+      })
+      .catch(() => {
+        if (!cancelled) setLoadError(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  // Reset transient state whenever the dialog closes.
+  useEffect(() => {
+    if (open) return
+    setQuery('')
+    setResults([])
+    setSelectedIndex(0)
+  }, [open])
+
+  // Focus the input and lock background scroll while open.
+  useEffect(() => {
+    if (!open) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const id = requestAnimationFrame(() => inputRef.current?.focus())
+    return () => {
+      document.body.style.overflow = prevOverflow
+      cancelAnimationFrame(id)
+    }
+  }, [open])
+
+  const runQuery = useCallback((value: string) => {
+    setQuery(value)
+    setSelectedIndex(0)
+    const index = indexRef.current
+    setResults(index && value.trim() ? searchDocs(index, value) : [])
+  }, [])
+
+  const go = useCallback(
+    (result: SearchResult | undefined) => {
+      if (!result) return
+      onClose()
+      window.location.assign(result.href)
+    },
+    [onClose],
+  )
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault()
+          setSelectedIndex((i) => (i < results.length - 1 ? i + 1 : i))
+          break
+        case 'ArrowUp':
+          event.preventDefault()
+          setSelectedIndex((i) => (i > 0 ? i - 1 : i))
+          break
+        case 'Enter':
+          event.preventDefault()
+          go(results[selectedIndex])
+          break
+        case 'Escape':
+          event.preventDefault()
+          onClose()
+          break
+      }
+    },
+    [results, selectedIndex, go, onClose],
+  )
+
+  // Keep the highlighted row in view during keyboard navigation.
+  useEffect(() => {
+    listRef.current?.children[selectedIndex]?.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
+
+  const body = useMemo(() => {
+    if (loadError) {
+      return (
+        <div className="px-4 py-10 text-center font-sans text-[14px] text-foreground/45">
+          Couldn’t load search. Please try again.
+        </div>
+      )
+    }
+    if (!query.trim()) {
+      return (
+        <div className="px-4 py-10 text-center font-sans text-[14px] text-foreground/45">
+          Start typing to search the docs…
+        </div>
+      )
+    }
+    if (results.length === 0) {
+      return (
+        <div className="px-4 py-10 text-center font-sans text-[14px] text-foreground/45">
+          No results found
+        </div>
+      )
+    }
+    return (
+      <div ref={listRef} role="listbox" aria-label="Search results" className="py-2">
+        {results.map((result, i) => (
+          <ResultRow
+            key={result.id}
+            result={result}
+            selected={i === selectedIndex}
+            onSelect={() => go(result)}
+            onHover={() => setSelectedIndex(i)}
+          />
+        ))}
+      </div>
+    )
+  }, [loadError, query, results, selectedIndex, go])
+
+  if (!open || typeof document === 'undefined') return null
+
+  return createPortal(
+    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-close is a standard modal affordance.
+    // biome-ignore lint/a11y/useKeyWithClickEvents: Escape is handled on the input/dialog.
+    <div
+      className="fixed inset-0 z-[200] flex items-start justify-center bg-black/60 px-4 pt-[12vh] backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search documentation"
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleKeyDown}
+        className="flex max-h-[70vh] w-full max-w-[600px] flex-col overflow-hidden rounded-md border border-line bg-surface-page shadow-2xl"
+      >
+        <div className="flex items-center gap-3 border-line border-b px-4 py-3 text-foreground/60">
+          <SearchIcon />
+          <input
+            ref={inputRef}
+            type="text"
+            role="combobox"
+            aria-expanded={results.length > 0}
+            aria-controls="marketing-search-results"
+            aria-autocomplete="list"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="Search documentation…"
+            value={query}
+            onChange={(event) => runQuery(event.target.value)}
+            className="flex-1 bg-transparent font-sans text-[15px] text-foreground tracking-[0] outline-none placeholder:text-foreground/40"
+          />
+          <kbd className="rounded border border-line px-1.5 py-0.5 font-sans text-[11px] text-foreground/40">
+            Esc
+          </kbd>
+        </div>
+        <div id="marketing-search-results" className="flex-1 overflow-y-auto">
+          {body}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/marketing/blogPlugin.ts
+++ b/src/marketing/blogPlugin.ts
@@ -40,11 +40,21 @@ export type RenderedPost = {
 // Markdown → HTML with Shiki syntax highlighting. Vesper is the closest
 // built-in theme to the site's muted dark palette; the pre background is
 // overridden to the surface token in CSS.
+// `@shikijs/rehype` uses a process-wide singleton highlighter whose `langAlias`
+// is fixed by the *first* caller. Vocs registers `sol -> solidity` for the docs;
+// if this blog processor initializes the singleton first (e.g. the homepage
+// renders the blog before docs), it must register the same alias and a fallback,
+// otherwise docs pages with ```sol fences crash with "Language `sol` is not
+// included in this bundle".
 const processor = unified()
   .use(remarkParse)
   .use(remarkGfm)
   .use(remarkRehype)
-  .use(rehypeShiki, { theme: 'vesper' })
+  .use(rehypeShiki, {
+    theme: 'vesper',
+    langAlias: { sol: 'solidity' },
+    fallbackLanguage: 'plaintext',
+  })
   .use(rehypeStringify)
 
 // Minimal frontmatter parser for our simple schema (quoted strings, an

--- a/src/marketing/next.d.ts
+++ b/src/marketing/next.d.ts
@@ -14,6 +14,11 @@ declare module 'virtual:blog-posts' {
   }[]
 }
 
+declare module 'virtual:marketing/search-index' {
+  /** Returns the serialized MiniSearch index JSON for the docs search. */
+  export function getSearchIndex(): Promise<string>
+}
+
 declare module 'next/link' {
   export { default } from './next-shims'
 }

--- a/src/marketing/search.ts
+++ b/src/marketing/search.ts
@@ -1,0 +1,102 @@
+import { getSearchIndex } from 'virtual:marketing/search-index'
+import MiniSearch, { type Options, type SearchOptions } from 'minisearch'
+
+// The fields, store fields and tokenizer below mirror Vocs' internal search
+// config (vocs/dist/internal/search.client.js) so the index that Vocs builds is
+// queried here exactly as it is inside the docs app. Vocs doesn't export these,
+// so they're duplicated and must be kept in sync.
+const searchFields = ['category', 'subtitle', 'text', 'title', 'titles']
+const storeFields = [
+  'category',
+  'href',
+  'searchPriority',
+  'subtitle',
+  'text',
+  'title',
+  'titles',
+  'type',
+]
+
+export type SearchResult = {
+  id: string
+  href: string
+  title: string
+  titles: string[]
+  text: string
+  category?: string
+  type: 'page' | 'section' | 'nav'
+  searchPriority?: number
+  terms?: string[]
+}
+
+/**
+ * Splits on whitespace, punctuation and camelCase/PascalCase, keeping both the
+ * original and the sub-tokens. Copied verbatim from Vocs' tokenizer so query
+ * tokenization matches how the index was built.
+ *
+ * "createUser" → ["createuser", "create", "user"]
+ */
+function tokenize(text: string): string[] {
+  const tokens: string[] = []
+  for (const word of text.split(/[\s\-._/:@]+/)) {
+    if (!word) continue
+    tokens.push(word.toLowerCase())
+    const split = word
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+      .split(/\s+/)
+      .map((w) => w.toLowerCase())
+      .filter((w) => w.length > 0)
+    if (split.length > 1) tokens.push(...split)
+  }
+  return tokens.filter((w) => w.length > 0)
+}
+
+// Mirrors Vocs' resolved default `search` options (vocs/dist/internal/config.js)
+// so ranking matches the docs search dialog.
+const searchOptions: SearchOptions = {
+  combineWith: 'AND',
+  fuzzy: 0.2,
+  prefix: true,
+  boost: { title: 4, subtitle: 3, text: 2, category: 1, titles: 1 },
+  boostDocument: (_id, _term, storedFields) => {
+    const priority = (storedFields?.searchPriority as number | undefined) ?? 1
+    const href = storedFields?.href as string | undefined
+    const isDocsPath = href?.startsWith('/docs/') ?? false
+    // Treat /docs/ as root for depth calculation (subtract 1).
+    const segments = href ? href.split('/').filter(Boolean).length : 1
+    const depth = isDocsPath ? Math.max(segments - 1, 1) : segments
+    const depthBoost = 1 / Math.max(depth, 1)
+    const docsBoost = isDocsPath ? 1.5 : 1
+    return priority * depthBoost * docsBoost
+  },
+}
+
+const loadOptions: Options<SearchResult> = {
+  fields: searchFields,
+  storeFields,
+  tokenize,
+}
+
+let indexPromise: Promise<MiniSearch<SearchResult>> | null = null
+
+/** Loads (and caches) the MiniSearch index that Vocs built. */
+export function loadSearchIndex(): Promise<MiniSearch<SearchResult>> {
+  if (!indexPromise) {
+    indexPromise = getSearchIndex()
+      .then((json) => MiniSearch.loadJSON<SearchResult>(json, loadOptions))
+      .catch((error) => {
+        // Reset so a later open can retry rather than caching the failure.
+        indexPromise = null
+        throw error
+      })
+  }
+  return indexPromise
+}
+
+export function searchDocs(index: MiniSearch<SearchResult>, query: string): SearchResult[] {
+  if (!query.trim()) return []
+  return index
+    .search(query, { ...searchOptions, tokenize })
+    .slice(0, 20) as unknown as SearchResult[]
+}

--- a/src/marketing/searchIndexPlugin.ts
+++ b/src/marketing/searchIndexPlugin.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import type { Plugin, ResolvedConfig } from 'vite'
+
+// Exposes the Vocs-built search index to the marketing SPA via a single virtual
+// module that works in both environments:
+//
+// - Dev: the marketing pages are served by the main `vite.config.ts` dev server,
+//   which includes the `vocs()` plugin, so we re-export Vocs' own
+//   `virtual:vocs/search-index`.
+// - Build: the marketing build (`vite.marketing.config.ts`) has no `vocs()`
+//   plugin, but the Vocs build runs first and emits
+//   `dist/public/assets/search-index-<hash>.json`. We locate that file and emit
+//   a fetch-based loader. The scan happens lazily in `load()` so it never runs
+//   during the Vocs build (where the index doesn't exist yet).
+
+const VIRTUAL_ID = 'virtual:marketing/search-index'
+const RESOLVED_VIRTUAL_ID = `\0${VIRTUAL_ID}`
+const INDEX_FILE_RE = /^search-index-[a-f0-9]{12}\.json$/
+
+export function marketingSearchIndexPlugin(): Plugin {
+  let config: ResolvedConfig
+
+  return {
+    name: 'tempo-marketing-search-index',
+    enforce: 'pre',
+    configResolved(resolved) {
+      config = resolved
+    },
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_VIRTUAL_ID
+    },
+    async load(id) {
+      if (id !== RESOLVED_VIRTUAL_ID) return
+
+      // Dev: delegate to Vocs' virtual module (only resolvable when the vocs
+      // plugin is present, which it is on the shared dev server).
+      if (config.command === 'serve') {
+        return `export { getSearchIndex } from 'virtual:vocs/search-index'`
+      }
+
+      // Build: find the hashed index emitted by the prior Vocs build.
+      const assetsDir = path.resolve(config.root, config.build.outDir, 'assets')
+      const files = await fs.readdir(assetsDir).catch(() => [] as string[])
+      const candidates = await Promise.all(
+        files
+          .filter((name) => INDEX_FILE_RE.test(name))
+          .map(async (name) => ({
+            name,
+            mtimeMs: (await fs.stat(path.join(assetsDir, name))).mtimeMs,
+          })),
+      )
+
+      if (candidates.length === 0) {
+        throw new Error(
+          `[search] No search-index-*.json found in ${assetsDir}. ` +
+            `The Vocs build must run before the marketing build.`,
+        )
+      }
+
+      candidates.sort((a, b) => b.mtimeMs - a.mtimeMs)
+      if (candidates.length > 1) {
+        this.warn(`[search] Multiple search indexes found; using newest: ${candidates[0].name}`)
+      }
+
+      const href = `/assets/${candidates[0].name}`
+      return `export async function getSearchIndex() {
+  const response = await fetch(${JSON.stringify(href)})
+  if (!response.ok) throw new Error('Failed to fetch search index: ' + response.status)
+  return response.text()
+}`
+    },
+  }
+}

--- a/src/marketing/searchIndexPlugin.ts
+++ b/src/marketing/searchIndexPlugin.ts
@@ -3,22 +3,33 @@ import path from 'node:path'
 import type { Plugin, ResolvedConfig } from 'vite'
 
 // Exposes the Vocs-built search index to the marketing SPA via a single virtual
-// module that works in both environments:
+// module (`virtual:marketing/search-index`) that resolves differently depending
+// on which build it's part of:
 //
-// - Dev: the marketing pages are served by the main `vite.config.ts` dev server,
-//   which includes the `vocs()` plugin, so we re-export Vocs' own
-//   `virtual:vocs/search-index`.
-// - Build: the marketing build (`vite.marketing.config.ts`) has no `vocs()`
-//   plugin, but the Vocs build runs first and emits
+// - `source: 'vocs'` (vite.config.ts — the docs build and the shared dev
+//   server): the `vocs()` plugin is present, so we just re-export Vocs' own
+//   `virtual:vocs/search-index`. This covers dev, where the marketing pages are
+//   served by this same config.
+// - `source: 'dist'` (vite.marketing.config.ts — the standalone marketing
+//   build): there's no `vocs()` plugin, but the docs build runs first and emits
 //   `dist/public/assets/search-index-<hash>.json`. We locate that file and emit
 //   a fetch-based loader. The scan happens lazily in `load()` so it never runs
-//   during the Vocs build (where the index doesn't exist yet).
+//   at config time.
 
 const VIRTUAL_ID = 'virtual:marketing/search-index'
 const RESOLVED_VIRTUAL_ID = `\0${VIRTUAL_ID}`
 const INDEX_FILE_RE = /^search-index-[a-f0-9]{12}\.json$/
 
-export function marketingSearchIndexPlugin(): Plugin {
+type Options = {
+  /**
+   * Where the index comes from. `'vocs'` re-exports Vocs' virtual module (docs
+   * build + dev); `'dist'` reads the hashed JSON emitted by the docs build
+   * (standalone marketing build).
+   */
+  source: 'vocs' | 'dist'
+}
+
+export function marketingSearchIndexPlugin({ source }: Options): Plugin {
   let config: ResolvedConfig
 
   return {
@@ -33,13 +44,12 @@ export function marketingSearchIndexPlugin(): Plugin {
     async load(id) {
       if (id !== RESOLVED_VIRTUAL_ID) return
 
-      // Dev: delegate to Vocs' virtual module (only resolvable when the vocs
-      // plugin is present, which it is on the shared dev server).
-      if (config.command === 'serve') {
+      // Docs build + dev: Vocs owns the index, so delegate to its virtual module.
+      if (source === 'vocs') {
         return `export { getSearchIndex } from 'virtual:vocs/search-index'`
       }
 
-      // Build: find the hashed index emitted by the prior Vocs build.
+      // Marketing build: find the hashed index emitted by the prior docs build.
       const assetsDir = path.resolve(config.root, config.build.outDir, 'assets')
       const files = await fs.readdir(assetsDir).catch(() => [] as string[])
       const candidates = await Promise.all(
@@ -54,7 +64,7 @@ export function marketingSearchIndexPlugin(): Plugin {
       if (candidates.length === 0) {
         throw new Error(
           `[search] No search-index-*.json found in ${assetsDir}. ` +
-            `The Vocs build must run before the marketing build.`,
+            `The docs build must run before the marketing build.`,
         )
       }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import { defineConfig, loadEnv, type Plugin, type ResolvedConfig } from 'vite'
 import mkcert from 'vite-plugin-mkcert'
 import { vocs } from 'vocs/vite'
 import { blogPostsPlugin } from './src/marketing/blogPlugin'
+import { marketingSearchIndexPlugin } from './src/marketing/searchIndexPlugin'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
@@ -28,6 +29,7 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       blogPostsPlugin(),
+      marketingSearchIndexPlugin(),
       marketingPages(),
       vocs(),
       Icons({ compiler: 'jsx', jsx: 'react' }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       blogPostsPlugin(),
-      marketingSearchIndexPlugin(),
+      marketingSearchIndexPlugin({ source: 'vocs' }),
       marketingPages(),
       vocs(),
       Icons({ compiler: 'jsx', jsx: 'react' }),

--- a/vite.marketing.config.ts
+++ b/vite.marketing.config.ts
@@ -6,6 +6,7 @@ import Icons from 'unplugin-icons/vite'
 import { defineConfig, type Plugin } from 'vite'
 import { type CategorySlug, categoryBySlug } from './src/marketing/app/blog/_lib/categories'
 import { blogPostsPlugin, loadRenderedPosts } from './src/marketing/blogPlugin'
+import { marketingSearchIndexPlugin } from './src/marketing/searchIndexPlugin'
 import {
   absoluteUrl,
   blogPostJsonLd,
@@ -227,6 +228,7 @@ export default defineConfig({
   publicDir: path.resolve(process.cwd(), 'public'),
   plugins: [
     blogPostsPlugin(),
+    marketingSearchIndexPlugin(),
     tailwindcss(),
     Icons({ compiler: 'jsx', jsx: 'react' }),
     react(),

--- a/vite.marketing.config.ts
+++ b/vite.marketing.config.ts
@@ -228,7 +228,7 @@ export default defineConfig({
   publicDir: path.resolve(process.cwd(), 'public'),
   plugins: [
     blogPostsPlugin(),
-    marketingSearchIndexPlugin(),
+    marketingSearchIndexPlugin({ source: 'dist' }),
     tailwindcss(),
     Icons({ compiler: 'jsx', jsx: 'react' }),
     react(),


### PR DESCRIPTION
## What

Extends the documentation search affordance to the marketing site (homepage + all marketing pages) and fixes a pre-existing dev-server crash that broke docs rendering.

## Changes

### Search on the marketing site
- **Desktop:** a `Search ⌘K` button in the marketing header.
- **Mobile:** a search icon next to the hamburger.
- **Keyboard:** a global Cmd/Ctrl+K listener anywhere on the marketing site.

The marketing SPA has no Vocs search runtime, so the affordance navigates to `/docs?search=1`. `DocsHeader` detects the param on mount, opens the Vocs search dialog, and strips the param (so refresh/back doesn't reopen it). The cross-app contract lives in the new `src/lib/docs-search.ts`.

### Docs header
- Added the missing **Blog** menu item (parity with the marketing header).

### Layout
- Absolutely-centered the nav menu in both headers, so the added search button no longer shifts it off-center.

### Shiki `sol` crash fix (the real cause of "search from homepage breaks")
`@shikijs/rehype` uses a **process-wide singleton highlighter** whose `langAlias` is fixed by the **first caller**. The blog plugin initialized it with **no** `langAlias`, so once the homepage rendered the blog, any docs page containing a ` ```sol ` fence crashed with:

> Error [ShikiError]: Language `sol` is not included in this bundle.

This returned 500 / killed the dev server on any full-page load of a docs page after visiting the homepage — which is why search "broke" when triggered from the homepage (and why the dev server kept dying). The fix gives the blog processor the same `langAlias: { sol: 'solidity' }` and a `fallbackLanguage: 'plaintext'`, so it no longer poisons the shared singleton.

## Verification

Playwright, against the dev server:
- Homepage → Search CTA → `/docs` returns **200**, search dialog opens, `?search` stripped ✅
- A `sol` docs page (`/docs/protocol/tip20/spec`) renders **200** (was 500) ✅
- Cmd/Ctrl+K from the homepage opens docs search ✅
- Docs in-header search still works (regression) ✅
- Nav menu is horizontally centered (0px delta at 1440px) ✅

`pnpm run check:types` and `biome check` both pass.

## Notes
- Scoped to 4 files; no Vocs internals imported.
- The Shiki fix also hardens the blog pipeline against unknown code-fence languages via the plaintext fallback.
