### PR TITLE
fix: make blog light mode legible (text + diagrams)

### DIFF
--- a/blogs/DIAGRAMS.md
+++ b/blogs/DIAGRAMS.md
@@ -17,11 +17,34 @@ document wins.
 
 ## Rules in one paragraph
 
-Dark `#0e0e0e` canvas, 840px wide. All text is monospace, labels are
-UPPERCASE. Boxes are sharp-cornered rectangles with 1px strokes. Everything is
-greyscale except **one** accent color, used only on the element the diagram is
-about. No gradients, no shadows, no rounded corners, no icons, no second
-accent.
+Theme-aware canvas, 840px wide. All text is monospace, labels are UPPERCASE.
+Boxes are sharp-cornered rectangles with 1px strokes. Everything is greyscale
+except **one** accent color, used only on the element the diagram is about. No
+gradients, no shadows, no rounded corners, no icons, no second accent.
+
+## Theme-aware colors (important)
+
+Diagrams are **inlined into the page HTML at build time** (see
+`src/marketing/blogPlugin.ts`), so they follow the site's light/dark theme.
+**Do not hardcode hex colors.** Instead:
+
+- Use the `class="..."` hooks below for shapes — they map to theme tokens in
+  `src/pages/_root.css` (the `.blog-prose svg.blog-diagram .dgm-*` rules).
+- Use `fill="currentColor"` + `fill-opacity="..."` for all text. `currentColor`
+  resolves to the theme foreground (light text on dark, dark text on light).
+
+| Hook | Element | Maps to |
+| --- | --- | --- |
+| `class="dgm-bg"` | full-bleed background `<rect>` | `--diagram-bg` |
+| `class="dgm-box"` | neutral box `<rect>` (fill + stroke) | `--diagram-box` / `--diagram-box-border` |
+| `class="dgm-accent-box"` | the one accent box `<rect>` | `--diagram-accent-bg` / `--diagram-accent` |
+| `class="dgm-line"` | gridlines/connectors/baseline `<line>` | `--diagram-line` |
+| `class="dgm-line-soft"` | faint dividers `<line>` | `--diagram-line-soft` |
+| `class="dgm-accent-line"` | accent connector `<line>`/`<g>` | `--diagram-accent` |
+| `class="dgm-accent"` | accent text/`<g>` (fill) | `--diagram-accent` |
+
+`class` can go on a `<g>` to apply to all children (e.g. a group of accent
+text or connector lines).
 
 ## Canvas
 
@@ -29,49 +52,51 @@ accent.
 | --- | --- |
 | Width | `840` (fixed — matches the post column) |
 | Height | whatever the content needs, typically 360–420 |
-| Background | full-bleed `<rect>` of `#0e0e0e` |
+| Background | full-bleed `<rect class="dgm-bg">` |
 | Margins | 40px on all sides; content starts at `x=40` |
 | Root attrs | `fill="none" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, 'JetBrains Mono', monospace"` |
 
-The site wraps embedded images in a 1px border, so don't draw your own outer
-frame.
+The site wraps embedded diagrams in a 1px border, so don't draw your own outer
+frame. (The build adds `class="blog-diagram"` and `role="img"` to the root
+`<svg>` automatically — don't add them by hand.)
 
 ## Palette
 
-Hardcode these hex values — an SVG loaded via `<img>` can't read the site's
-CSS variables. They mirror tokens in `app/globals.css`:
+**Don't hardcode hex.** Use the class hooks (shapes) and `currentColor` (text)
+from the "Theme-aware colors" section above so the diagram works in both
+themes. The tokens resolve to these values:
 
-| Role | Value | Mirrors token |
-| --- | --- | --- |
-| Canvas background | `#0e0e0e` | `--surface-block` |
-| Neutral box fill | `#1c1c1c` | — |
-| Neutral box stroke | `#2e2e2e` | `--line-strong` |
-| Gridlines, dividers | `#181818` | `--line` |
-| Dashed annotation stroke | `#2e2e2e`, `stroke-dasharray="4 4"` | — |
-| Accent stroke/text | `#65ff54` | `--indicator-green` |
-| Accent fill | `#143810` | — |
-| Alt accent (rare) | `#5d88ff` stroke, `#10204d` fill | `--accent-blue` |
+| Role | Hook | Dark | Light |
+| --- | --- | --- | --- |
+| Canvas background | `dgm-bg` | `#0e0e0e` | `#f5f5f5` |
+| Neutral box | `dgm-box` | `#1c1c1c` / `#2e2e2e` | `#ffffff` / `#d4d4d4` |
+| Gridlines, connectors | `dgm-line` | `#2e2e2e` | `#d4d4d4` |
+| Faint dividers | `dgm-line-soft` | `#181818` | `#e5e5e5` |
+| Accent box | `dgm-accent-box` | `#143810` / `#65ff54` | `#e3f5e5` / `#168f24` |
+| Accent stroke/text | `dgm-accent` / `dgm-accent-line` | `#65ff54` | `#168f24` |
+| All text | `currentColor` + `fill-opacity` | foreground | foreground |
 
-Use green by default. Reach for blue only when a single diagram genuinely
-needs two accents (almost never).
+Use green (the default accent) only. There is no second accent.
 
 ## Typography
 
-All monospace (inherited from the root `font-family`), all caps for labels:
+All monospace (inherited from the root `font-family`), all caps for labels.
+Use `fill="currentColor"` with the opacity below; accent text uses
+`class="dgm-accent"` instead:
 
 | Role | Size | Fill |
 | --- | --- | --- |
-| Title | `13`, `letter-spacing="0.04em"` | `rgba(255,255,255,0.85)` |
-| Subtitle | `11` | `rgba(255,255,255,0.4)` |
-| Box/data labels | `11` | `rgba(255,255,255,0.6)` neutral, `#65ff54` accent |
-| Axis ticks, lane names | `10`–`11` | `rgba(255,255,255,0.3)`–`0.35` |
-| Emphasized value or axis label | `11` | `rgba(255,255,255,0.7)` |
+| Title | `13`, `letter-spacing="0.04em"` | `currentColor` `fill-opacity="0.85"` |
+| Subtitle | `11` | `currentColor` `fill-opacity="0.4"` |
+| Box/data labels | `11` | `currentColor` `fill-opacity="0.6"`, or `class="dgm-accent"` |
+| Axis ticks, lane names | `10`–`11` | `currentColor` `fill-opacity="0.3"`–`0.35` |
+| Emphasized value or axis label | `11` | `currentColor` `fill-opacity="0.7"` |
 
 Every diagram opens with a title block at the top left:
 
 ```xml
-<text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="rgba(255,255,255,0.85)">TITLE OF THE DIAGRAM</text>
-<text x="40" y="64" font-size="11" fill="rgba(255,255,255,0.4)">ONE-LINE QUALIFIER OR DATA SOURCE</text>
+<text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="currentColor" fill-opacity="0.85">TITLE OF THE DIAGRAM</text>
+<text x="40" y="64" font-size="11" fill="currentColor" fill-opacity="0.4">ONE-LINE QUALIFIER OR DATA SOURCE</text>
 ```
 
 ## Layout
@@ -79,11 +104,12 @@ Every diagram opens with a title block at the top left:
 - Center text in boxes with `text-anchor="middle"`; vertically, place text
   baseline ~5px below box center (e.g. 32px-tall box at `y=256` → text
   `y=277`).
-- Separate stacked sections with a full-width `#181818` divider line.
-- Charts: gridlines `#181818` with tick labels on the left, a `#2e2e2e`
-  baseline, values labeled above each mark.
-- Annotate empty/conceptual regions with a dashed `#2e2e2e` rect and a muted
-  centered label (see "RECLAIMED BLOCKSPACE" in the lanes diagram).
+- Separate stacked sections with a full-width `class="dgm-line-soft"` divider.
+- Charts: gridlines `class="dgm-line-soft"` with tick labels on the left, a
+  `class="dgm-line"` baseline, values labeled above each mark.
+- Annotate empty/conceptual regions with a dashed `class="dgm-line"` rect
+  (`stroke-dasharray="4 4"`) and a muted centered label (see "RECLAIMED
+  BLOCKSPACE" in the lanes diagram).
 
 ## Templates
 
@@ -91,25 +117,25 @@ Every diagram opens with a title block at the top left:
 
 ```xml
 <svg width="840" height="420" viewBox="0 0 840 420" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, 'JetBrains Mono', monospace">
-  <rect width="840" height="420" fill="#0e0e0e"/>
-  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="rgba(255,255,255,0.85)">TITLE</text>
-  <text x="40" y="64" font-size="11" fill="rgba(255,255,255,0.4)">QUALIFIER</text>
+  <rect class="dgm-bg" width="840" height="420"/>
+  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="currentColor" fill-opacity="0.85">TITLE</text>
+  <text x="40" y="64" font-size="11" fill="currentColor" fill-opacity="0.4">QUALIFIER</text>
 
-  <g stroke="#181818">
+  <g class="dgm-line-soft">
     <line x1="40" y1="120" x2="800" y2="120"/>
     <line x1="40" y1="240" x2="800" y2="240"/>
   </g>
-  <line x1="40" y1="360" x2="800" y2="360" stroke="#2e2e2e"/>
+  <line class="dgm-line" x1="40" y1="360" x2="800" y2="360"/>
 
   <!-- neutral bar -->
-  <rect x="120" y="250" width="96" height="110" fill="#1c1c1c" stroke="#2e2e2e"/>
-  <text x="168" y="238" font-size="11" fill="rgba(255,255,255,0.45)" text-anchor="middle">VALUE</text>
-  <text x="168" y="382" font-size="11" fill="rgba(255,255,255,0.4)" text-anchor="middle">LABEL</text>
+  <rect class="dgm-box" x="120" y="250" width="96" height="110"/>
+  <text x="168" y="238" font-size="11" fill="currentColor" fill-opacity="0.45" text-anchor="middle">VALUE</text>
+  <text x="168" y="382" font-size="11" fill="currentColor" fill-opacity="0.4" text-anchor="middle">LABEL</text>
 
   <!-- accent bar: the data point the diagram is about -->
-  <rect x="612" y="106" width="96" height="254" fill="#143810" stroke="#65ff54"/>
-  <text x="660" y="94" font-size="11" fill="#65ff54" text-anchor="middle">VALUE</text>
-  <text x="660" y="382" font-size="11" fill="rgba(255,255,255,0.7)" text-anchor="middle">LABEL</text>
+  <rect class="dgm-accent-box" x="612" y="106" width="96" height="254"/>
+  <text class="dgm-accent" x="660" y="94" font-size="11" text-anchor="middle">VALUE</text>
+  <text x="660" y="382" font-size="11" fill="currentColor" fill-opacity="0.7" text-anchor="middle">LABEL</text>
 </svg>
 ```
 
@@ -117,23 +143,23 @@ Every diagram opens with a title block at the top left:
 
 ```xml
 <svg width="840" height="220" viewBox="0 0 840 220" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, 'JetBrains Mono', monospace">
-  <rect width="840" height="220" fill="#0e0e0e"/>
-  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="rgba(255,255,255,0.85)">TITLE</text>
-  <text x="40" y="64" font-size="11" fill="rgba(255,255,255,0.4)">QUALIFIER</text>
+  <rect class="dgm-bg" width="840" height="220"/>
+  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="currentColor" fill-opacity="0.85">TITLE</text>
+  <text x="40" y="64" font-size="11" fill="currentColor" fill-opacity="0.4">QUALIFIER</text>
 
-  <text x="40" y="120" font-size="11" fill="rgba(255,255,255,0.35)">LANE</text>
+  <text x="40" y="120" font-size="11" fill="currentColor" fill-opacity="0.35">LANE</text>
 
   <!-- neutral box -->
-  <rect x="120" y="96" width="110" height="36" fill="#1c1c1c" stroke="#2e2e2e"/>
-  <text x="175" y="119" font-size="11" fill="rgba(255,255,255,0.6)" text-anchor="middle">item</text>
+  <rect class="dgm-box" x="120" y="96" width="110" height="36"/>
+  <text x="175" y="119" font-size="11" fill="currentColor" fill-opacity="0.6" text-anchor="middle">item</text>
 
   <!-- accent box -->
-  <rect x="246" y="96" width="110" height="36" fill="#143810" stroke="#65ff54"/>
-  <text x="301" y="119" font-size="11" fill="#65ff54" text-anchor="middle">item</text>
+  <rect class="dgm-accent-box" x="246" y="96" width="110" height="36"/>
+  <text class="dgm-accent" x="301" y="119" font-size="11" text-anchor="middle">item</text>
 
   <!-- conceptual region -->
-  <rect x="372" y="96" width="200" height="36" fill="none" stroke="#2e2e2e" stroke-dasharray="4 4"/>
-  <text x="472" y="119" font-size="11" fill="rgba(255,255,255,0.35)" text-anchor="middle">ANNOTATION</text>
+  <rect class="dgm-line" x="372" y="96" width="200" height="36" fill="none" stroke-dasharray="4 4"/>
+  <text x="472" y="119" font-size="11" fill="currentColor" fill-opacity="0.35" text-anchor="middle">ANNOTATION</text>
 </svg>
 ```
 

--- a/public/blog/account-key-roles.svg
+++ b/public/blog/account-key-roles.svg
@@ -1,32 +1,32 @@
 <svg width="840" height="300" viewBox="0 0 840 300" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, 'JetBrains Mono', monospace">
-  <rect width="840" height="300" fill="#0e0e0e"/>
+  <rect class="dgm-bg" width="840" height="300"/>
 
-  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="rgba(255,255,255,0.85)">ACCOUNT KEY ROLES</text>
-  <text x="40" y="64" font-size="11" fill="rgba(255,255,255,0.4)">T6 SEPARATES OWNERSHIP FROM KEY ADMINISTRATION</text>
+  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="currentColor" fill-opacity="0.85">ACCOUNT KEY ROLES</text>
+  <text x="40" y="64" font-size="11" fill="currentColor" fill-opacity="0.4">T6 SEPARATES OWNERSHIP FROM KEY ADMINISTRATION</text>
 
   <!-- root key -->
-  <rect x="40" y="110" width="233" height="120" fill="#1c1c1c" stroke="#2e2e2e"/>
-  <text x="156" y="150" font-size="12" fill="rgba(255,255,255,0.7)" text-anchor="middle">ROOT KEY</text>
-  <text x="156" y="180" font-size="11" fill="rgba(255,255,255,0.45)" text-anchor="middle">owns the account</text>
-  <text x="156" y="200" font-size="11" fill="rgba(255,255,255,0.45)" text-anchor="middle">stays protected</text>
+  <rect class="dgm-box" x="40" y="110" width="233" height="120"/>
+  <text x="156" y="150" font-size="12" fill="currentColor" fill-opacity="0.7" text-anchor="middle">ROOT KEY</text>
+  <text x="156" y="180" font-size="11" fill="currentColor" fill-opacity="0.45" text-anchor="middle">owns the account</text>
+  <text x="156" y="200" font-size="11" fill="currentColor" fill-opacity="0.45" text-anchor="middle">stays protected</text>
 
   <!-- admin key (the new role) -->
-  <rect x="303" y="110" width="234" height="120" fill="#143810" stroke="#65ff54"/>
-  <text x="420" y="150" font-size="12" fill="#65ff54" text-anchor="middle">ADMIN KEY</text>
-  <text x="420" y="180" font-size="11" fill="rgba(255,255,255,0.55)" text-anchor="middle">authorizes + revokes</text>
-  <text x="420" y="200" font-size="11" fill="rgba(255,255,255,0.55)" text-anchor="middle">other keys</text>
+  <rect class="dgm-accent-box" x="303" y="110" width="234" height="120"/>
+  <text class="dgm-accent" x="420" y="150" font-size="12" text-anchor="middle">ADMIN KEY</text>
+  <text x="420" y="180" font-size="11" fill="currentColor" fill-opacity="0.55" text-anchor="middle">authorizes + revokes</text>
+  <text x="420" y="200" font-size="11" fill="currentColor" fill-opacity="0.55" text-anchor="middle">other keys</text>
 
   <!-- limited key -->
-  <rect x="567" y="110" width="233" height="120" fill="#1c1c1c" stroke="#2e2e2e"/>
-  <text x="683" y="150" font-size="12" fill="rgba(255,255,255,0.7)" text-anchor="middle">LIMITED KEY</text>
-  <text x="683" y="180" font-size="11" fill="rgba(255,255,255,0.45)" text-anchor="middle">spend limits, call</text>
-  <text x="683" y="200" font-size="11" fill="rgba(255,255,255,0.45)" text-anchor="middle">scopes, expiry</text>
+  <rect class="dgm-box" x="567" y="110" width="233" height="120"/>
+  <text x="683" y="150" font-size="12" fill="currentColor" fill-opacity="0.7" text-anchor="middle">LIMITED KEY</text>
+  <text x="683" y="180" font-size="11" fill="currentColor" fill-opacity="0.45" text-anchor="middle">spend limits, call</text>
+  <text x="683" y="200" font-size="11" fill="currentColor" fill-opacity="0.45" text-anchor="middle">scopes, expiry</text>
 
   <!-- admin manages operational keys -->
-  <g stroke="#65ff54">
+  <g class="dgm-accent-line">
     <line x1="420" y1="230" x2="420" y2="252"/>
     <line x1="420" y1="252" x2="684" y2="252"/>
     <line x1="684" y1="252" x2="684" y2="230"/>
   </g>
-  <text x="552" y="247" font-size="10" fill="#65ff54" text-anchor="middle">MANAGES KEYS</text>
+  <text class="dgm-accent" x="552" y="247" font-size="10" text-anchor="middle">MANAGES KEYS</text>
 </svg>

--- a/public/blog/parallel-execution-lanes.svg
+++ b/public/blog/parallel-execution-lanes.svg
@@ -1,55 +1,55 @@
 <svg width="840" height="400" viewBox="0 0 840 400" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, 'JetBrains Mono', monospace">
-  <rect width="840" height="400" fill="#0e0e0e"/>
+  <rect class="dgm-bg" width="840" height="400"/>
 
   <!-- Serial -->
-  <text x="40" y="48" font-size="13" letter-spacing="0.04em" fill="rgba(255,255,255,0.85)">SERIAL EXECUTION</text>
-  <text x="40" y="68" font-size="11" fill="rgba(255,255,255,0.4)">ONE TRANSACTION AT A TIME, 6 BLOCKS OF WALL TIME</text>
+  <text x="40" y="48" font-size="13" letter-spacing="0.04em" fill="currentColor" fill-opacity="0.85">SERIAL EXECUTION</text>
+  <text x="40" y="68" font-size="11" fill="currentColor" fill-opacity="0.4">ONE TRANSACTION AT A TIME, 6 BLOCKS OF WALL TIME</text>
 
   <g font-size="11" text-anchor="middle">
-    <rect x="40"  y="88" width="110" height="44" fill="#1c1c1c" stroke="#2e2e2e"/>
-    <text x="95"  y="115" fill="rgba(255,255,255,0.6)">tx 1</text>
-    <rect x="166" y="88" width="110" height="44" fill="#1c1c1c" stroke="#2e2e2e"/>
-    <text x="221" y="115" fill="rgba(255,255,255,0.6)">tx 2</text>
-    <rect x="292" y="88" width="110" height="44" fill="#1c1c1c" stroke="#2e2e2e"/>
-    <text x="347" y="115" fill="rgba(255,255,255,0.6)">tx 3</text>
-    <rect x="418" y="88" width="110" height="44" fill="#1c1c1c" stroke="#2e2e2e"/>
-    <text x="473" y="115" fill="rgba(255,255,255,0.6)">tx 4</text>
-    <rect x="544" y="88" width="110" height="44" fill="#1c1c1c" stroke="#2e2e2e"/>
-    <text x="599" y="115" fill="rgba(255,255,255,0.6)">tx 5</text>
-    <rect x="670" y="88" width="110" height="44" fill="#1c1c1c" stroke="#2e2e2e"/>
-    <text x="725" y="115" fill="rgba(255,255,255,0.6)">tx 6</text>
+    <rect class="dgm-box" x="40"  y="88" width="110" height="44"/>
+    <text x="95"  y="115" fill="currentColor" fill-opacity="0.6">tx 1</text>
+    <rect class="dgm-box" x="166" y="88" width="110" height="44"/>
+    <text x="221" y="115" fill="currentColor" fill-opacity="0.6">tx 2</text>
+    <rect class="dgm-box" x="292" y="88" width="110" height="44"/>
+    <text x="347" y="115" fill="currentColor" fill-opacity="0.6">tx 3</text>
+    <rect class="dgm-box" x="418" y="88" width="110" height="44"/>
+    <text x="473" y="115" fill="currentColor" fill-opacity="0.6">tx 4</text>
+    <rect class="dgm-box" x="544" y="88" width="110" height="44"/>
+    <text x="599" y="115" fill="currentColor" fill-opacity="0.6">tx 5</text>
+    <rect class="dgm-box" x="670" y="88" width="110" height="44"/>
+    <text x="725" y="115" fill="currentColor" fill-opacity="0.6">tx 6</text>
   </g>
 
-  <line x1="40" y1="172" x2="800" y2="172" stroke="#181818"/>
+  <line class="dgm-line-soft" x1="40" y1="172" x2="800" y2="172"/>
 
   <!-- Parallel -->
-  <text x="40" y="212" font-size="13" letter-spacing="0.04em" fill="rgba(255,255,255,0.85)">PARALLEL EXECUTION (ALLEGRO)</text>
-  <text x="40" y="232" font-size="11" fill="rgba(255,255,255,0.4)">DISJOINT STATE RUNS CONCURRENTLY, 2 BLOCKS OF WALL TIME</text>
+  <text x="40" y="212" font-size="13" letter-spacing="0.04em" fill="currentColor" fill-opacity="0.85">PARALLEL EXECUTION (ALLEGRO)</text>
+  <text x="40" y="232" font-size="11" fill="currentColor" fill-opacity="0.4">DISJOINT STATE RUNS CONCURRENTLY, 2 BLOCKS OF WALL TIME</text>
 
   <g font-size="11">
-    <text x="40" y="280" fill="rgba(255,255,255,0.35)">LANE 0</text>
-    <text x="40" y="324" fill="rgba(255,255,255,0.35)">LANE 1</text>
-    <text x="40" y="368" fill="rgba(255,255,255,0.35)">LANE 2</text>
+    <text x="40" y="280" fill="currentColor" fill-opacity="0.35">LANE 0</text>
+    <text x="40" y="324" fill="currentColor" fill-opacity="0.35">LANE 1</text>
+    <text x="40" y="368" fill="currentColor" fill-opacity="0.35">LANE 2</text>
   </g>
 
-  <g font-size="11" text-anchor="middle">
-    <rect x="120" y="256" width="110" height="32" fill="#143810" stroke="#65ff54"/>
-    <text x="175" y="277" fill="#65ff54">tx 1</text>
-    <rect x="246" y="256" width="110" height="32" fill="#143810" stroke="#65ff54"/>
-    <text x="301" y="277" fill="#65ff54">tx 4</text>
+  <g class="dgm-accent" font-size="11" text-anchor="middle">
+    <rect class="dgm-accent-box" x="120" y="256" width="110" height="32"/>
+    <text x="175" y="277">tx 1</text>
+    <rect class="dgm-accent-box" x="246" y="256" width="110" height="32"/>
+    <text x="301" y="277">tx 4</text>
 
-    <rect x="120" y="300" width="110" height="32" fill="#143810" stroke="#65ff54"/>
-    <text x="175" y="321" fill="#65ff54">tx 2</text>
-    <rect x="246" y="300" width="110" height="32" fill="#143810" stroke="#65ff54"/>
-    <text x="301" y="321" fill="#65ff54">tx 5</text>
+    <rect class="dgm-accent-box" x="120" y="300" width="110" height="32"/>
+    <text x="175" y="321">tx 2</text>
+    <rect class="dgm-accent-box" x="246" y="300" width="110" height="32"/>
+    <text x="301" y="321">tx 5</text>
 
-    <rect x="120" y="344" width="110" height="32" fill="#143810" stroke="#65ff54"/>
-    <text x="175" y="365" fill="#65ff54">tx 3</text>
-    <rect x="246" y="344" width="110" height="32" fill="#143810" stroke="#65ff54"/>
-    <text x="301" y="365" fill="#65ff54">tx 6</text>
+    <rect class="dgm-accent-box" x="120" y="344" width="110" height="32"/>
+    <text x="175" y="365">tx 3</text>
+    <rect class="dgm-accent-box" x="246" y="344" width="110" height="32"/>
+    <text x="301" y="365">tx 6</text>
   </g>
 
   <!-- saved wall time -->
-  <rect x="372" y="256" width="408" height="120" fill="none" stroke="#2e2e2e" stroke-dasharray="4 4"/>
-  <text x="576" y="322" font-size="11" fill="rgba(255,255,255,0.35)" text-anchor="middle">RECLAIMED BLOCKSPACE</text>
+  <rect class="dgm-line" x="372" y="256" width="408" height="120" fill="none" stroke-dasharray="4 4"/>
+  <text x="576" y="322" font-size="11" fill="currentColor" fill-opacity="0.35" text-anchor="middle">RECLAIMED BLOCKSPACE</text>
 </svg>

--- a/public/blog/receive-policy-delivery-states.svg
+++ b/public/blog/receive-policy-delivery-states.svg
@@ -1,15 +1,15 @@
 <svg width="840" height="320" viewBox="0 0 840 320" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, 'JetBrains Mono', monospace">
-  <rect width="840" height="320" fill="#0e0e0e"/>
+  <rect class="dgm-bg" width="840" height="320"/>
 
-  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="rgba(255,255,255,0.85)">RECEIVE POLICY: THREE DELIVERY STATES</text>
-  <text x="40" y="64" font-size="11" fill="rgba(255,255,255,0.4)">WHAT AN INTEGRATOR MUST MODEL</text>
+  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="currentColor" fill-opacity="0.85">RECEIVE POLICY: THREE DELIVERY STATES</text>
+  <text x="40" y="64" font-size="11" fill="currentColor" fill-opacity="0.4">WHAT AN INTEGRATOR MUST MODEL</text>
 
   <!-- inbound transfer -->
-  <rect x="40" y="166" width="150" height="44" fill="#1c1c1c" stroke="#2e2e2e"/>
-  <text x="115" y="192" font-size="11" fill="rgba(255,255,255,0.6)" text-anchor="middle">INBOUND TRANSFER</text>
+  <rect class="dgm-box" x="40" y="166" width="150" height="44"/>
+  <text x="115" y="192" font-size="11" fill="currentColor" fill-opacity="0.6" text-anchor="middle">INBOUND TRANSFER</text>
 
   <!-- connectors -->
-  <g stroke="#2e2e2e">
+  <g class="dgm-line">
     <line x1="190" y1="188" x2="300" y2="188"/>
     <line x1="300" y1="124" x2="300" y2="252"/>
     <line x1="300" y1="124" x2="380" y2="124"/>
@@ -18,18 +18,18 @@
   </g>
 
   <!-- failed -->
-  <rect x="380" y="102" width="120" height="44" fill="#1c1c1c" stroke="#2e2e2e"/>
-  <text x="440" y="128" font-size="11" fill="rgba(255,255,255,0.6)" text-anchor="middle">FAILED</text>
-  <text x="516" y="128" font-size="11" fill="rgba(255,255,255,0.4)">token checks revert, no transfer</text>
+  <rect class="dgm-box" x="380" y="102" width="120" height="44"/>
+  <text x="440" y="128" font-size="11" fill="currentColor" fill-opacity="0.6" text-anchor="middle">FAILED</text>
+  <text x="516" y="128" font-size="11" fill="currentColor" fill-opacity="0.4">token checks revert, no transfer</text>
 
   <!-- credited -->
-  <rect x="380" y="166" width="120" height="44" fill="#1c1c1c" stroke="#2e2e2e"/>
-  <text x="440" y="192" font-size="11" fill="rgba(255,255,255,0.6)" text-anchor="middle">CREDITED</text>
-  <text x="516" y="192" font-size="11" fill="rgba(255,255,255,0.4)">receiver accepts, funds arrive</text>
+  <rect class="dgm-box" x="380" y="166" width="120" height="44"/>
+  <text x="440" y="192" font-size="11" fill="currentColor" fill-opacity="0.6" text-anchor="middle">CREDITED</text>
+  <text x="516" y="192" font-size="11" fill="currentColor" fill-opacity="0.4">receiver accepts, funds arrive</text>
 
   <!-- held (the new state) -->
-  <rect x="380" y="230" width="120" height="44" fill="#143810" stroke="#65ff54"/>
-  <text x="440" y="256" font-size="11" fill="#65ff54" text-anchor="middle">HELD</text>
-  <text x="516" y="247" font-size="11" fill="rgba(255,255,255,0.55)">held by ReceivePolicyGuard</text>
-  <text x="516" y="263" font-size="11" fill="rgba(255,255,255,0.55)">recoverable by the chosen authority</text>
+  <rect class="dgm-accent-box" x="380" y="230" width="120" height="44"/>
+  <text class="dgm-accent" x="440" y="256" font-size="11" text-anchor="middle">HELD</text>
+  <text x="516" y="247" font-size="11" fill="currentColor" fill-opacity="0.55">held by ReceivePolicyGuard</text>
+  <text x="516" y="263" font-size="11" fill="currentColor" fill-opacity="0.55">recoverable by the chosen authority</text>
 </svg>

--- a/public/blog/reth-tps-benchmark.svg
+++ b/public/blog/reth-tps-benchmark.svg
@@ -1,17 +1,17 @@
 <svg width="840" height="420" viewBox="0 0 840 420" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, 'JetBrains Mono', monospace">
-  <rect width="840" height="420" fill="#0e0e0e"/>
+  <rect class="dgm-bg" width="840" height="420"/>
 
-  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="rgba(255,255,255,0.85)">SUSTAINED TPS BY RELEASE</text>
-  <text x="40" y="64" font-size="11" fill="rgba(255,255,255,0.4)">LIVE NETWORK, CONTINUOUS LOAD — PERF.TEMPO.XYZ</text>
+  <text x="40" y="44" font-size="13" letter-spacing="0.04em" fill="currentColor" fill-opacity="0.85">SUSTAINED TPS BY RELEASE</text>
+  <text x="40" y="64" font-size="11" fill="currentColor" fill-opacity="0.4">LIVE NETWORK, CONTINUOUS LOAD — PERF.TEMPO.XYZ</text>
 
   <!-- gridlines -->
-  <g stroke="#181818">
+  <g class="dgm-line-soft">
     <line x1="40" y1="120" x2="800" y2="120"/>
     <line x1="40" y1="180" x2="800" y2="180"/>
     <line x1="40" y1="240" x2="800" y2="240"/>
     <line x1="40" y1="300" x2="800" y2="300"/>
   </g>
-  <g font-size="10" fill="rgba(255,255,255,0.3)">
+  <g font-size="10" fill="currentColor" fill-opacity="0.3">
     <text x="40" y="113">20K</text>
     <text x="40" y="173">15K</text>
     <text x="40" y="233">10K</text>
@@ -19,27 +19,27 @@
   </g>
 
   <!-- baseline -->
-  <line x1="40" y1="360" x2="800" y2="360" stroke="#2e2e2e"/>
+  <line class="dgm-line" x1="40" y1="360" x2="800" y2="360"/>
 
   <!-- bars: 12px = 1K TPS, baseline y=360 -->
   <g>
-    <rect x="120" y="255.6" width="96" height="104.4" fill="#1c1c1c" stroke="#2e2e2e"/>
-    <text x="168" y="243" font-size="11" fill="rgba(255,255,255,0.45)" text-anchor="middle">8,700</text>
-    <text x="168" y="382" font-size="11" fill="rgba(255,255,255,0.4)" text-anchor="middle">v1.5</text>
+    <rect class="dgm-box" x="120" y="255.6" width="96" height="104.4"/>
+    <text x="168" y="243" font-size="11" fill="currentColor" fill-opacity="0.45" text-anchor="middle">8,700</text>
+    <text x="168" y="382" font-size="11" fill="currentColor" fill-opacity="0.4" text-anchor="middle">v1.5</text>
   </g>
   <g>
-    <rect x="284" y="206.4" width="96" height="153.6" fill="#1c1c1c" stroke="#2e2e2e"/>
-    <text x="332" y="194" font-size="11" fill="rgba(255,255,255,0.45)" text-anchor="middle">12,800</text>
-    <text x="332" y="382" font-size="11" fill="rgba(255,255,255,0.4)" text-anchor="middle">v1.6</text>
+    <rect class="dgm-box" x="284" y="206.4" width="96" height="153.6"/>
+    <text x="332" y="194" font-size="11" fill="currentColor" fill-opacity="0.45" text-anchor="middle">12,800</text>
+    <text x="332" y="382" font-size="11" fill="currentColor" fill-opacity="0.4" text-anchor="middle">v1.6</text>
   </g>
   <g>
-    <rect x="448" y="156" width="96" height="204" fill="#1c1c1c" stroke="#2e2e2e"/>
-    <text x="496" y="144" font-size="11" fill="rgba(255,255,255,0.45)" text-anchor="middle">17,000</text>
-    <text x="496" y="382" font-size="11" fill="rgba(255,255,255,0.4)" text-anchor="middle">v1.7</text>
+    <rect class="dgm-box" x="448" y="156" width="96" height="204"/>
+    <text x="496" y="144" font-size="11" fill="currentColor" fill-opacity="0.45" text-anchor="middle">17,000</text>
+    <text x="496" y="382" font-size="11" fill="currentColor" fill-opacity="0.4" text-anchor="middle">v1.7</text>
   </g>
   <g>
-    <rect x="612" y="105.6" width="96" height="254.4" fill="#143810" stroke="#65ff54"/>
-    <text x="660" y="93" font-size="11" fill="#65ff54" text-anchor="middle">21,200</text>
-    <text x="660" y="382" font-size="11" fill="rgba(255,255,255,0.7)" text-anchor="middle">v1.8</text>
+    <rect class="dgm-accent-box" x="612" y="105.6" width="96" height="254.4"/>
+    <text class="dgm-accent" x="660" y="93" font-size="11" text-anchor="middle">21,200</text>
+    <text x="660" y="382" font-size="11" fill="currentColor" fill-opacity="0.7" text-anchor="middle">v1.8</text>
   </g>
 </svg>

--- a/src/marketing/app/_components/BlogSection.tsx
+++ b/src/marketing/app/_components/BlogSection.tsx
@@ -16,9 +16,9 @@ export default function BlogSection() {
         <h2 className="font-sans text-[clamp(2rem,6vw,3rem)] text-foreground leading-[1.1] tracking-[-0.02em] antialiased">
           Dive deeper into Tempo&apos;s engineering
         </h2>
-        <p className="mt-6 max-w-[560px] font-sans text-[16px] text-white/50 leading-[1.4] tracking-[0] lg:text-[20px]">
+        <p className="mt-6 max-w-[560px] font-sans text-[16px] text-foreground/50 leading-[1.4] tracking-[0] lg:text-[20px]">
           Engineering deep dives, network upgrades, events, and case studies{' '}
-          <span className="text-white">from the team building Tempo.</span>
+          <span className="text-foreground">from the team building Tempo.</span>
         </p>
       </Reveal>
 
@@ -34,10 +34,10 @@ export default function BlogSection() {
             <h3 className="max-w-[480px] font-sans text-[clamp(1.5rem,3.5vw,2.125rem)] text-foreground leading-[1.15] tracking-[-0.02em] antialiased">
               {featured.title}
             </h3>
-            <p className="max-w-[480px] font-sans text-[15px] text-white/50 leading-[1.55] tracking-[0]">
+            <p className="max-w-[480px] font-sans text-[15px] text-foreground/50 leading-[1.55] tracking-[0]">
               {featured.excerpt}
             </p>
-            <p className="font-mono text-[12px] text-white/40 uppercase tracking-[0.02em]">
+            <p className="font-mono text-[12px] text-foreground/40 uppercase tracking-[0.02em]">
               {formatDate(featured.date)}
             </p>
           </div>
@@ -58,7 +58,7 @@ export default function BlogSection() {
                     {post.title}
                   </span>
                   <span className="flex flex-wrap items-center gap-3">
-                    <span className="whitespace-nowrap font-mono text-[12px] text-white/40 uppercase tracking-[0.02em]">
+                    <span className="whitespace-nowrap font-mono text-[12px] text-foreground/40 uppercase tracking-[0.02em]">
                       {formatDate(post.date)}
                     </span>
                   </span>

--- a/src/marketing/app/blog/[slug]/page.tsx
+++ b/src/marketing/app/blog/[slug]/page.tsx
@@ -19,7 +19,7 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
             </h1>
             <Link
               href="/blog"
-              className="font-mono text-[12px] text-white/40 uppercase tracking-[0.02em] transition-colors hover:text-white"
+              className="font-mono text-[12px] text-foreground/40 uppercase tracking-[0.02em] transition-colors hover:text-foreground"
             >
               ← Blog
             </Link>
@@ -39,16 +39,16 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
           <Reveal>
             <Link
               href="/blog"
-              className="font-mono text-[12px] text-white/40 uppercase tracking-[0.02em] transition-colors hover:text-white"
+              className="font-mono text-[12px] text-foreground/40 uppercase tracking-[0.02em] transition-colors hover:text-foreground"
             >
               ← Blog
             </Link>
 
             <div className="mt-8 flex flex-wrap items-center gap-3">
-              <span className="whitespace-nowrap border border-line-strong px-2.5 py-[3px] font-mono text-[11px] text-white/50 uppercase tracking-[0.02em]">
+              <span className="whitespace-nowrap border border-line-strong px-2.5 py-[3px] font-mono text-[11px] text-foreground/50 uppercase tracking-[0.02em]">
                 {categoryBySlug(post.category).badge}
               </span>
-              <span className="font-mono text-[12px] text-white/40 uppercase tracking-[0.02em]">
+              <span className="font-mono text-[12px] text-foreground/40 uppercase tracking-[0.02em]">
                 {formatDate(post.date)}
               </span>
               {isNew(post.date) && (
@@ -62,7 +62,7 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
               {post.title}
             </h1>
 
-            <p className="mt-5 font-sans text-[17px] text-white/50 leading-[1.55] tracking-[0]">
+            <p className="mt-5 font-sans text-[17px] text-foreground/50 leading-[1.55] tracking-[0]">
               {post.excerpt}
             </p>
           </Reveal>

--- a/src/marketing/app/blog/_components/PostExplorer.tsx
+++ b/src/marketing/app/blog/_components/PostExplorer.tsx
@@ -30,7 +30,7 @@ export default function PostExplorer({ posts }: { posts: PostMeta[] }) {
             className={`h-9 whitespace-nowrap border px-4 font-sans text-[13px] tracking-[0] transition-colors ${
               active === filter.slug
                 ? 'border-foreground bg-foreground text-background'
-                : 'border-line-strong text-white/50 hover:border-white/40 hover:text-white'
+                : 'border-line-strong text-foreground/50 hover:border-foreground/40 hover:text-foreground'
             }`}
           >
             {filter.label}
@@ -47,7 +47,7 @@ export default function PostExplorer({ posts }: { posts: PostMeta[] }) {
                 className="group flex flex-col gap-2.5 border-line border-b px-5 py-6 transition-colors hover:bg-surface-block lg:px-8"
               >
                 <span className="flex flex-wrap items-center gap-3">
-                  <span className="whitespace-nowrap border border-line-strong px-2.5 py-[3px] font-mono text-[11px] text-white/50 uppercase tracking-[0.02em]">
+                  <span className="whitespace-nowrap border border-line-strong px-2.5 py-[3px] font-mono text-[11px] text-foreground/50 uppercase tracking-[0.02em]">
                     {categoryBySlug(post.category).badge}
                   </span>
                   {isNew(post.date) && (
@@ -59,7 +59,7 @@ export default function PostExplorer({ posts }: { posts: PostMeta[] }) {
                     {post.title}
                   </span>
                 </span>
-                <span className="max-w-[640px] font-sans text-[14px] text-white/50 leading-[1.5] tracking-[0] transition-colors group-hover:text-white/70">
+                <span className="max-w-[640px] font-sans text-[14px] text-foreground/50 leading-[1.5] tracking-[0] transition-colors group-hover:text-foreground/70">
                   {post.excerpt}
                 </span>
               </Link>

--- a/src/marketing/app/blog/page.tsx
+++ b/src/marketing/app/blog/page.tsx
@@ -36,10 +36,10 @@ export default function BlogPage() {
               <h1 className="max-w-[480px] font-sans text-[clamp(1.75rem,4vw,2.5rem)] text-foreground leading-[1.15] tracking-[-0.02em] antialiased">
                 {featured.title}
               </h1>
-              <p className="max-w-[480px] font-sans text-[15px] text-white/50 leading-[1.55] tracking-[0]">
+              <p className="max-w-[480px] font-sans text-[15px] text-foreground/50 leading-[1.55] tracking-[0]">
                 {featured.excerpt}
               </p>
-              <p className="flex flex-wrap items-center gap-3 font-mono text-[12px] text-white/40 uppercase tracking-[0.02em]">
+              <p className="flex flex-wrap items-center gap-3 font-mono text-[12px] text-foreground/40 uppercase tracking-[0.02em]">
                 {formatDate(featured.date)}
                 {isNew(featured.date) && (
                   <span className="whitespace-nowrap border border-indicator-green px-2.5 py-[3px] text-[11px] text-indicator-green">

--- a/src/marketing/blogPlugin.ts
+++ b/src/marketing/blogPlugin.ts
@@ -20,6 +20,25 @@ const VIRTUAL_ID = 'virtual:blog-posts'
 const RESOLVED_VIRTUAL_ID = `\0${VIRTUAL_ID}`
 
 const BLOGS_DIR = path.resolve(process.cwd(), 'blogs')
+const PUBLIC_DIR = path.resolve(process.cwd(), 'public')
+
+// Inline local SVG diagrams (`![alt](/blog/foo.svg)`) into the HTML so they can
+// follow the active theme via CSS custom properties; SVGs loaded through an
+// `<img>` tag are isolated from the page's theme tokens. Photos (jpg/png) and
+// remote images are left as-is.
+function inlineSvgImages(html: string): string {
+  return html.replace(/<img\b[^>]*?>/g, (tag) => {
+    const src = /\ssrc="([^"]+)"/.exec(tag)?.[1]
+    if (!src || !src.startsWith('/') || !src.endsWith('.svg')) return tag
+
+    const filePath = path.join(PUBLIC_DIR, src)
+    if (!fs.existsSync(filePath)) return tag
+
+    const alt = (/\salt="([^"]*)"/.exec(tag)?.[1] ?? '').replace(/"/g, '&quot;')
+    const svg = fs.readFileSync(filePath, 'utf8').trim()
+    return svg.replace(/<svg\b/, `<svg class="blog-diagram" role="img" aria-label="${alt}"`)
+  })
+}
 
 const CATEGORY_SLUGS = ['network-upgrades', 'events', 'technical', 'case-studies']
 
@@ -96,7 +115,7 @@ async function renderPost(filename: string): Promise<RenderedPost> {
     )
   }
 
-  const html = String(await processor.process(content))
+  const html = inlineSvgImages(String(await processor.process(content)))
 
   return {
     slug,
@@ -137,9 +156,13 @@ export function blogPostsPlugin(): Plugin {
       return `export const posts = ${JSON.stringify(posts)}`
     },
     configureServer(server) {
+      const BLOG_ASSETS_DIR = path.join(PUBLIC_DIR, 'blog')
       server.watcher.add(BLOGS_DIR)
+      server.watcher.add(BLOG_ASSETS_DIR)
       const invalidate = (file: string) => {
-        if (!file.startsWith(BLOGS_DIR)) return
+        // Posts are rendered with their referenced SVGs inlined, so a change to
+        // either the markdown or a /blog asset must drop the cache.
+        if (!file.startsWith(BLOGS_DIR) && !file.startsWith(BLOG_ASSETS_DIR)) return
         cache = null
         const mod = server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_ID)
         if (mod) {

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -547,6 +547,17 @@
   --color-prose-caption: rgba(255, 255, 255, 0.4);
   --color-scrollbar-thumb: #151515;
 
+  /* Blog diagram (inlined SVG) palette — kept identical to the original
+     dark-only artwork so dark mode is unchanged; the light overrides below
+     swap these for legible values on a light page. */
+  --diagram-bg: #0e0e0e;
+  --diagram-box: #1c1c1c;
+  --diagram-box-border: #2e2e2e;
+  --diagram-line: #2e2e2e;
+  --diagram-line-soft: #181818;
+  --diagram-accent: #65ff54;
+  --diagram-accent-bg: #143810;
+
   --background: var(--color-background);
   --foreground: var(--color-foreground);
   --foreground-secondary: var(--color-foreground-secondary);
@@ -690,6 +701,13 @@
   --color-prose-quote: color-mix(in srgb, var(--color-foreground) 52%, transparent);
   --color-prose-caption: color-mix(in srgb, var(--color-foreground) 45%, transparent);
   --color-scrollbar-thumb: #d4d4d4;
+  --diagram-bg: #f5f5f5;
+  --diagram-box: #ffffff;
+  --diagram-box-border: #d4d4d4;
+  --diagram-line: #d4d4d4;
+  --diagram-line-soft: #e5e5e5;
+  --diagram-accent: #168f24;
+  --diagram-accent-bg: #e3f5e5;
   --canvas-dot-rgb: 17, 17, 17;
   --canvas-dot-alpha-base: 0.045;
   --showcase-window-frame: var(--surface-block);
@@ -1284,8 +1302,41 @@ body {
   margin-top: 1.5em;
   border: 1px solid var(--line);
 }
-/* An italic-only paragraph right after an image is a caption by convention. */
-.blog-prose p:has(img) + p:has(> em:only-child) {
+/* Diagrams are inlined as SVG at build time (see blogPlugin) so they can
+   follow the active theme. Text uses currentColor; shapes use diagram tokens. */
+.blog-prose svg.blog-diagram {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin-top: 1.5em;
+  border: 1px solid var(--line);
+  color: var(--foreground);
+}
+.blog-prose svg.blog-diagram .dgm-bg {
+  fill: var(--diagram-bg);
+}
+.blog-prose svg.blog-diagram .dgm-box {
+  fill: var(--diagram-box);
+  stroke: var(--diagram-box-border);
+}
+.blog-prose svg.blog-diagram .dgm-accent-box {
+  fill: var(--diagram-accent-bg);
+  stroke: var(--diagram-accent);
+}
+.blog-prose svg.blog-diagram .dgm-line {
+  stroke: var(--diagram-line);
+}
+.blog-prose svg.blog-diagram .dgm-line-soft {
+  stroke: var(--diagram-line-soft);
+}
+.blog-prose svg.blog-diagram .dgm-accent-line {
+  stroke: var(--diagram-accent);
+}
+.blog-prose svg.blog-diagram .dgm-accent {
+  fill: var(--diagram-accent);
+}
+/* An italic-only paragraph right after an image/diagram is a caption. */
+.blog-prose :is(p:has(img), p:has(svg)) + p:has(> em:only-child) {
   margin-top: 0.75em;
   font-size: 13px;
   color: var(--prose-caption);


### PR DESCRIPTION
## What

Fixes two light-mode regressions on the blog surface.

### Missing text
The blog post page, index, `PostExplorer`, and `BlogSection` used hardcoded `text-white/*` (and `hover:text-white`) classes that are invisible on a light background. Swapped them for the `text-foreground` theme token, so the category badge, date, "← Blog" link, and excerpt show in both themes.

### Diagrams stuck dark
The blog diagram SVGs were dark-only (`#0e0e0e` fills, white-opacity text) and loaded via `<img>`, so they couldn't react to the site's `data-theme` toggle. Now:

- `blogPlugin` **inlines** local `/blog/*.svg` diagrams into the post HTML at build time so they inherit page CSS.
- The four diagrams use `.dgm-*` token classes for shapes and `currentColor` for text.
- Added `--diagram-*` tokens (light + dark) and `.blog-prose svg.blog-diagram` rules in `_root.css`. **Dark mode is visually unchanged.**
- The post cache now invalidates when `/blog` assets change, so SVG edits hot-reload in dev.

### Docs
Updated `blogs/DIAGRAMS.md` so future diagrams use the theme-aware class/`currentColor` approach instead of hardcoded hex.

## Test plan
- [x] Toggle light/dark on a blog post — badge/date/back-link/excerpt readable in both.
- [x] Toggle light/dark — all diagrams adapt (light canvas + dark text in light mode).
- [x] Dark mode diagrams unchanged.
- `xmllint` passes on all four SVGs; biome + tsc clean.