### PR TITLE
Fix marketing social image URLs

### DIFF
--- a/src/marketing/seo.ts
+++ b/src/marketing/seo.ts
@@ -21,8 +21,9 @@ export function resolveBaseUrl(): string {
   if (URL.canParse(process.env.VITE_BASE_URL ?? '')) {
     return (process.env.VITE_BASE_URL as string).replace(/\/$/, '')
   }
+  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
-  if (process.env.VERCEL_ENV === 'production' && productionUrl) return `https://${productionUrl}`
+  if (productionUrl) return `https://${productionUrl}`
   return ''
 }
 

--- a/vite.marketing.config.ts
+++ b/vite.marketing.config.ts
@@ -216,8 +216,9 @@ function marketingOgImage(route: string, metadata: { title: string; description:
     blog: 'BLOG',
   }
   const section = route.startsWith('blog/') ? 'BLOG' : sections[route] || 'BUILD'
+  const title = route === 'performance' ? 'Performance' : metadata.title
   return ogImageUrl(siteBaseUrl, {
-    title: metadata.title,
+    title,
     description: metadata.description,
     section,
   })

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -6,8 +6,9 @@ import { createFeedbackAdapter } from './src/lib/feedback-adapter'
 const baseUrl = (() => {
   if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') return ''
   if (URL.canParse(process.env.VITE_BASE_URL)) return process.env.VITE_BASE_URL.replace(/\/$/, '')
+  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
-  if (process.env.VERCEL_ENV === 'production' && productionUrl) return `https://${productionUrl}`
+  if (productionUrl) return `https://${productionUrl}`
   return ''
 })()
 


### PR DESCRIPTION
Marketing and blog pages were generating relative Open Graph image URLs when the production base URL was not explicitly configured. This makes production base URL resolution fall back to https://docs.tempo.xyz so Vite marketing pages emit absolute dynamic social card URLs like the Vocs docs pages.

Verification:
- pnpm check:types
- VERCEL_ENV=production pnpm exec vite build --config vite.marketing.config.ts
- inspected generated OG tags for /blog/t6, /blog, /performance, and /

Prompted by: @snario