### PR TITLE
Clean up marketing page titles

### DIFF
--- a/src/marketing/MarketingRoute.tsx
+++ b/src/marketing/MarketingRoute.tsx
@@ -18,7 +18,7 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
       'The only blockchain designed for payments. Sub-second transactions, sub-cent fees.',
   },
   '/build': {
-    title: 'Tempo',
+    title: 'Build on Tempo',
     description:
       'Build payment products on Tempo with stablecoins, fast settlement, and predictable fees.',
   },
@@ -32,16 +32,16 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
       'Stablecoin-first Tempo Tokens for payments, fees, memos, policies, and liquidity.',
   },
   '/performance': {
-    title: 'Tempo Performance',
+    title: 'Performance',
     description:
       'Nightly benchmarks on Tempo throughput, block times, execution rates, and uptime.',
   },
   '/diagrams': {
-    title: 'Tempo Diagrams',
+    title: 'Diagrams',
     description: 'A playground for Tempo diagrams, product visuals, and house-style SVG exports.',
   },
   '/blog': {
-    title: 'Blog — Tempo Developers',
+    title: 'Blog',
     description:
       'Engineering deep dives, network upgrades, events, and case studies from the Tempo team.',
   },

--- a/src/marketing/app/diagrams/page.tsx
+++ b/src/marketing/app/diagrams/page.tsx
@@ -5,7 +5,7 @@ import FeatureDiagramGallery from './_components/FeatureDiagramGallery'
 import Playground from './_components/Playground'
 
 export const metadata: Metadata = {
-  title: 'Diagram playground — Tempo Developers',
+  title: 'Diagrams',
   description:
     "Internal playground for Tempo's diagram language, including feature diagrams and static SVG exports.",
 }

--- a/src/marketing/app/performance/page.tsx
+++ b/src/marketing/app/performance/page.tsx
@@ -13,7 +13,7 @@ import UptimeStrip from './_components/UptimeStrip'
 import { fetchPerfRuns, fmtInt, type PerfRun } from './_lib/runs'
 
 export const metadata: Metadata = {
-  title: 'Performance — Tempo Developers',
+  title: 'Performance',
   description:
     'Nightly benchmarks on a live Tempo network: throughput, block times, and execution rates, published as raw runs.',
 }

--- a/src/marketing/main.tsx
+++ b/src/marketing/main.tsx
@@ -80,7 +80,7 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
       'The only blockchain designed for payments. Sub-second transactions, sub-cent fees.',
   },
   '/build': {
-    title: 'Tempo',
+    title: 'Build on Tempo',
     description:
       'Build payment products on Tempo with stablecoins, fast settlement, and predictable fees.',
   },
@@ -94,16 +94,16 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
       'Stablecoin-first Tempo Tokens for payments, fees, memos, policies, and liquidity.',
   },
   '/performance': {
-    title: 'Tempo Performance',
+    title: 'Performance',
     description:
       'Nightly benchmarks on Tempo throughput, block times, execution rates, and uptime.',
   },
   '/diagrams': {
-    title: 'Tempo Diagrams',
+    title: 'Diagrams',
     description: 'A playground for Tempo diagrams, product visuals, and house-style SVG exports.',
   },
   '/blog': {
-    title: 'Blog — Tempo Developers',
+    title: 'Blog',
     description:
       'Engineering deep dives, network upgrades, events, and case studies from the Tempo team.',
   },

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -9,7 +9,7 @@ import {
   resolveBaseUrl,
 } from '../../marketing/seo'
 
-const BLOG_TITLE = 'Blog — Tempo Developers'
+const BLOG_TITLE = 'Blog'
 const BLOG_DESCRIPTION =
   'Engineering deep dives, network upgrades, events, and case studies from the Tempo team.'
 
@@ -38,7 +38,7 @@ export default function Page({ slug }: { slug: string }) {
   const base = resolveBaseUrl()
   const post = postBySlug.get(slug)
 
-  const title = post ? `${post.title} — Tempo Developers` : BLOG_TITLE
+  const title = post ? post.title : BLOG_TITLE
   const description = post?.excerpt ?? BLOG_DESCRIPTION
   const canonical = absoluteUrl(base, post ? `/blog/${slug}` : '/blog')
   const ogImage = ogImageUrl(base, { title, description, section: 'BLOG' })

--- a/vite.marketing.config.ts
+++ b/vite.marketing.config.ts
@@ -67,7 +67,7 @@ async function marketingRouteCopiesForBuild() {
   blogPostByRoute.clear()
   for (const post of posts) {
     blogRouteMetadata.set(`blog/${post.slug}`, {
-      title: `${post.title} — Tempo Developers`,
+      title: post.title,
       description: post.excerpt,
     })
     blogPostByRoute.set(`blog/${post.slug}`, {
@@ -88,7 +88,7 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
       'The only blockchain designed for payments. Sub-second transactions, sub-cent fees.',
   },
   build: {
-    title: 'Tempo',
+    title: 'Build on Tempo',
     description:
       'Build payment products on Tempo with stablecoins, fast settlement, and predictable fees.',
   },
@@ -102,16 +102,16 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
       'Stablecoin-first Tempo Tokens for payments, fees, memos, policies, and liquidity.',
   },
   performance: {
-    title: 'Tempo Performance',
+    title: 'Performance',
     description:
       'Nightly benchmarks on Tempo throughput, block times, execution rates, and uptime.',
   },
   diagrams: {
-    title: 'Tempo Diagrams',
+    title: 'Diagrams',
     description: 'A playground for Tempo diagrams, product visuals, and house-style SVG exports.',
   },
   blog: {
-    title: 'Blog — Tempo Developers',
+    title: 'Blog',
     description:
       'Engineering deep dives, network upgrades, events, and case studies from the Tempo team.',
   },
@@ -216,9 +216,8 @@ function marketingOgImage(route: string, metadata: { title: string; description:
     blog: 'BLOG',
   }
   const section = route.startsWith('blog/') ? 'BLOG' : sections[route] || 'BUILD'
-  const title = route === 'performance' ? 'Performance' : metadata.title
   return ogImageUrl(siteBaseUrl, {
-    title,
+    title: metadata.title,
     description: metadata.description,
     section,
   })


### PR DESCRIPTION
Removes the hard-coded performance-only OG title branch and makes the recent non-docs Vite page titles concise enough to drive their social cards directly.

Updated generated titles / OG titles:
- /build -> Build on Tempo
- /performance -> Performance
- /diagrams -> Diagrams
- /blog -> Blog
- /blog/t6 -> raw post title without the Tempo Developers suffix

Verification:
- pnpm check:types
- VERCEL_ENV=production pnpm exec vite build --config vite.marketing.config.ts
- inspected generated title, og:title, twitter:title, and og:image tags for /, /build, /build/tempo-transactions, /build/tip20-tokens, /performance, /diagrams, /blog, and /blog/t6

Prompted by: @snario