### PR TITLE
Fix homepage showcase layout shift

### DIFF
--- a/src/marketing/app/_components/TokensShowcase.tsx
+++ b/src/marketing/app/_components/TokensShowcase.tsx
@@ -13,6 +13,7 @@ import Reveal from './Reveal'
 const VISUAL_HEIGHT = 'lg:h-[424px]'
 const CODE_HEIGHT = 'max-h-[390px]'
 const DIAGRAM_CONTAINER = 'p-6 lg:min-h-0 lg:p-10'
+const PANEL_HEIGHT = 'min-h-[454px]'
 const SHOWCASE_HEIGHT = 'lg:min-h-[560px]'
 
 type Row = {
@@ -320,7 +321,7 @@ export default function TokensShowcase() {
           <div className="absolute top-6 right-6 z-20 lg:top-8 lg:right-10">
             <ModeToggle mode={mode} setMode={setMode} />
           </div>
-          <div className="grid w-full max-w-[560px] grid-cols-1">
+          <div className={`grid w-full max-w-[560px] grid-cols-1 ${PANEL_HEIGHT}`}>
             {rows.map((row, i) => (
               <Fragment key={row.title}>
                 <div

--- a/src/marketing/app/_components/TransactionsShowcase.tsx
+++ b/src/marketing/app/_components/TransactionsShowcase.tsx
@@ -18,6 +18,7 @@ import {
 const VISUAL_HEIGHT = 'lg:h-[424px]'
 const CODE_HEIGHT = 'max-h-[390px]'
 const DIAGRAM_CONTAINER = 'p-6 lg:min-h-0 lg:p-10'
+const PANEL_HEIGHT = 'min-h-[454px]'
 const SHOWCASE_HEIGHT = 'lg:min-h-[560px]'
 
 type Row = {
@@ -149,7 +150,7 @@ export default function TransactionsShowcase() {
           <div className="absolute top-6 right-6 z-20 lg:top-8 lg:right-10">
             <ModeToggle mode={mode} setMode={setMode} />
           </div>
-          <div className="grid w-full max-w-[560px] grid-cols-1">
+          <div className={`grid w-full max-w-[560px] grid-cols-1 ${PANEL_HEIGHT}`}>
             {rows.map((row, i) => (
               <Fragment key={row.title}>
                 <div


### PR DESCRIPTION
## Summary
- reserve a stable visual/code panel height on the homepage transaction and token showcases
- prevent section height changes when toggling between Diagram and Code

## Verification
- pnpm check:types
- pnpm build (completed; transient GitHub fetch timeout logged during changelog SSG, build exited 0)
- pnpm exec biome check src/marketing/app/_components/TransactionsShowcase.tsx src/marketing/app/_components/TokensShowcase.tsx
- Playwright measurements on http://localhost:5173/ confirmed both affected sections keep identical bounding-box heights across Diagram -> Code -> Diagram

Prompted by: @tmm