### PR TITLE
fix: update stale KeyAuthorization digest comment in Tempo transaction spec

### DIFF
--- a/src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx
+++ b/src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx
@@ -770,7 +770,7 @@ Access-key-signed transactions cannot perform contract creation. Any `CREATE` or
      ]
    };
 
-   // Compute digest: keccak256(rlp([chain_id, key_type, key_id, expiry, limits, allowed_calls]))
+   // Compute digest: keccak256(rlp([chain_id, key_type, key_id, expiry?, limits?, allowed_calls?, witness?, is_admin?, account?]))
    const authDigest = computeAuthorizationDigest(keyAuth);
    ```
 


### PR DESCRIPTION
Updates the example digest comment in the Tempo transaction spec to the canonical post-T6 `KeyAuthorization` RLP form, including the `witness?`, `is_admin?`, and `account?` optional trailing fields.

This was the only occurrence in the file still using the old short form; the other three (lines 590, 608, 648) already use the full form. T6 (TIP-1049) added the `is_admin?`/`account?` fields and T5 added `witness?`.