### PR TITLE
docs(api): add active-development callouts

### DIFF
--- a/src/pages/api.mdx
+++ b/src/pages/api.mdx
@@ -9,6 +9,10 @@ import { Cards, Card, OpenApi } from 'vocs'
 
 Use the Tempo API for indexed chain data, readable account activity, token metadata, balances, transfers, transaction receipts, and RPC methods.
 
+:::warning
+The Tempo API is under active development. Endpoints are not yet stable and may change without notice.
+:::
+
 ## Getting Started
 
 Every endpoint is served over HTTPS from `https://api.tempo.xyz` under the `/v1` prefix. Most read endpoints are public, so you can make your first request without any credentials:

--- a/src/pages/api/versioning-policy.mdx
+++ b/src/pages/api/versioning-policy.mdx
@@ -7,8 +7,8 @@ description: Learn how Tempo API versions, breaking changes, deprecations, and s
 
 The Tempo API evolves without breaking existing integrations whenever practical. This page explains how the API is versioned, what we consider a breaking change, and how changes are communicated.
 
-:::info
-The Tempo API is versioned by URL path. The current stable version is served under the `/v1` prefix, such as `/v1/tokens`. Breaking changes ship as a new prefix, such as `/v2` or `/v3`. Each prior version stays available for its deprecation window so you can migrate on your own schedule.
+:::warning
+The Tempo API is under active development. Endpoints are not yet stable and may change without notice. The policy below will apply after stabilization.
 :::
 
 ## Where This Policy Does Not Apply


### PR DESCRIPTION
Adds a warning callout to the API overview (`/api`) and the versioning policy page noting that the API is under active development and endpoints may change without notice.

On the versioning policy page, the warning clarifies that the policy applies after stabilization, and the now-premature `/v1` versioning info callout is removed.