### PR TITLE
Remove placeholder blog routes from sitemap

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig(({ mode }) => {
       marketingSearchIndexPlugin({ source: 'vocs' }),
       marketingPages(),
       vocs(),
+      removePlaceholderSitemapRoutes(),
       Icons({ compiler: 'jsx', jsx: 'react' }),
       react(),
       ...(useHttp ? [] : [mkcert()]),
@@ -97,6 +98,44 @@ function marketingPages(): Plugin {
         res.end(html)
       })
     },
+  }
+}
+
+function removePlaceholderSitemapRoutes(): Plugin {
+  return {
+    name: 'tempo-remove-placeholder-sitemap-routes',
+    async closeBundle() {
+      const publicDir = path.resolve(process.cwd(), 'dist/public')
+      const sitemapFiles = await findSitemapFiles(publicDir)
+
+      await Promise.all(
+        sitemapFiles.map(async (file) => {
+          const sitemap = await fs.readFile(file, 'utf-8')
+          const filtered = sitemap.replace(
+            /<url>\s*<loc>[^<]*(?:%5B|\[)[^<]*(?:%5D|\])[^<]*<\/loc>[\s\S]*?<\/url>\s*/gi,
+            '',
+          )
+          if (filtered !== sitemap) await fs.writeFile(file, filtered)
+        }),
+      )
+    },
+  }
+}
+
+async function findSitemapFiles(directory: string): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(directory, { withFileTypes: true })
+    const files = await Promise.all(
+      entries.map(async (entry) => {
+        const entryPath = path.join(directory, entry.name)
+        if (entry.isDirectory()) return findSitemapFiles(entryPath)
+        if (entry.isFile() && /^sitemap.*\.xml$/.test(entry.name)) return [entryPath]
+        return []
+      }),
+    )
+    return files.flat()
+  } catch {
+    return []
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds a Vite post-build sitemap filter that removes generated URLs containing route placeholders like /blog/[slug].
- Keeps real static blog post routes intact while preventing placeholder 404s from being advertised to crawlers.

## Testing
- git diff --check
- pnpm exec biome check vite.config.ts
- pnpm exec tsgo --project tsconfig.json --noEmit
- Verified the sitemap filter removes /blog/[slug] and preserves /blog/t6 with a targeted Node check.

## Notes
- pnpm build is blocked in this sandbox by Vocs failing to fetch the remote OpenAPI spec from api.tempo.xyz with ETIMEDOUT during the vocs:llms build step.

Prompted by: @juandolealt