### PR TITLE
Fix faucet success explorer link

### DIFF
--- a/e2e/faucet.test.ts
+++ b/e2e/faucet.test.ts
@@ -17,6 +17,11 @@ test('fund an address via faucet', async ({ page }) => {
   // Click "Add funds" button
   await page.getByRole('button', { name: 'Add funds' }).click()
 
-  // Confirm "View receipt" link is visible
-  await expect(page.getByRole('link', { name: 'View receipt' })).toBeVisible({ timeout: 90000 })
+  // Confirm the explorer link resolves to the funded account's transfers
+  const transfersLink = page.getByRole('link', { name: 'View transfers' })
+  await expect(transfersLink).toBeVisible({ timeout: 90000 })
+  await expect(transfersLink).toHaveAttribute(
+    'href',
+    'https://explore.testnet.tempo.xyz/address/0xbeefcafe54750903ac1c8909323af7beb21ea2cb?tab=transfers',
+  )
 })

--- a/src/components/guides/Demo.tsx
+++ b/src/components/guides/Demo.tsx
@@ -89,12 +89,16 @@ export function ReceiptHash({ hash }: { hash: string }) {
 export function ExplorerAccountLink({
   address,
   inline = false,
+  label = 'View account',
+  tab,
 }: {
   address: string
   inline?: boolean
+  label?: string
+  tab?: string
 }) {
   const { trackExternalLinkClick } = usePostHogTracking()
-  const url = `${getExplorerHost()}/address/${address}`
+  const url = `${getExplorerHost()}/address/${address}${tab ? `?tab=${tab}` : ''}`
 
   return (
     <div className={inline ? 'inline-flex' : 'mt-1'}>
@@ -103,9 +107,9 @@ export function ExplorerAccountLink({
         target="_blank"
         rel="noreferrer"
         className="flex items-center gap-1 text-[13px] text-accent -tracking-[1%] hover:underline"
-        onClick={() => trackExternalLinkClick(url, 'View account')}
+        onClick={() => trackExternalLinkClick(url, label)}
       >
-        View account
+        {label}
         <LucideExternalLink className="size-3" />
       </a>
     </div>

--- a/src/components/guides/steps/payments/AddFundsToOthers.tsx
+++ b/src/components/guides/steps/payments/AddFundsToOthers.tsx
@@ -7,7 +7,7 @@ import { mnemonicToAccount } from 'viem/accounts'
 import { Actions } from 'viem/tempo'
 import { useBlockNumber, useClient, useConnection } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
-import { Button, ExplorerLink, Step } from '../../Demo'
+import { Button, ExplorerAccountLink, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
 
@@ -142,8 +142,8 @@ export function AddFundsToOthers(props: DemoStepProps) {
               disabled={fundAccount.isPending}
             />
           </div>
-          {fundAccount.data?.[0]?.transactionHash && (
-            <ExplorerLink hash={fundAccount.data[0].transactionHash} />
+          {fundAccount.isSuccess && isValidTarget && (
+            <ExplorerAccountLink address={targetAddress} label="View transfers" tab="transfers" />
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Link faucet success states to the funded account transfers tab
- Allow explorer account links to customize labels and tab query params
- Update the faucet e2e check to assert the transfers link target

## Motivation

The faucet returns receipt hashes, but the explorer receipt detail route can fail while the account transfers page still shows the funded transfers. The docs should keep the success link clickable and useful after faucet completion.

## Key design considerations

- Reuses the existing explorer account link component instead of adding a new link pattern
- Keeps the faucet success action tied to the address the user funded
- Preserves default account-link behavior for existing call sites