### PR TITLE
feat: add faucet to resources menu

### DIFF
--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -214,6 +214,15 @@ function WalletIcon() {
   )
 }
 
+function FaucetIcon() {
+  return (
+    <Glyph>
+      <path d="M12 3.5c3.5 4.3 5.3 7.2 5.3 10a5.3 5.3 0 0 1-10.6 0c0-2.8 1.8-5.7 5.3-10Z" />
+      <path d="M10 16.5c1.5 1 3.5.5 4.4-1" />
+    </Glyph>
+  )
+}
+
 function ApiIcon() {
   return (
     <Glyph>
@@ -301,6 +310,12 @@ const developersMenu: MegaMenuData = {
           desc: 'A Tempo-first wallet for your agents',
           href: 'https://wallet.tempo.xyz',
           icon: <WalletIcon />,
+        },
+        {
+          label: 'Faucet',
+          desc: 'Get testnet tokens for development',
+          href: `${DOCS_BASE_PATH}/quickstart/faucet`,
+          icon: <FaucetIcon />,
         },
         {
           label: 'TIDX',

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -15,6 +15,7 @@ import {
   ApiIcon,
   DocsIcon,
   ExplorerIcon,
+  FaucetIcon,
   McpIcon,
   TerminalIcon,
   TokensIcon,
@@ -73,6 +74,12 @@ const developersMenu: MegaMenuData = {
           desc: 'A Tempo-first wallet for your agents',
           href: 'https://wallet.tempo.xyz',
           icon: <WalletIcon />,
+        },
+        {
+          label: 'Faucet',
+          desc: 'Get testnet tokens for development',
+          href: '/docs/quickstart/faucet',
+          icon: <FaucetIcon />,
         },
         {
           label: 'TIDX',

--- a/src/marketing/app/_components/menuIcons.tsx
+++ b/src/marketing/app/_components/menuIcons.tsx
@@ -84,6 +84,15 @@ export function WalletIcon() {
   )
 }
 
+export function FaucetIcon() {
+  return (
+    <Glyph>
+      <path d="M12 3.5c3.5 4.3 5.3 7.2 5.3 10a5.3 5.3 0 0 1-10.6 0c0-2.8 1.8-5.7 5.3-10Z" />
+      <path d="M10 16.5c1.5 1 3.5.5 4.4-1" />
+    </Glyph>
+  )
+}
+
 export function ApiIcon() {
   return (
     <Glyph>


### PR DESCRIPTION
## Summary

- Add Faucet to the Resources dropdown on the homepage header
- Add Faucet to the Resources dropdown on docs pages
- Add a matching faucet icon for the shared menu style

## Motivation

The faucet is a high-traffic developer resource and should be discoverable from the primary Resources navigation.

## Key design considerations

- Links to the existing faucet documentation page
- Keeps the new item in the existing Tools column with the same menu item structure and visual treatment