### PR TITLE
test: add faucet wallet e2e coverage

### DIFF
--- a/e2e/faucet.test.ts
+++ b/e2e/faucet.test.ts
@@ -20,3 +20,55 @@ test('fund an address via faucet', async ({ page }) => {
   // Confirm "View receipt" link is visible
   await expect(page.getByRole('link', { name: 'View receipt' })).toBeVisible({ timeout: 90000 })
 })
+
+test('fund a connected passkey wallet via faucet', async ({ page }) => {
+  test.setTimeout(240000)
+
+  const client = await page.context().newCDPSession(page)
+  await client.send('WebAuthn.enable')
+  const { authenticatorId } = await client.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+    },
+  })
+
+  try {
+    await page.goto('/docs/quickstart/faucet')
+
+    const tab = page.getByRole('tab', { name: 'Fund your wallet' })
+    await expect(tab).toBeVisible({ timeout: 90000 })
+    await tab.click()
+
+    const connectStep = page
+      .locator('[data-active][data-completed]')
+      .filter({ hasText: 'Connect your browser wallet.' })
+      .first()
+    const connectButton = connectStep.getByRole('button').first()
+    await expect(connectButton).toBeVisible({ timeout: 30000 })
+    await expect(connectButton).toBeEnabled()
+    await connectButton.click()
+
+    await expect(connectStep.getByRole('button', { name: 'Disconnect' })).toBeVisible({
+      timeout: 30000,
+    })
+
+    const addFundsStep = page
+      .locator('[data-active][data-completed]')
+      .filter({ hasText: 'Add testnet funds to your wallet.' })
+      .first()
+    const addFundsButton = addFundsStep.getByRole('button', { name: 'Add funds' })
+    await expect(addFundsButton).toBeVisible({ timeout: 30000 })
+    await expect(addFundsButton).toBeEnabled()
+    await addFundsButton.click()
+
+    await expect(addFundsStep.getByRole('button', { name: 'Add more funds' })).toBeVisible({
+      timeout: 120000,
+    })
+  } finally {
+    await client.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId }).catch(() => {})
+  }
+})

--- a/src/components/guides/Demo.tsx
+++ b/src/components/guides/Demo.tsx
@@ -16,6 +16,7 @@ import { cva, cx } from '../../../cva.config'
 import { usePostHogTracking } from '../../lib/posthog'
 import { useTempoWalletConnector, useWebAuthnConnector } from '../../wagmi.config'
 import { Container as ParentContainer } from '../Container'
+import { isFundableWalletConnector } from '../lib/wallets'
 import { alphaUsd } from './tokens'
 
 export { alphaUsd, betaUsd, pathUsd, thetaUsd } from './tokens'
@@ -155,8 +156,9 @@ export function Container(
     }
 
     if (source === 'wallet') {
-      const walletConnection = connections.find(
-        (c) => c.connector.id !== 'webAuthn' && c.connector.id !== 'xyz.tempo',
+      const includeWebAuthn = import.meta.env.VITE_E2E === 'true'
+      const walletConnection = connections.find((c) =>
+        isFundableWalletConnector(c.connector, { includeWebAuthn }),
       )
       return walletConnection?.accounts[0]
     }

--- a/src/components/guides/steps/wallet/AddFundsToWallet.tsx
+++ b/src/components/guides/steps/wallet/AddFundsToWallet.tsx
@@ -7,15 +7,17 @@ import { mnemonicToAccount } from 'viem/accounts'
 import { Actions } from 'viem/tempo'
 import { useBlockNumber, useClient, useConnections } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
+import { isFundableWalletConnector } from '../../../lib/wallets'
 import { Button, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
 
 export function AddFundsToWallet(props: DemoStepProps) {
   const { stepNumber = 2, last = false } = props
+  const isE2E = import.meta.env.VITE_E2E === 'true'
   const connections = useConnections()
-  const walletConnection = connections.find(
-    (c) => c.connector.id !== 'webAuthn' && c.connector.id !== 'xyz.tempo',
+  const walletConnection = connections.find((c) =>
+    isFundableWalletConnector(c.connector, { includeWebAuthn: isE2E }),
   )
   const address = walletConnection?.accounts[0]
   const hasNonWebAuthnWallet = Boolean(address)

--- a/src/components/guides/steps/wallet/ConnectWallet.tsx
+++ b/src/components/guides/steps/wallet/ConnectWallet.tsx
@@ -11,19 +11,20 @@ import {
 } from 'wagmi'
 import LucideCheck from '~icons/lucide/check'
 import LucideWalletCards from '~icons/lucide/wallet-cards'
-import { filterSupportedInjectedConnectors } from '../../../lib/wallets'
+import { filterSupportedInjectedConnectors, isFundableWalletConnector } from '../../../lib/wallets'
 import { Button, Step, StringFormatter, useCopyToClipboard } from '../../Demo'
 import type { DemoStepProps } from '../types'
 
 export function ConnectWallet(props: DemoStepProps) {
   const { stepNumber = 1 } = props
+  const isE2E = import.meta.env.VITE_E2E === 'true'
   const { chain, connector } = useConnection()
   const connections = useConnections()
   const connect = useConnect()
   const disconnect = useDisconnect()
   const connectors = useConnectors()
   const injectedConnectors = React.useMemo(
-    () => filterSupportedInjectedConnectors(connectors),
+    () => filterSupportedInjectedConnectors(connectors, { includeWebAuthn: isE2E }),
     [connectors],
   )
   const switchChain = useSwitchChain()
@@ -31,7 +32,9 @@ export function ConnectWallet(props: DemoStepProps) {
   const isSupported = chains.some((c) => c.id === chain?.id)
   const [copied, copyToClipboard] = useCopyToClipboard()
 
-  const walletConnection = connections.find((c) => c.connector.id !== 'webAuthn')
+  const walletConnection = connections.find((c) =>
+    isFundableWalletConnector(c.connector, { includeWebAuthn: isE2E }),
+  )
   const walletAddress = walletConnection?.accounts[0]
   const walletConnector = walletConnection?.connector
   const hasNonWebAuthnWallet = Boolean(walletAddress)
@@ -55,7 +58,14 @@ export function ConnectWallet(props: DemoStepProps) {
               variant="default"
               className="flex items-center gap-1.5"
               key={conn.id}
-              onClick={() => connect.connect({ connector: conn })}
+              onClick={() =>
+                connect.connect({
+                  connector: conn,
+                  ...(isE2E && conn.id === 'webAuthn'
+                    ? { capabilities: { method: 'register' as const, name: 'Tempo Docs' } }
+                    : {}),
+                })
+              }
             >
               {conn.icon ? <img className="size-5" src={conn.icon} alt={conn.name} /> : <div />}
               {conn.name}

--- a/src/components/lib/wallets.ts
+++ b/src/components/lib/wallets.ts
@@ -3,14 +3,24 @@ import type { Connector } from 'wagmi'
 const UNSUPPORTED_WALLET_IDS = new Set(['app.phantom'])
 const UNSUPPORTED_WALLET_NAMES = new Set(['Phantom'])
 
-export function filterSupportedInjectedConnectors(connectors: readonly Connector[]) {
+export function filterSupportedInjectedConnectors(
+  connectors: readonly Connector[],
+  options: { includeWebAuthn?: boolean } = {},
+) {
   const seen = new Set<string>()
   return connectors.filter((connector) => {
-    if (connector.id === 'webAuthn') return false
+    if (connector.id === 'webAuthn' && !options.includeWebAuthn) return false
     if (UNSUPPORTED_WALLET_IDS.has(connector.id)) return false
     if (UNSUPPORTED_WALLET_NAMES.has(connector.name)) return false
     if (seen.has(connector.id)) return false
     seen.add(connector.id)
     return true
   })
+}
+
+export function isFundableWalletConnector(
+  connector: Pick<Connector, 'id'>,
+  options: { includeWebAuthn?: boolean } = {},
+) {
+  return connector.id !== 'webAuthn' || options.includeWebAuthn === true
 }

--- a/src/lib/faucet-api.test.ts
+++ b/src/lib/faucet-api.test.ts
@@ -1,0 +1,105 @@
+import { Actions } from 'viem/tempo'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OPTIONS, POST } from '../pages/_api/api/faucet'
+
+vi.mock('viem/tempo', () => ({
+  Actions: {
+    faucet: {
+      fund: vi.fn(),
+    },
+  },
+}))
+
+const fund = vi.mocked(Actions.faucet.fund)
+
+describe('faucet API', () => {
+  beforeEach(() => {
+    fund.mockReset()
+  })
+
+  it.each([
+    ['missing address', {}],
+    ['empty address', { address: '' }],
+    ['missing 0x prefix', { address: 'beefcafe54750903ac1c8909323af7beb21ea2cb' }],
+    ['too short', { address: '0xbeefcafe54750903ac1c8909323af7beb21ea2c' }],
+    ['too long', { address: '0xbeefcafe54750903ac1c8909323af7beb21ea2cbb' }],
+    ['non-hex character', { address: '0xbeefcafe54750903ac1c8909323af7beb21ea2cg' }],
+  ])('rejects %s', async (_name, body) => {
+    const response = await POST(jsonRequest(body))
+
+    await expect(response.json()).resolves.toEqual({
+      data: null,
+      error: 'Invalid or missing address',
+    })
+    expect(response.status).toBe(400)
+    expect(fund).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid JSON', async () => {
+    const response = await POST(
+      new Request('https://docs.tempo.xyz/api/faucet', {
+        method: 'POST',
+        body: '{',
+      }),
+    )
+
+    await expect(response.json()).resolves.toEqual({
+      data: null,
+      error: 'Invalid request: could not parse JSON',
+    })
+    expect(response.status).toBe(400)
+    expect(fund).not.toHaveBeenCalled()
+  })
+
+  it('funds a valid address and normalizes it to lowercase', async () => {
+    fund.mockResolvedValueOnce(['0xhash1', '0xhash2'])
+
+    const response = await POST(
+      jsonRequest({ address: '0xBEEFcafe54750903ac1c8909323af7beb21ea2cb' }),
+    )
+
+    await expect(response.json()).resolves.toEqual({
+      data: [{ hash: '0xhash1' }, { hash: '0xhash2' }],
+      error: null,
+    })
+    expect(response.status).toBe(200)
+    expect(fund).toHaveBeenCalledTimes(1)
+    expect(fund).toHaveBeenCalledWith(expect.anything(), {
+      account: '0xbeefcafe54750903ac1c8909323af7beb21ea2cb',
+    })
+  })
+
+  it('allows docs and Vercel origins for CORS', async () => {
+    const docsResponse = await OPTIONS(requestWithOrigin('https://docs.tempo.xyz'))
+    const vercelResponse = await OPTIONS(requestWithOrigin('https://docs-git-branch.vercel.app'))
+
+    expect(docsResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://docs.tempo.xyz')
+    expect(vercelResponse.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://docs-git-branch.vercel.app',
+    )
+  })
+
+  it('does not allow arbitrary CORS origins', async () => {
+    const response = await OPTIONS(requestWithOrigin('https://example.com'))
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+})
+
+function jsonRequest(body: unknown) {
+  return new Request('https://docs.tempo.xyz/api/faucet', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      'content-type': 'application/json',
+      origin: 'https://docs.tempo.xyz',
+    },
+  })
+}
+
+function requestWithOrigin(origin: string) {
+  return new Request('https://docs.tempo.xyz/api/faucet', {
+    method: 'OPTIONS',
+    headers: { origin },
+  })
+}


### PR DESCRIPTION
## Summary

- Add end-to-end coverage for funding a connected passkey wallet from the faucet page
- Add API tests for faucet address validation, lowercase normalization, invalid JSON, and CORS behavior
- Share wallet connector detection so the faucet steps and balance footer use the same fundable-wallet logic
- Allow the e2e WebAuthn connector to exercise the wallet funding path without changing production connector filtering

## Motivation

The faucet wallet flow should keep showing an enabled add-funds action after a passkey wallet connects. The API should also reject malformed addresses, including short copied addresses, before attempting to fund.

## Key design considerations

- Keep production wallet filtering unchanged for raw WebAuthn connectors
- Scope WebAuthn inclusion to `VITE_E2E=true` so Playwright can use a virtual authenticator
- Keep API tests outside `src/pages` so Vocs does not treat Vitest files as routable page modules
- Reuse the same connector predicate across connect, funding, and balance display code