### PR TITLE
docs(exchange,fee-amm): clarify Exchange vs Fee AMM distinction

### DIFF
--- a/src/pages/docs/protocol/exchange/index.mdx
+++ b/src/pages/docs/protocol/exchange/index.mdx
@@ -10,6 +10,10 @@ Tempo features an enshrined decentralized exchange (DEX) designed specifically f
 
 The exchange operates as a singleton precompiled contract at address `0xdec0000000000000000000000000000000000000`. It maintains an orderbook with separate queues for each price tick, using price-time priority for order matching.
 
+:::info
+**Exchange vs. Fee AMM** — these are two different systems. The Exchange is the user-facing market: you (or your app) trade stablecoins at market prices via swaps and orders against an orderbook. The [Fee AMM](/docs/protocol/fees/fee-amm) is protocol fee-conversion liquidity: it converts users' transaction-fee payments into validators' preferred tokens at a fixed price through protocol-driven swaps, and is not a trading venue. See [Exchange vs. Fee AMM](#exchange-vs-fee-amm) below.
+:::
+
 Trading pairs are determined by each token's quote token. All TIP-20 tokens specify a quote token for trading on the exchange. See [Quote Tokens](/docs/protocol/exchange/quote-tokens) for more information on quote token selection and the optional [pathUSD](/docs/protocol/exchange/quote-tokens#pathusd) stablecoin. See the [Stablecoin DEX Specification](/docs/protocol/exchange/spec) for detailed information on the exchange structure.
 
 The exchange supports three types of orders, each with different execution behavior:
@@ -21,6 +25,21 @@ The exchange supports three types of orders, each with different execution behav
 | [**Market Orders**](/docs/protocol/exchange/executing-swaps#swap-functions) | Execute immediately against the best available orders in the book (via swap functions). Swaps and cancellations execute immediately within the transaction. |
 
 For the complete execution mechanics, see the [Stablecoin DEX Specification](/docs/protocol/exchange/spec).
+
+## Exchange vs. Fee AMM
+
+Tempo has two stablecoin-swapping systems that are easy to confuse. They serve different purposes:
+
+| | Exchange (DEX) | [Fee AMM](/docs/protocol/fees/fee-amm) |
+|---|---|---|
+| **Purpose** | User-facing stablecoin trading | Converting transaction fees into validators' preferred tokens |
+| **Who initiates swaps** | Users and apps | The protocol, automatically (plus arbitrageurs rebalancing) |
+| **Pricing** | Market-driven orderbook (price-time priority) | Fixed conversion price |
+| **Liquidity** | Limit and flip orders resting in the orderbook | LP deposits into per-pair fee pools |
+| **Contract** | Stablecoin DEX precompile (`0xdec0…0000`) | `FeeManager` precompile (`0xfeec…0000`) |
+| **Use it for** | Swaps, prices, orderbook depth, fills | Letting users pay fees in any stablecoin |
+
+If you want to **trade** stablecoins or read market data (pairs, swaps, orders, prices), use the Exchange. If you want to **enable fee payments** in your stablecoin or provide fee-conversion liquidity, see the [Fee AMM](/docs/protocol/fees/fee-amm).
 
 To get started with the exchange, explore these guides:
 

--- a/src/pages/docs/protocol/fees/fee-amm/index.mdx
+++ b/src/pages/docs/protocol/fees/fee-amm/index.mdx
@@ -8,6 +8,10 @@ import { Cards, Card } from 'vocs'
 
 The Fee AMM (Automated Market Maker) is a dedicated system for converting transaction fees between different stablecoins. It enables users to pay fees in any supported stablecoin while allowing validators to receive fees in their preferred token.
 
+:::info
+**Fee AMM vs. Exchange** — these are two different systems. The Fee AMM is protocol-driven: it converts transaction-fee payments into validators' preferred tokens at a fixed price, and only the protocol (and arbitrageurs rebalancing it) swaps against it — it is not a trading venue. For user-facing stablecoin trading (swaps, orders, prices, orderbook), use the [Exchange](/docs/protocol/exchange). See [Fee AMM vs. Exchange](#fee-amm-vs-exchange) below.
+:::
+
 ## How It Works
 
 When a user pays fees in a stablecoin that differs from the validator's preference, the Fee AMM automatically converts the payment:
@@ -17,6 +21,21 @@ When a user pays fees in a stablecoin that differs from the validator's preferen
 - **Liquidity providers earn**: 0.003 (0.3%) as fees
 
 This conversion happens automatically at the end of each block through batched swaps, preventing MEV attacks like sandwiching.
+
+## Fee AMM vs. Exchange
+
+Tempo has two stablecoin-swapping systems that are easy to confuse. They serve different purposes:
+
+| | [Exchange (DEX)](/docs/protocol/exchange) | Fee AMM |
+|---|---|---|
+| **Purpose** | User-facing stablecoin trading | Converting transaction fees into validators' preferred tokens |
+| **Who initiates swaps** | Users and apps | The protocol, automatically (plus arbitrageurs rebalancing) |
+| **Pricing** | Market-driven orderbook (price-time priority) | Fixed conversion price |
+| **Liquidity** | Limit and flip orders resting in the orderbook | LP deposits into per-pair fee pools |
+| **Contract** | Stablecoin DEX precompile (`0xdec0…0000`) | `FeeManager` precompile (`0xfeec…0000`) |
+| **Use it for** | Swaps, prices, orderbook depth, fills | Letting users pay fees in any stablecoin |
+
+If you want to **trade** stablecoins or read market data, use the [Exchange](/docs/protocol/exchange). If you want to **enable fee payments** in your stablecoin or provide fee-conversion liquidity, you're in the right place — continue below.
 
 ## Learn More
 


### PR DESCRIPTION
## What

Clarifies the difference between Tempo's two stablecoin-swapping systems, which are easy to confuse, directly in the protocol docs.

- **Exchange (DEX)** — the user-facing market: trade stablecoins at market prices via swaps and orders against an orderbook.
- **Fee AMM** — protocol fee-conversion liquidity: converts users' transaction-fee payments into validators' preferred tokens at a fixed price through protocol-driven swaps. Not a trading venue.

## Changes

- `src/pages/docs/protocol/exchange/index.mdx` — adds a disambiguation `:::info` callout and an **"Exchange vs. Fee AMM"** comparison table.
- `src/pages/docs/protocol/fees/fee-amm/index.mdx` — adds a mirrored callout and a **"Fee AMM vs. Exchange"** comparison table.

The table contrasts purpose, who initiates swaps, pricing (market orderbook vs. fixed), liquidity, contract address (`0xdec0…` DEX vs. `0xfeec…` FeeManager), and what to use each for, with cross-links between the pages.

## Verification

Both pages compile cleanly with Vocs' remark plugins (frontmatter, GFM tables, directives).
