### PR TITLE
docs(api): add Transactions & Transfers concept page

### DIFF
--- a/src/pages/api/transactions-and-transfers.mdx
+++ b/src/pages/api/transactions-and-transfers.mdx
@@ -5,15 +5,15 @@ description: Understand the Tempo API model for transactions and transfers.
 
 # Transactions, Transfers & Receipts
 
-Transactions, transfers, and receipts are the most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is what you submit to the chain, a **transfer** is a token movement that results from executing it, and a **receipt** is the record of that execution.
+Transactions, transfers, and receipts are the most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is what a user submits to the chain, a **transfer** is a token movement that results from executing it, and a **receipt** is the record of that execution.
 
 :::info
-**At a glance** — a transaction is what you *submit*; transfers and a receipt are what *happens* when it executes. One transaction can produce zero, one, or many token transfers, and exactly one receipt once it is mined. Use [`/v1/transactions`](/api/transactions) to inspect submitted transactions (add `include=receipt` for the outcome), and [`/v1/transfers`](/api/transfers) to list the token movements that resulted.
+**At a glance** — a transaction is what a user *submits*; transfers and a receipt are what *happens* when it executes. One transaction can produce zero, one, or many token transfers, and exactly one receipt once it is mined. Use [`/v1/transactions`](/api/transactions) to inspect submitted transactions (add `include=receipt` for the outcome), and [`/v1/transfers`](/api/transfers) to list the token movements that resulted.
 :::
 
 ## The model
 
-- A **transaction** is what you submit to Tempo: a signed envelope that moves value or calls a contract. It may produce zero, one, or many token transfers. Request `include=receipt` to see the execution outcome, or query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
+- A **transaction** is what a user submits to Tempo: a signed envelope that moves value or calls a contract. It may produce zero, one, or many token transfers. Request `include=receipt` to see the execution outcome, or query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
 - A **transfer** is an effect of transaction execution: a TIP-20 token moved from one account to another. Multiple transfers can come from a single transaction, and some transactions produce no transfers at all.
 - A **receipt** is the record of a transaction's execution: its success or failure, what it cost, and the event logs it emitted. There is exactly one receipt per mined transaction.
 
@@ -22,7 +22,7 @@ A transaction that calls a contract might emit several transfers (for example, a
 ```text
 ╭───────────────────────╮      produces 0..N       ╭───────────────────────╮
 │      Transaction      │ ───────────────────────▶ │       Transfer        │
-│   (what you submit)   │                          │ (observed token move) │
+│ (what a user submits) │                          │ (observed token move) │
 ╰───────────────────────╯                          ╰───────────────────────╯
             │                                                  │
             │ include=receipt                                  │ transactionHash
@@ -49,7 +49,7 @@ A pending transaction has no receipt yet — it appears once the transaction is 
 
 | | Transaction | Transfer | Receipt |
 | --- | --- | --- | --- |
-| **What it is** | Something you submit to the chain | A token movement caused by execution | The record of a transaction's execution |
+| **What it is** | Something a user submits to the chain | A token movement caused by execution | The record of a transaction's execution |
 | **Cardinality** | One per submission | Zero, one, or many per transaction | Exactly one per mined transaction |
 | **Endpoint** | [`/v1/transactions`](/api/transactions) | [`/v1/transfers`](/api/transfers) | `/v1/receipts` ([Transactions](/api/transactions)) |
 | **Use it for** | Inspecting submitted transactions, fees, and status | Tracking who received which tokens, and reconciling balances | Checking success/failure, gas, fees, and emitted logs |

--- a/src/pages/api/transactions-and-transfers.mdx
+++ b/src/pages/api/transactions-and-transfers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Transactions, Transfers & Receipts
-description: Understand the Tempo API model — a transaction is what you submit to the chain; a transfer is a token movement it produces; a receipt is the record of its execution.
+description: Understand the Tempo API model for transactions and transfers.
 ---
 
 # Transactions, Transfers & Receipts

--- a/src/pages/api/transactions-and-transfers.mdx
+++ b/src/pages/api/transactions-and-transfers.mdx
@@ -1,21 +1,20 @@
 ---
-title: Transactions, Transfers & Receipts
+title: Transactions & Transfers
 description: Understand the Tempo API model for transactions and transfers.
 ---
 
-# Transactions, Transfers & Receipts
+# Transactions & Transfers
 
-Transactions, transfers, and receipts are the most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is what a user submits to the chain, a **transfer** is a token movement that results from executing it, and a **receipt** is the record of that execution.
+Transactions and transfers are the two most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is what a user submits to the chain, while a **transfer** is a token movement that results from executing one.
 
 :::info
-**At a glance** — a transaction is what a user *submits*; transfers and a receipt are what *happens* when it executes. One transaction can produce zero, one, or many token transfers, and exactly one receipt once it is mined. Use [`/v1/transactions`](/api/transactions) to inspect submitted transactions (add `include=receipt` for the outcome), and [`/v1/transfers`](/api/transfers) to list the token movements that resulted.
+**Transactions vs. transfers** — a transaction is what a user *submits*; transfers are what *happens* when it executes. One transaction can produce zero, one, or many token transfers. Use [`/v1/transactions`](/api/transactions) to inspect submitted transactions and their outcomes, and [`/v1/transfers`](/api/transfers) to list the token movements that resulted.
 :::
 
 ## The model
 
-- A **transaction** is what a user submits to Tempo: a signed envelope that moves value or calls a contract. It may produce zero, one, or many token transfers. Request `include=receipt` to see the execution outcome, or query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
+- A **transaction** is what a user submits to Tempo: a signed envelope that moves value or calls a contract. It may produce zero, one, or many token transfers. Query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
 - A **transfer** is an effect of transaction execution: a TIP-20 token moved from one account to another. Multiple transfers can come from a single transaction, and some transactions produce no transfers at all.
-- A **receipt** is the record of a transaction's execution: its success or failure, what it cost, and the event logs it emitted. There is exactly one receipt per mined transaction.
 
 A transaction that calls a contract might emit several transfers (for example, a swap that moves tokens in and out), exactly one (a simple payment), or none (a contract call that updates state without moving tokens). Each transfer carries the `transactionHash` of the transaction that produced it, so you can always trace a movement back to the transaction that caused it.
 
@@ -24,35 +23,20 @@ A transaction that calls a contract might emit several transfers (for example, a
 │      Transaction      │ ───────────────────────▶ │       Transfer        │
 │ (what a user submits) │                          │ (observed token move) │
 ╰───────────────────────╯                          ╰───────────────────────╯
-            │                                                  │
-            │ include=receipt                                  │ transactionHash
-            ▼                                                  ▼
-   Receipt (execution record)                        resolves back to its transaction
+                                                               │
+                                                               │ transactionHash
+                                                               ▼
+                                                  resolves back to its transaction
 ```
-
-## Receipts
-
-A **receipt** is the record of executing a transaction. It exists only once the transaction is mined, and there is exactly one receipt per transaction. It answers *what happened when this ran*:
-
-- **`status`** — whether the transaction succeeded or reverted.
-- **`gasUsed`**, **`cumulativeGasUsed`**, **`effectiveGasPrice`** — what executing it cost.
-- **`feeAmount`**, **`feePayer`**, **`feeToken`** — the fee charged and who paid it (on Tempo, fees are paid in a USD stablecoin).
-- **`logs`** — the raw event logs emitted during execution. Token [transfers](/api/transfers) are decoded from these logs and served as their own resource, so you rarely need to parse logs yourself.
-
-A pending transaction has no receipt yet — it appears once the transaction is included in a block. There are three ways to read one:
-
-- Embed it on a transaction with `include=receipt` on [`/v1/transactions`](/api/transactions).
-- List receipts with `GET /v1/receipts` (under [Transactions](/api/transactions)).
-- Look up a single receipt by transaction hash with `GET /v1/receipts/{hash}`.
 
 ## When to use which
 
-| | Transaction | Transfer | Receipt |
-| --- | --- | --- | --- |
-| **What it is** | Something a user submits to the chain | A token movement caused by execution | The record of a transaction's execution |
-| **Cardinality** | One per submission | Zero, one, or many per transaction | Exactly one per mined transaction |
-| **Endpoint** | [`/v1/transactions`](/api/transactions) | [`/v1/transfers`](/api/transfers) | `/v1/receipts` ([Transactions](/api/transactions)) |
-| **Use it for** | Inspecting submitted transactions, fees, and status | Tracking who received which tokens, and reconciling balances | Checking success/failure, gas, fees, and emitted logs |
-| **Key link** | Its hash appears on every transfer and receipt it produced | `transactionHash` points back to its transaction | Keyed by the transaction hash it records |
+| | Transaction | Transfer |
+| --- | --- | --- |
+| **What it is** | Something a user submits to the chain | A token movement caused by execution |
+| **Cardinality** | One per submission | Zero, one, or many per transaction |
+| **Endpoint** | [`/v1/transactions`](/api/transactions) | [`/v1/transfers`](/api/transfers) |
+| **Use it for** | Inspecting submitted transactions, fees, and status | Tracking who received which tokens, and reconciling balances |
+| **Key link** | Its hash appears on every transfer it produced | `transactionHash` points back to its transaction |
 
-If you want to know **what was requested** — the call and its parameters — use [Transactions](/api/transactions). If you want to know **what tokens actually moved**, use [Transfers](/api/transfers). If you want to know **whether it succeeded and what it cost**, read the receipt via `include=receipt` or [`/v1/receipts`](/api/transactions).
+If you want to know **what was requested** — the call, its fees, and whether it succeeded — use [Transactions](/api/transactions). If you want to know **what tokens actually moved**, use [Transfers](/api/transfers).

--- a/src/pages/api/transactions-and-transfers.mdx
+++ b/src/pages/api/transactions-and-transfers.mdx
@@ -1,0 +1,42 @@
+---
+title: Transactions & Transfers
+description: Understand the Tempo API model for transactions and transfers — a transaction is the instruction submitted to the chain, a transfer is an observed token movement it produces.
+---
+
+# Transactions & Transfers
+
+Transactions and transfers are the two most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is an instruction submitted to the chain, while a **transfer** is a token movement that results from executing one.
+
+:::info
+**Transactions vs. transfers** — a transaction is what you *submit*; transfers are what *happens* when it executes. One transaction can produce zero, one, or many token transfers. Use [`/v1/transactions`](/api/transactions) to inspect submitted instructions and their outcomes, and [`/v1/transfers`](/api/transfers) to list the token movements that resulted.
+:::
+
+## The model
+
+- A **transaction** is the instruction submitted to Tempo: a signed envelope that moves value or calls a contract. It may produce zero, one, or many token transfers. Request `include=receipt` to see the execution outcome, or query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
+- A **transfer** is an effect of transaction execution: a TIP-20 token moved from one account to another. Multiple transfers can come from a single transaction, and some transactions produce no transfers at all.
+
+A transaction that calls a contract might emit several transfers (for example, a swap that moves tokens in and out), exactly one (a simple payment), or none (a contract call that updates state without moving tokens). Each transfer carries the `transactionHash` of the transaction that produced it, so you can always trace a movement back to its instruction.
+
+```text
+╭───────────────────────╮      produces 0..N       ╭───────────────────────╮
+│      Transaction       │ ───────────────────────▶ │       Transfer         │
+│ (instruction you send) │                          │ (observed token move)  │
+╰───────────────────────╯                          ╰───────────────────────╯
+         │                                                      │
+         │ include=receipt                                      │ transactionHash
+         ▼                                                      ▼
+   execution outcome                                 links back to its transaction
+```
+
+## When to use which
+
+| | Transaction | Transfer |
+| --- | --- | --- |
+| **What it is** | An instruction submitted to the chain | A token movement caused by execution |
+| **Cardinality** | One per submission | Zero, one, or many per transaction |
+| **Endpoint** | [`/v1/transactions`](/api/transactions) | [`/v1/transfers`](/api/transfers) |
+| **Use it for** | Inspecting submitted instructions, fees, status, and execution outcome (`include=receipt`) | Tracking who received which tokens, and reconciling balances |
+| **Key link** | Its hash appears on every transfer it produced | `transactionHash` points back to its transaction |
+
+If you want to know **what was requested** — the call, its fees, and whether it succeeded — use [Transactions](/api/transactions). If you want to know **what tokens actually moved**, use [Transfers](/api/transfers).

--- a/src/pages/api/transactions-and-transfers.mdx
+++ b/src/pages/api/transactions-and-transfers.mdx
@@ -1,42 +1,42 @@
 ---
 title: Transactions & Transfers
-description: Understand the Tempo API model for transactions and transfers — a transaction is the instruction submitted to the chain, a transfer is an observed token movement it produces.
+description: Understand the Tempo API model for transactions and transfers — a transaction is what you submit to the chain, a transfer is an observed token movement it produces.
 ---
 
 # Transactions & Transfers
 
-Transactions and transfers are the two most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is an instruction submitted to the chain, while a **transfer** is a token movement that results from executing one.
+Transactions and transfers are the two most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is what you submit to the chain, while a **transfer** is a token movement that results from executing one.
 
 :::info
-**Transactions vs. transfers** — a transaction is what you *submit*; transfers are what *happens* when it executes. One transaction can produce zero, one, or many token transfers. Use [`/v1/transactions`](/api/transactions) to inspect submitted instructions and their outcomes, and [`/v1/transfers`](/api/transfers) to list the token movements that resulted.
+**Transactions vs. transfers** — a transaction is what you *submit*; transfers are what *happens* when it executes. One transaction can produce zero, one, or many token transfers. Use [`/v1/transactions`](/api/transactions) to inspect submitted transactions and their outcomes, and [`/v1/transfers`](/api/transfers) to list the token movements that resulted.
 :::
 
 ## The model
 
-- A **transaction** is the instruction submitted to Tempo: a signed envelope that moves value or calls a contract. It may produce zero, one, or many token transfers. Request `include=receipt` to see the execution outcome, or query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
+- A **transaction** is what you submit to Tempo: a signed envelope that moves value or calls a contract. It may produce zero, one, or many token transfers. Request `include=receipt` to see the execution outcome, or query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
 - A **transfer** is an effect of transaction execution: a TIP-20 token moved from one account to another. Multiple transfers can come from a single transaction, and some transactions produce no transfers at all.
 
-A transaction that calls a contract might emit several transfers (for example, a swap that moves tokens in and out), exactly one (a simple payment), or none (a contract call that updates state without moving tokens). Each transfer carries the `transactionHash` of the transaction that produced it, so you can always trace a movement back to its instruction.
+A transaction that calls a contract might emit several transfers (for example, a swap that moves tokens in and out), exactly one (a simple payment), or none (a contract call that updates state without moving tokens). Each transfer carries the `transactionHash` of the transaction that produced it, so you can always trace a movement back to the transaction that caused it.
 
 ```text
 ╭───────────────────────╮      produces 0..N       ╭───────────────────────╮
-│      Transaction       │ ───────────────────────▶ │       Transfer         │
-│ (instruction you send) │                          │ (observed token move)  │
+│      Transaction      │ ───────────────────────▶ │       Transfer        │
+│   (what you submit)   │                          │ (observed token move) │
 ╰───────────────────────╯                          ╰───────────────────────╯
-         │                                                      │
-         │ include=receipt                                      │ transactionHash
-         ▼                                                      ▼
-   execution outcome                                 links back to its transaction
+            │                                                  │
+            │ include=receipt                                  │ transactionHash
+            ▼                                                  ▼
+   execution outcome                                  resolves back to its transaction
 ```
 
 ## When to use which
 
 | | Transaction | Transfer |
 | --- | --- | --- |
-| **What it is** | An instruction submitted to the chain | A token movement caused by execution |
+| **What it is** | Something you submit to the chain | A token movement caused by execution |
 | **Cardinality** | One per submission | Zero, one, or many per transaction |
 | **Endpoint** | [`/v1/transactions`](/api/transactions) | [`/v1/transfers`](/api/transfers) |
-| **Use it for** | Inspecting submitted instructions, fees, status, and execution outcome (`include=receipt`) | Tracking who received which tokens, and reconciling balances |
+| **Use it for** | Inspecting submitted transactions, fees, status, and execution outcome (`include=receipt`) | Tracking who received which tokens, and reconciling balances |
 | **Key link** | Its hash appears on every transfer it produced | `transactionHash` points back to its transaction |
 
 If you want to know **what was requested** — the call, its fees, and whether it succeeded — use [Transactions](/api/transactions). If you want to know **what tokens actually moved**, use [Transfers](/api/transfers).

--- a/src/pages/api/transactions-and-transfers.mdx
+++ b/src/pages/api/transactions-and-transfers.mdx
@@ -1,20 +1,21 @@
 ---
-title: Transactions & Transfers
-description: Understand the Tempo API model for transactions and transfers — a transaction is what you submit to the chain, a transfer is an observed token movement it produces.
+title: Transactions, Transfers & Receipts
+description: Understand the Tempo API model — a transaction is what you submit to the chain; a transfer is a token movement it produces; a receipt is the record of its execution.
 ---
 
-# Transactions & Transfers
+# Transactions, Transfers & Receipts
 
-Transactions and transfers are the two most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is what you submit to the chain, while a **transfer** is a token movement that results from executing one.
+Transactions, transfers, and receipts are the most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is what you submit to the chain, a **transfer** is a token movement that results from executing it, and a **receipt** is the record of that execution.
 
 :::info
-**Transactions vs. transfers** — a transaction is what you *submit*; transfers are what *happens* when it executes. One transaction can produce zero, one, or many token transfers. Use [`/v1/transactions`](/api/transactions) to inspect submitted transactions and their outcomes, and [`/v1/transfers`](/api/transfers) to list the token movements that resulted.
+**At a glance** — a transaction is what you *submit*; transfers and a receipt are what *happens* when it executes. One transaction can produce zero, one, or many token transfers, and exactly one receipt once it is mined. Use [`/v1/transactions`](/api/transactions) to inspect submitted transactions (add `include=receipt` for the outcome), and [`/v1/transfers`](/api/transfers) to list the token movements that resulted.
 :::
 
 ## The model
 
 - A **transaction** is what you submit to Tempo: a signed envelope that moves value or calls a contract. It may produce zero, one, or many token transfers. Request `include=receipt` to see the execution outcome, or query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
 - A **transfer** is an effect of transaction execution: a TIP-20 token moved from one account to another. Multiple transfers can come from a single transaction, and some transactions produce no transfers at all.
+- A **receipt** is the record of a transaction's execution: its success or failure, what it cost, and the event logs it emitted. There is exactly one receipt per mined transaction.
 
 A transaction that calls a contract might emit several transfers (for example, a swap that moves tokens in and out), exactly one (a simple payment), or none (a contract call that updates state without moving tokens). Each transfer carries the `transactionHash` of the transaction that produced it, so you can always trace a movement back to the transaction that caused it.
 
@@ -26,17 +27,32 @@ A transaction that calls a contract might emit several transfers (for example, a
             │                                                  │
             │ include=receipt                                  │ transactionHash
             ▼                                                  ▼
-   execution outcome                                  resolves back to its transaction
+   Receipt (execution record)                        resolves back to its transaction
 ```
+
+## Receipts
+
+A **receipt** is the record of executing a transaction. It exists only once the transaction is mined, and there is exactly one receipt per transaction. It answers *what happened when this ran*:
+
+- **`status`** — whether the transaction succeeded or reverted.
+- **`gasUsed`**, **`cumulativeGasUsed`**, **`effectiveGasPrice`** — what executing it cost.
+- **`feeAmount`**, **`feePayer`**, **`feeToken`** — the fee charged and who paid it (on Tempo, fees are paid in a USD stablecoin).
+- **`logs`** — the raw event logs emitted during execution. Token [transfers](/api/transfers) are decoded from these logs and served as their own resource, so you rarely need to parse logs yourself.
+
+A pending transaction has no receipt yet — it appears once the transaction is included in a block. There are three ways to read one:
+
+- Embed it on a transaction with `include=receipt` on [`/v1/transactions`](/api/transactions).
+- List receipts with `GET /v1/receipts` (under [Transactions](/api/transactions)).
+- Look up a single receipt by transaction hash with `GET /v1/receipts/{hash}`.
 
 ## When to use which
 
-| | Transaction | Transfer |
-| --- | --- | --- |
-| **What it is** | Something you submit to the chain | A token movement caused by execution |
-| **Cardinality** | One per submission | Zero, one, or many per transaction |
-| **Endpoint** | [`/v1/transactions`](/api/transactions) | [`/v1/transfers`](/api/transfers) |
-| **Use it for** | Inspecting submitted transactions, fees, status, and execution outcome (`include=receipt`) | Tracking who received which tokens, and reconciling balances |
-| **Key link** | Its hash appears on every transfer it produced | `transactionHash` points back to its transaction |
+| | Transaction | Transfer | Receipt |
+| --- | --- | --- | --- |
+| **What it is** | Something you submit to the chain | A token movement caused by execution | The record of a transaction's execution |
+| **Cardinality** | One per submission | Zero, one, or many per transaction | Exactly one per mined transaction |
+| **Endpoint** | [`/v1/transactions`](/api/transactions) | [`/v1/transfers`](/api/transfers) | `/v1/receipts` ([Transactions](/api/transactions)) |
+| **Use it for** | Inspecting submitted transactions, fees, and status | Tracking who received which tokens, and reconciling balances | Checking success/failure, gas, fees, and emitted logs |
+| **Key link** | Its hash appears on every transfer and receipt it produced | `transactionHash` points back to its transaction | Keyed by the transaction hash it records |
 
-If you want to know **what was requested** — the call, its fees, and whether it succeeded — use [Transactions](/api/transactions). If you want to know **what tokens actually moved**, use [Transfers](/api/transfers).
+If you want to know **what was requested** — the call and its parameters — use [Transactions](/api/transactions). If you want to know **what tokens actually moved**, use [Transfers](/api/transfers). If you want to know **whether it succeeded and what it cost**, read the receipt via `include=receipt` or [`/v1/receipts`](/api/transactions).

--- a/src/pages/api/transactions-and-transfers.mdx
+++ b/src/pages/api/transactions-and-transfers.mdx
@@ -38,5 +38,3 @@ A transaction that calls a contract might emit several transfers (for example, a
 | **Endpoint** | [`/v1/transactions`](/api/transactions) | [`/v1/transfers`](/api/transfers) |
 | **Use it for** | Inspecting submitted transactions, fees, and status | Tracking who received which tokens, and reconciling balances |
 | **Key link** | Its hash appears on every transfer it produced | `transactionHash` points back to its transaction |
-
-If you want to know **what was requested** — the call, its fees, and whether it succeeded — use [Transactions](/api/transactions). If you want to know **what tokens actually moved**, use [Transfers](/api/transfers).

--- a/src/pages/api/transactions.mdx
+++ b/src/pages/api/transactions.mdx
@@ -3,8 +3,6 @@ title: Transactions
 description: List and inspect transactions submitted to Tempo.
 ---
 
-import { OpenApi } from 'vocs'
-
 # Transactions
 
 A transaction is what a user submits to Tempo: a signed envelope that moves value or calls a contract. One transaction can produce zero, one, or many token [transfers](/api/transfers). Query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
@@ -12,5 +10,3 @@ A transaction is what a user submits to Tempo: a signed envelope that moves valu
 :::info
 See [Transactions & Transfers](/api/transactions-and-transfers) for how a transaction relates to the transfers it produces.
 :::
-
-<OpenApi.Endpoints path="/api" resource="transactions" />

--- a/src/pages/api/transactions.mdx
+++ b/src/pages/api/transactions.mdx
@@ -7,7 +7,7 @@ import { OpenApi } from 'vocs'
 
 # Transactions
 
-A transaction is what you submit to Tempo: a signed envelope that moves value or calls a contract. One transaction can produce zero, one, or many token [transfers](/api/transfers), and exactly one receipt once it is mined. Request `include=receipt` to embed the execution outcome, or read receipts with `GET /v1/receipts`.
+A transaction is what a user submits to Tempo: a signed envelope that moves value or calls a contract. One transaction can produce zero, one, or many token [transfers](/api/transfers), and exactly one receipt once it is mined. Request `include=receipt` to embed the execution outcome, or read receipts with `GET /v1/receipts`.
 
 :::info
 **New to the model?** See [Transactions, Transfers & Receipts](/api/transactions-and-transfers) for how a transaction relates to the transfers and receipt it produces.

--- a/src/pages/api/transactions.mdx
+++ b/src/pages/api/transactions.mdx
@@ -10,7 +10,7 @@ import { OpenApi } from 'vocs'
 A transaction is what a user submits to Tempo: a signed envelope that moves value or calls a contract. One transaction can produce zero, one, or many token [transfers](/api/transfers). Query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
 
 :::info
-**New to the model?** See [Transactions & Transfers](/api/transactions-and-transfers) for how a transaction relates to the transfers it produces.
+See [Transactions & Transfers](/api/transactions-and-transfers) for how a transaction relates to the transfers it produces.
 :::
 
 <OpenApi.Endpoints path="/api" resource="transactions" />

--- a/src/pages/api/transactions.mdx
+++ b/src/pages/api/transactions.mdx
@@ -1,16 +1,16 @@
 ---
 title: Transactions
-description: List and inspect transactions submitted to Tempo, along with their receipts — the record of each transaction's execution.
+description: List and inspect transactions submitted to Tempo.
 ---
 
 import { OpenApi } from 'vocs'
 
 # Transactions
 
-A transaction is what a user submits to Tempo: a signed envelope that moves value or calls a contract. One transaction can produce zero, one, or many token [transfers](/api/transfers), and exactly one receipt once it is mined. Request `include=receipt` to embed the execution outcome, or read receipts with `GET /v1/receipts`.
+A transaction is what a user submits to Tempo: a signed envelope that moves value or calls a contract. One transaction can produce zero, one, or many token [transfers](/api/transfers). Query [`/v1/transfers`](/api/transfers) to list the token movements it caused.
 
 :::info
-**New to the model?** See [Transactions, Transfers & Receipts](/api/transactions-and-transfers) for how a transaction relates to the transfers and receipt it produces.
+**New to the model?** See [Transactions & Transfers](/api/transactions-and-transfers) for how a transaction relates to the transfers it produces.
 :::
 
 <OpenApi.Endpoints path="/api" resource="transactions" />

--- a/src/pages/api/transactions.mdx
+++ b/src/pages/api/transactions.mdx
@@ -1,0 +1,16 @@
+---
+title: Transactions
+description: List and inspect transactions submitted to Tempo, along with their receipts — the record of each transaction's execution.
+---
+
+import { OpenApi } from 'vocs'
+
+# Transactions
+
+A transaction is what you submit to Tempo: a signed envelope that moves value or calls a contract. One transaction can produce zero, one, or many token [transfers](/api/transfers), and exactly one receipt once it is mined. Request `include=receipt` to embed the execution outcome, or read receipts with `GET /v1/receipts`.
+
+:::info
+**New to the model?** See [Transactions, Transfers & Receipts](/api/transactions-and-transfers) for how a transaction relates to the transfers and receipt it produces.
+:::
+
+<OpenApi.Endpoints path="/api" resource="transactions" />

--- a/src/pages/api/transfers.mdx
+++ b/src/pages/api/transfers.mdx
@@ -1,0 +1,16 @@
+---
+title: Transfers
+description: List token transfer events across Tempo — the token movements produced by executing transactions.
+---
+
+import { OpenApi } from 'vocs'
+
+# Transfers
+
+A transfer is an effect of executing a [transaction](/api/transactions): a TIP-20 token moved from one account to another, optionally with a payment memo. Multiple transfers can come from one transaction, and some transactions produce none; each transfer links back to its transaction via `transactionHash`.
+
+:::info
+**New to the model?** See [Transactions, Transfers & Receipts](/api/transactions-and-transfers) for how a transfer relates to the transaction that produced it.
+:::
+
+<OpenApi.Endpoints path="/api" resource="transfers" />

--- a/src/pages/api/transfers.mdx
+++ b/src/pages/api/transfers.mdx
@@ -10,7 +10,7 @@ import { OpenApi } from 'vocs'
 A transfer is an effect of executing a [transaction](/api/transactions): a TIP-20 token moved from one account to another, optionally with a payment memo. Multiple transfers can come from one transaction, and some transactions produce none; each transfer links back to its transaction via `transactionHash`.
 
 :::info
-**New to the model?** See [Transactions & Transfers](/api/transactions-and-transfers) for how a transfer relates to the transaction that produced it.
+See [Transactions & Transfers](/api/transactions-and-transfers) for how a transfer relates to the transaction that produced it.
 :::
 
 <OpenApi.Endpoints path="/api" resource="transfers" />

--- a/src/pages/api/transfers.mdx
+++ b/src/pages/api/transfers.mdx
@@ -3,8 +3,6 @@ title: Transfers
 description: List token transfer events across Tempo — the token movements produced by executing transactions.
 ---
 
-import { OpenApi } from 'vocs'
-
 # Transfers
 
 A transfer is an effect of executing a [transaction](/api/transactions): a TIP-20 token moved from one account to another, optionally with a payment memo. Multiple transfers can come from one transaction, and some transactions produce none; each transfer links back to its transaction via `transactionHash`.
@@ -12,5 +10,3 @@ A transfer is an effect of executing a [transaction](/api/transactions): a TIP-2
 :::info
 See [Transactions & Transfers](/api/transactions-and-transfers) for how a transfer relates to the transaction that produced it.
 :::
-
-<OpenApi.Endpoints path="/api" resource="transfers" />

--- a/src/pages/api/transfers.mdx
+++ b/src/pages/api/transfers.mdx
@@ -10,7 +10,7 @@ import { OpenApi } from 'vocs'
 A transfer is an effect of executing a [transaction](/api/transactions): a TIP-20 token moved from one account to another, optionally with a payment memo. Multiple transfers can come from one transaction, and some transactions produce none; each transfer links back to its transaction via `transactionHash`.
 
 :::info
-**New to the model?** See [Transactions, Transfers & Receipts](/api/transactions-and-transfers) for how a transfer relates to the transaction that produced it.
+**New to the model?** See [Transactions & Transfers](/api/transactions-and-transfers) for how a transfer relates to the transaction that produced it.
 :::
 
 <OpenApi.Endpoints path="/api" resource="transfers" />

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -127,6 +127,10 @@ export default defineConfig({
             link: '/api/conventions',
           },
           {
+            text: 'Transactions & Transfers',
+            link: '/api/transactions-and-transfers',
+          },
+          {
             text: 'JSON-RPC API',
             link: '/api/json-rpc',
           },

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -127,7 +127,7 @@ export default defineConfig({
             link: '/api/conventions',
           },
           {
-            text: 'Transactions, Transfers & Receipts',
+            text: 'Transactions & Transfers',
             link: '/api/transactions-and-transfers',
           },
           {

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -127,7 +127,7 @@ export default defineConfig({
             link: '/api/conventions',
           },
           {
-            text: 'Transactions & Transfers',
+            text: 'Transactions, Transfers & Receipts',
             link: '/api/transactions-and-transfers',
           },
           {


### PR DESCRIPTION
## Why

The API reference has separate **Transactions** and **Transfers** sections, and from reading the docs the distinction wasn't obvious. We deliberately kept the per-endpoint descriptions short (see cadent #210) and moved the holistic conceptual model here.

## What

Adds a new **Transactions & Transfers** concept page to the API reference (`/api/transactions-and-transfers`), placed right after Conventions in the sidebar. It explains:

- A **transaction** is the instruction submitted to the chain; it may produce zero, one, or many token transfers (`include=receipt` for the outcome).
- A **transfer** is an effect of execution: a TIP-20 token moved between accounts, linking back to its transaction via `transactionHash`.
- A relationship diagram and a "when to use which" comparison table, cross-linking to the `/api/transactions` and `/api/transfers` operation pages.

Follows the same disambiguation pattern as #563 (Exchange vs. Fee AMM).

## Verification

- `vite build` succeeds; the page and both link targets (`/api/transactions`, `/api/transfers`) generate correctly
- Uses the repo's ` ```text ` convention for the ASCII diagram
