### PR TITLE
fix: keep faucet wallet controls enabled

### DIFF
--- a/src/components/guides/steps/wallet/AddTokensToWallet.tsx
+++ b/src/components/guides/steps/wallet/AddTokensToWallet.tsx
@@ -1,6 +1,7 @@
 'use client'
 import * as React from 'react'
-import { useConnection, useWatchAsset } from 'wagmi'
+import { useConnections, useWatchAsset } from 'wagmi'
+import { isFundableWalletConnector } from '../../../lib/wallets'
 import { Button, Step } from '../../Demo'
 import { alphaUsd, betaUsd, pathUsd, thetaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -57,10 +58,12 @@ function AddTokenButton(props: {
 
 export function AddTokensToWallet(props: DemoStepProps) {
   const { stepNumber = 3, last = false } = props
-  const { address, connector } = useConnection()
-  const hasNonWebAuthnWallet = Boolean(
-    address && connector?.id !== 'webAuthn' && connector?.id !== 'xyz.tempo',
+  const isE2E = import.meta.env.VITE_E2E === 'true'
+  const connections = useConnections()
+  const walletConnection = connections.find((c) =>
+    isFundableWalletConnector(c.connector, { includeWebAuthn: isE2E }),
   )
+  const hasNonWebAuthnWallet = Boolean(walletConnection?.accounts[0])
 
   const [addedTokens, setAddedTokens] = React.useState<Set<string>>(new Set())
   const [expanded, setExpanded] = React.useState(false)

--- a/src/components/guides/steps/wallet/ConnectWallet.tsx
+++ b/src/components/guides/steps/wallet/ConnectWallet.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import {
   useChains,
   useConnect,
-  useConnection,
   useConnections,
   useConnectors,
   useDisconnect,
@@ -18,7 +17,6 @@ import type { DemoStepProps } from '../types'
 export function ConnectWallet(props: DemoStepProps) {
   const { stepNumber = 1 } = props
   const isE2E = import.meta.env.VITE_E2E === 'true'
-  const { chain, connector } = useConnection()
   const connections = useConnections()
   const connect = useConnect()
   const disconnect = useDisconnect()
@@ -29,7 +27,6 @@ export function ConnectWallet(props: DemoStepProps) {
   )
   const switchChain = useSwitchChain()
   const chains = useChains()
-  const isSupported = chains.some((c) => c.id === chain?.id)
   const [copied, copyToClipboard] = useCopyToClipboard()
 
   const walletConnection = connections.find((c) =>
@@ -37,6 +34,7 @@ export function ConnectWallet(props: DemoStepProps) {
   )
   const walletAddress = walletConnection?.accounts[0]
   const walletConnector = walletConnection?.connector
+  const isSupported = chains.some((c) => c.id === walletConnection?.chainId)
   const hasNonWebAuthnWallet = Boolean(walletAddress)
   const active = !hasNonWebAuthnWallet || !isSupported
   const completed = hasNonWebAuthnWallet && isSupported
@@ -118,12 +116,12 @@ export function ConnectWallet(props: DemoStepProps) {
               })
             }
           >
-            Add Tempo to {connector?.name ?? 'Wallet'}
+            Add Tempo to {walletConnector?.name ?? 'Wallet'}
           </Button>
         )}
         {switchChain.isSuccess && (
           <div className="flex items-center font-normal text-[14px] -tracking-[2%]">
-            Added Tempo to {connector?.name ?? 'Wallet'}!
+            Added Tempo to {walletConnector?.name ?? 'Wallet'}!
           </div>
         )}
       </div>
@@ -136,7 +134,6 @@ export function ConnectWallet(props: DemoStepProps) {
     copied,
     copyToClipboard,
     disconnect,
-    connector,
     connect,
     isSupported,
     switchChain,

--- a/src/components/guides/steps/wallet/SetFeeToken.tsx
+++ b/src/components/guides/steps/wallet/SetFeeToken.tsx
@@ -1,8 +1,9 @@
 'use client'
 import * as React from 'react'
 import { type Address, isAddress } from 'viem'
-import { useChainId, useConfig, useConnection } from 'wagmi'
+import { useChainId, useConfig, useConnections } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
+import { isFundableWalletConnector } from '../../../lib/wallets'
 import { Button, ExplorerLink, Step, StringFormatter } from '../../Demo'
 import { alphaUsd, betaUsd, thetaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -26,10 +27,13 @@ const DEFAULT_FEE_TOKEN_OPTION = FEE_TOKEN_OPTIONS[0]
 
 export function SetFeeToken(props: DemoStepProps) {
   const { stepNumber = 1 } = props
-  const { address, connector } = useConnection()
-  const hasNonWebAuthnWallet = Boolean(
-    address && connector?.id !== 'webAuthn' && connector?.id !== 'xyz.tempo',
+  const isE2E = import.meta.env.VITE_E2E === 'true'
+  const connections = useConnections()
+  const walletConnection = connections.find((c) =>
+    isFundableWalletConnector(c.connector, { includeWebAuthn: isE2E }),
   )
+  const address = walletConnection?.accounts[0]
+  const hasNonWebAuthnWallet = Boolean(address)
   const chainId = useChainId()
   const config = useConfig()
 

--- a/src/components/lib/wallets.test.ts
+++ b/src/components/lib/wallets.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { isFundableWalletConnector } from './wallets'
+
+describe('isFundableWalletConnector', () => {
+  it.each([
+    ['injected', true],
+    ['io.metamask', true],
+    ['webAuthn', false],
+    ['xyz.tempo', false],
+  ])('returns %s fundable wallet status as %s', (connectorId, expected) => {
+    expect(isFundableWalletConnector({ id: connectorId })).toBe(expected)
+  })
+
+  it('allows WebAuthn only when requested for e2e', () => {
+    expect(isFundableWalletConnector({ id: 'webAuthn' }, { includeWebAuthn: true })).toBe(true)
+  })
+})

--- a/src/components/lib/wallets.ts
+++ b/src/components/lib/wallets.ts
@@ -2,6 +2,11 @@ import type { Connector } from 'wagmi'
 
 const UNSUPPORTED_WALLET_IDS = new Set(['app.phantom'])
 const UNSUPPORTED_WALLET_NAMES = new Set(['Phantom'])
+const TEMPO_MANAGED_WALLET_IDS = new Set(['webAuthn', 'xyz.tempo'])
+
+export function isBrowserWalletConnectorId(connectorId: string) {
+  return !TEMPO_MANAGED_WALLET_IDS.has(connectorId)
+}
 
 export function filterSupportedInjectedConnectors(
   connectors: readonly Connector[],
@@ -9,7 +14,7 @@ export function filterSupportedInjectedConnectors(
 ) {
   const seen = new Set<string>()
   return connectors.filter((connector) => {
-    if (connector.id === 'webAuthn' && !options.includeWebAuthn) return false
+    if (!isFundableWalletConnector(connector, options)) return false
     if (UNSUPPORTED_WALLET_IDS.has(connector.id)) return false
     if (UNSUPPORTED_WALLET_NAMES.has(connector.name)) return false
     if (seen.has(connector.id)) return false
@@ -22,5 +27,6 @@ export function isFundableWalletConnector(
   connector: Pick<Connector, 'id'>,
   options: { includeWebAuthn?: boolean } = {},
 ) {
-  return connector.id !== 'webAuthn' || options.includeWebAuthn === true
+  if (connector.id === 'webAuthn') return options.includeWebAuthn === true
+  return isBrowserWalletConnectorId(connector.id)
 }


### PR DESCRIPTION
## Summary

- Use the browser wallet connection consistently across faucet wallet steps.
- Exclude Tempo-managed wallet connectors from injected wallet selection.
- Add coverage for browser wallet connector detection.

## Motivation

The faucet wallet flow could show connected and funded state while leaving later wallet actions disabled because different steps read different active connection sources.

## Key design considerations

- Reuses a shared connector predicate to keep step behavior consistent.
- Keeps Tempo Wallet and WebAuthn connections separate from browser wallet actions.