### PR TITLE
fix: restore faucet wallet options

### DIFF
--- a/e2e/faucet.test.ts
+++ b/e2e/faucet.test.ts
@@ -50,7 +50,7 @@ test('fund a connected passkey wallet via faucet', async ({ page }) => {
 
     const connectStep = page
       .locator('[data-active][data-completed]')
-      .filter({ hasText: 'Connect your browser wallet.' })
+      .filter({ hasText: 'Connect your wallet.' })
       .first()
     const connectButton = connectStep.getByRole('button').first()
     await expect(connectButton).toBeVisible({ timeout: 30000 })

--- a/src/components/guides/steps/wallet/AddTokensToWallet.tsx
+++ b/src/components/guides/steps/wallet/AddTokensToWallet.tsx
@@ -1,7 +1,7 @@
 'use client'
 import * as React from 'react'
 import { useConnections, useWatchAsset } from 'wagmi'
-import { isFundableWalletConnector } from '../../../lib/wallets'
+import { isBrowserWalletConnectorId } from '../../../lib/wallets'
 import { Button, Step } from '../../Demo'
 import { alphaUsd, betaUsd, pathUsd, thetaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -58,11 +58,8 @@ function AddTokenButton(props: {
 
 export function AddTokensToWallet(props: DemoStepProps) {
   const { stepNumber = 3, last = false } = props
-  const isE2E = import.meta.env.VITE_E2E === 'true'
   const connections = useConnections()
-  const walletConnection = connections.find((c) =>
-    isFundableWalletConnector(c.connector, { includeWebAuthn: isE2E }),
-  )
+  const walletConnection = connections.find((c) => isBrowserWalletConnectorId(c.connector.id))
   const hasNonWebAuthnWallet = Boolean(walletConnection?.accounts[0])
 
   const [addedTokens, setAddedTokens] = React.useState<Set<string>>(new Set())

--- a/src/components/guides/steps/wallet/ConnectWallet.tsx
+++ b/src/components/guides/steps/wallet/ConnectWallet.tsx
@@ -1,6 +1,7 @@
 'use client'
 import * as React from 'react'
 import {
+  type Connector,
   useChains,
   useConnect,
   useConnections,
@@ -10,7 +11,10 @@ import {
 } from 'wagmi'
 import LucideCheck from '~icons/lucide/check'
 import LucideWalletCards from '~icons/lucide/wallet-cards'
-import { filterSupportedInjectedConnectors, isFundableWalletConnector } from '../../../lib/wallets'
+import {
+  filterSupportedFundableWalletConnectors,
+  isFundableWalletConnector,
+} from '../../../lib/wallets'
 import { Button, Step, StringFormatter, useCopyToClipboard } from '../../Demo'
 import type { DemoStepProps } from '../types'
 
@@ -21,8 +25,9 @@ export function ConnectWallet(props: DemoStepProps) {
   const connect = useConnect()
   const disconnect = useDisconnect()
   const connectors = useConnectors()
-  const injectedConnectors = React.useMemo(
-    () => filterSupportedInjectedConnectors(connectors, { includeWebAuthn: isE2E }),
+  const [connectError, setConnectError] = React.useState<Error | null>(null)
+  const fundableConnectors = React.useMemo(
+    () => filterSupportedFundableWalletConnectors(connectors, { includeWebAuthn: isE2E }),
     [connectors],
   )
   const switchChain = useSwitchChain()
@@ -39,31 +44,40 @@ export function ConnectWallet(props: DemoStepProps) {
   const active = !hasNonWebAuthnWallet || !isSupported
   const completed = hasNonWebAuthnWallet && isSupported
 
+  const handleConnect = React.useCallback(
+    async (connector: Connector) => {
+      setConnectError(null)
+      try {
+        await disconnect.disconnectAsync().catch(() => {})
+        await connect.connectAsync({
+          connector,
+          ...(isE2E && connector.id === 'webAuthn'
+            ? { capabilities: { method: 'register' as const, name: 'Tempo Docs' } }
+            : {}),
+        })
+      } catch (error) {
+        setConnectError(error instanceof Error ? error : new Error('Failed to connect wallet.'))
+      }
+    },
+    [connect.connectAsync, disconnect.disconnectAsync],
+  )
+
   const actions = React.useMemo(() => {
-    if (!injectedConnectors.length) {
-      return (
-        <div className="flex items-center text-[14px] -tracking-[2%]">
-          No browser wallets found.
-        </div>
-      )
+    if (!fundableConnectors.length) {
+      return <div className="flex items-center text-[14px] -tracking-[2%]">No wallets found.</div>
     }
 
     if (!hasNonWebAuthnWallet) {
       return (
         <div className="flex flex-wrap justify-center gap-2">
-          {injectedConnectors.map((conn) => (
+          {fundableConnectors.map((conn) => (
             <Button
               variant="default"
               className="flex items-center gap-1.5"
               key={conn.id}
-              onClick={() =>
-                connect.connect({
-                  connector: conn,
-                  ...(isE2E && conn.id === 'webAuthn'
-                    ? { capabilities: { method: 'register' as const, name: 'Tempo Docs' } }
-                    : {}),
-                })
-              }
+              disabled={connect.isPending}
+              onClick={() => void handleConnect(conn)}
+              type="button"
             >
               {conn.icon ? <img className="size-5" src={conn.icon} alt={conn.name} /> : <div />}
               {conn.name}
@@ -127,27 +141,29 @@ export function ConnectWallet(props: DemoStepProps) {
       </div>
     )
   }, [
-    injectedConnectors,
+    fundableConnectors,
     hasNonWebAuthnWallet,
     walletAddress,
     walletConnector,
     copied,
     copyToClipboard,
     disconnect,
-    connect,
+    connect.isPending,
+    handleConnect,
     isSupported,
     switchChain,
     chains,
   ])
 
-  const stackConnectors = injectedConnectors.length > 2
+  const stackConnectors = fundableConnectors.length > 2
 
   return (
     <Step
       active={active}
       completed={completed}
+      error={connectError ?? connect.error}
       number={stepNumber}
-      title="Connect your browser wallet."
+      title="Connect your wallet."
       actions={!stackConnectors && actions}
     >
       {stackConnectors && actions}

--- a/src/components/guides/steps/wallet/SetFeeToken.tsx
+++ b/src/components/guides/steps/wallet/SetFeeToken.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { type Address, isAddress } from 'viem'
 import { useChainId, useConfig, useConnections } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
-import { isFundableWalletConnector } from '../../../lib/wallets'
+import { isBrowserWalletConnectorId } from '../../../lib/wallets'
 import { Button, ExplorerLink, Step, StringFormatter } from '../../Demo'
 import { alphaUsd, betaUsd, thetaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -27,11 +27,8 @@ const DEFAULT_FEE_TOKEN_OPTION = FEE_TOKEN_OPTIONS[0]
 
 export function SetFeeToken(props: DemoStepProps) {
   const { stepNumber = 1 } = props
-  const isE2E = import.meta.env.VITE_E2E === 'true'
   const connections = useConnections()
-  const walletConnection = connections.find((c) =>
-    isFundableWalletConnector(c.connector, { includeWebAuthn: isE2E }),
-  )
+  const walletConnection = connections.find((c) => isBrowserWalletConnectorId(c.connector.id))
   const address = walletConnection?.accounts[0]
   const hasNonWebAuthnWallet = Boolean(address)
   const chainId = useChainId()

--- a/src/components/lib/wallets.test.ts
+++ b/src/components/lib/wallets.test.ts
@@ -1,17 +1,76 @@
 import { describe, expect, it } from 'vitest'
-import { isFundableWalletConnector } from './wallets'
+import type { Connector } from 'wagmi'
+import {
+  filterSupportedFundableWalletConnectors,
+  filterSupportedInjectedConnectors,
+  isBrowserWalletConnectorId,
+  isFundableWalletConnector,
+} from './wallets'
+
+const connectors = [
+  { id: 'injected', name: 'Injected Wallet' },
+  { id: 'io.metamask', name: 'MetaMask' },
+  { id: 'webAuthn', name: 'Passkey' },
+  { id: 'xyz.tempo', name: 'Tempo Wallet' },
+  { id: 'app.phantom', name: 'Phantom' },
+  { id: 'injected', name: 'Injected Wallet Duplicate' },
+] as Connector[]
 
 describe('isFundableWalletConnector', () => {
   it.each([
     ['injected', true],
     ['io.metamask', true],
     ['webAuthn', false],
-    ['xyz.tempo', false],
+    ['xyz.tempo', true],
   ])('returns %s fundable wallet status as %s', (connectorId, expected) => {
     expect(isFundableWalletConnector({ id: connectorId })).toBe(expected)
   })
 
   it('allows WebAuthn only when requested for e2e', () => {
     expect(isFundableWalletConnector({ id: 'webAuthn' }, { includeWebAuthn: true })).toBe(true)
+  })
+})
+
+describe('isBrowserWalletConnectorId', () => {
+  it.each([
+    ['injected', true],
+    ['io.metamask', true],
+    ['webAuthn', false],
+    ['xyz.tempo', false],
+  ])('returns %s browser wallet status as %s', (connectorId, expected) => {
+    expect(isBrowserWalletConnectorId(connectorId)).toBe(expected)
+  })
+})
+
+describe('filterSupportedInjectedConnectors', () => {
+  it('keeps only supported browser wallets by default', () => {
+    expect(filterSupportedInjectedConnectors(connectors).map((connector) => connector.id)).toEqual([
+      'injected',
+      'io.metamask',
+    ])
+  })
+
+  it('allows WebAuthn only when requested for e2e', () => {
+    expect(
+      filterSupportedInjectedConnectors(connectors, { includeWebAuthn: true }).map(
+        (connector) => connector.id,
+      ),
+    ).toEqual(['injected', 'io.metamask', 'webAuthn'])
+  })
+})
+
+describe('filterSupportedFundableWalletConnectors', () => {
+  it('keeps supported faucet-fundable wallets by default', () => {
+    expect(
+      filterSupportedFundableWalletConnectors(connectors).map((connector) => connector.id),
+    ).toEqual(['injected', 'io.metamask', 'xyz.tempo'])
+  })
+
+  it('allows WebAuthn only when requested for e2e', () => {
+    expect(
+      filterSupportedFundableWalletConnectors(connectors, { includeWebAuthn: true }).map(
+        (connector) => connector.id,
+      ),
+    ).toEqual(['injected', 'io.metamask', 'webAuthn', 'xyz.tempo'])
   })
 })

--- a/src/components/lib/wallets.ts
+++ b/src/components/lib/wallets.ts
@@ -8,13 +8,13 @@ export function isBrowserWalletConnectorId(connectorId: string) {
   return !TEMPO_MANAGED_WALLET_IDS.has(connectorId)
 }
 
-export function filterSupportedInjectedConnectors(
+function filterSupportedConnectors(
   connectors: readonly Connector[],
-  options: { includeWebAuthn?: boolean } = {},
+  isSupported: (connector: Connector) => boolean,
 ) {
   const seen = new Set<string>()
   return connectors.filter((connector) => {
-    if (!isFundableWalletConnector(connector, options)) return false
+    if (!isSupported(connector)) return false
     if (UNSUPPORTED_WALLET_IDS.has(connector.id)) return false
     if (UNSUPPORTED_WALLET_NAMES.has(connector.name)) return false
     if (seen.has(connector.id)) return false
@@ -23,10 +23,29 @@ export function filterSupportedInjectedConnectors(
   })
 }
 
+export function filterSupportedInjectedConnectors(
+  connectors: readonly Connector[],
+  options: { includeWebAuthn?: boolean } = {},
+) {
+  return filterSupportedConnectors(connectors, (connector) => {
+    if (connector.id === 'webAuthn') return options.includeWebAuthn === true
+    return isBrowserWalletConnectorId(connector.id)
+  })
+}
+
+export function filterSupportedFundableWalletConnectors(
+  connectors: readonly Connector[],
+  options: { includeWebAuthn?: boolean } = {},
+) {
+  return filterSupportedConnectors(connectors, (connector) =>
+    isFundableWalletConnector(connector, options),
+  )
+}
+
 export function isFundableWalletConnector(
   connector: Pick<Connector, 'id'>,
   options: { includeWebAuthn?: boolean } = {},
 ) {
   if (connector.id === 'webAuthn') return options.includeWebAuthn === true
-  return isBrowserWalletConnectorId(connector.id)
+  return true
 }


### PR DESCRIPTION
## Summary

- Restore Tempo Wallet as a valid faucet wallet option alongside injected wallets.
- Keep token-list and fee-token steps scoped to injected browser wallets.
- Update faucet copy and tests to reflect generic wallet support.

## Motivation

The faucet wallet flow should fund either Tempo Wallet or injected wallets, while EVM-specific follow-up actions should only target injected wallets.

## Key design considerations

- Keeps the shared fundable-wallet helper broad enough for Tempo Wallet and injected wallets.
- Uses the browser-wallet helper only for wallet-watchAsset and fee-token actions.