### PR TITLE
fix(perf): clarify benchmark vs live figures and payment-lane chart

### DIFF
--- a/src/marketing/app/performance/_components/PaymentLanes.tsx
+++ b/src/marketing/app/performance/_components/PaymentLanes.tsx
@@ -7,10 +7,16 @@ import { linePath, scaleLinear } from '../_lib/chart'
 import { fmtInt, type PerfRun } from '../_lib/runs'
 import useMeasure from './useMeasure'
 
-// The payment-lanes story, told with real data: the chart is split into two
-// always-visible bands. General blockspace carries the actual settled-TPS
-// series from the nightly feed (tens of thousands of TPS); the dedicated
-// payment lane below has tiny sub-cent fee movement, with pulses flowing along it.
+// The payment-lanes story: the chart is split into two always-visible bands to
+// show that payments ride in reserved blockspace. The top band carries the real
+// settled-TPS series from the nightly feed — general network load that rises and
+// falls. The bottom band is the dedicated payment lane, drawn as a steady
+// reserved rail with transfer pulses flowing along it: payments keep moving no
+// matter how busy the rest of the network gets.
+//
+// Tempo fees are a fixed base fee (not congestion-priced), so this chart
+// deliberately shows NO fee curve — a flat-vs-volatile fee comparison would
+// wrongly imply a dynamic, load-based fee market that Tempo does not have.
 
 // No y-axis on this chart, so the bands run flush to the container's left
 // edge; the right padding is the lane for the pinned end labels. On mobile that
@@ -19,7 +25,7 @@ const PAD = { l: 0, r: 150, t: 20, b: 24 }
 const MOBILE_BP = 480
 const H = 300
 const DIVIDER = 190
-const FEE_Y = (DIVIDER + H - PAD.b) / 2 + 6
+const LANE_Y = (DIVIDER + H - PAD.b) / 2 + 6
 const DRAW_MS = 900
 
 export default function PaymentLanes({ runs }: { runs: PerfRun[] }) {
@@ -60,14 +66,12 @@ export default function PaymentLanes({ runs }: { runs: PerfRun[] }) {
   const yAt = scaleLinear([min * 0.92, max * 1.08], [DIVIDER - 14, PAD.t + 34])
   const loadPts = values.map((v, i) => [xAt(i), yAt(v)] as [number, number])
   const loadEndY = hasData ? loadPts[loadPts.length - 1][1] : 0
-  const feePointCount = Math.max(values.length, 16)
-  const feeXAt = scaleLinear([0, feePointCount - 1], [PAD.l, endX])
-  const feePts = Array.from(
-    { length: feePointCount },
-    (_, i) =>
-      [feeXAt(i), FEE_Y + Math.sin(i * 1.7) * 1.15 + Math.sin(i * 0.55) * 0.55] as [number, number],
-  )
-  const feeEndY = feePts[feePts.length - 1]?.[1] ?? FEE_Y
+  // The payment lane is a steady reserved rail — a straight line, not a data
+  // series — with pulses flowing along it to show payments always moving.
+  const lanePts: [number, number][] = [
+    [PAD.l, LANE_Y],
+    [endX, LANE_Y],
+  ]
 
   return (
     <div ref={ref} className="relative w-full" style={{ height: H }}>
@@ -87,7 +91,7 @@ export default function PaymentLanes({ runs }: { runs: PerfRun[] }) {
             y={PAD.t + 18}
             className="fill-foreground/35 font-mono text-[10px] tracking-wider"
           >
-            GENERAL BLOCKSPACE · SHARED LOAD
+            NETWORK LOAD · NIGHTLY TPS
           </text>
 
           {/* Dedicated payment lane zone. */}
@@ -106,7 +110,7 @@ export default function PaymentLanes({ runs }: { runs: PerfRun[] }) {
             fillOpacity="0.8"
             className="font-mono text-[10px] tracking-wider"
           >
-            DEDICATED PAYMENT LANE
+            DEDICATED PAYMENT LANE · RESERVED BLOCKSPACE
           </text>
 
           <line
@@ -146,14 +150,16 @@ export default function PaymentLanes({ runs }: { runs: PerfRun[] }) {
                   transition: `opacity 250ms ease-out ${DRAW_MS}ms`,
                 }}
               >
-                {fmtInt(values[values.length - 1])} TPS load
+                {fmtInt(values[values.length - 1])} TPS
               </text>
             </>
           ) : null}
 
-          {/* The fee line: near-flat, with micro fluctuations and pulses flowing along the lane. */}
+          {/* The reserved payment-lane rail: a steady green line with transfer
+              pulses flowing along it. Not a measured series — it represents the
+              guaranteed blockspace that keeps payments moving under any load. */}
           <path
-            d={linePath(feePts)}
+            d={linePath(lanePts)}
             fill="none"
             stroke="var(--indicator-green)"
             strokeWidth="2"
@@ -161,7 +167,7 @@ export default function PaymentLanes({ runs }: { runs: PerfRun[] }) {
             strokeLinecap="round"
           />
           <path
-            d={linePath(feePts)}
+            d={linePath(lanePts)}
             fill="none"
             stroke="#ffffff"
             strokeOpacity="0.55"
@@ -171,22 +177,14 @@ export default function PaymentLanes({ runs }: { runs: PerfRun[] }) {
             strokeLinejoin="round"
             className="lane-flow motion-reduce:animate-none"
           />
-          <circle
-            cx={endX}
-            cy={feeEndY}
-            r="3.5"
-            fill="var(--indicator-green)"
-            stroke="var(--surface-page)"
-            strokeWidth="2"
-          />
           <text
             x={mobile ? endX - 12 : endX + 12}
-            y={mobile ? DIVIDER + 20 : feeEndY + 4}
+            y={mobile ? DIVIDER + 20 : LANE_Y + 4}
             textAnchor={mobile ? 'end' : 'start'}
             fill="var(--indicator-green)"
             className="font-mono text-[11px]"
           >
-            &lt;$0.001 average fee
+            payments keep flowing
           </text>
         </svg>
       ) : null}

--- a/src/marketing/app/performance/_components/SettlementStream.tsx
+++ b/src/marketing/app/performance/_components/SettlementStream.tsx
@@ -1,25 +1,18 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { createPublicClient, http } from 'viem'
-import type { PerfRun } from '../_lib/runs'
+import { useState } from 'react'
+import { MAX_BLOCKS, type StreamBlock } from './useFinalizedBlocks'
 import useMeasure from './useMeasure'
 
-// The settlement story as a live conveyor: Viem watches Tempo's finalized
-// chain head and pushes each real block into the stream. Since finalized heads
-// are already settled, every cell represents an observed finalized block; the
-// per-block interval is measured from each block's on-chain millisecond
-// timestamp (`timestampMillis`), so it stays accurate even when polling catches
-// up several finalized blocks at once.
+// The settlement story as a live conveyor of finalized blocks. The live feed
+// (and its heartbeat release cadence) lives in `useFinalizedBlocks` so this
+// stays a presentational view fed by the same data as the hero "Avg block
+// time" stat — the two can never disagree. Since finalized heads are already
+// settled, every cell is an observed settlement; the per-block interval is
+// only rolled up into the single labelled average below the track, not shown
+// per cell, so it can't be mistaken for a different number.
 
-// Tempo blocks carry a millisecond-precision Unix timestamp that standard EVM
-// blocks lack. It is not part of viem's block type, so we read it off the raw
-// block as a hex string.
-type TempoBlock = { number: bigint | null; timestampMillis?: `0x${string}` }
-
-const TEMPO_RPC_URL = 'https://rpc.tempo.xyz'
 const TEMPO_EXPLORER_BLOCK_URL = 'https://explore.tempo.xyz/block'
-const POLL_MS = 500
 
 const H = 180
 const CELL = 64 // square block cell, px
@@ -27,75 +20,38 @@ const GAP = 14
 const STEP = CELL + GAP
 const TRACK_TOP = (H - CELL) / 2
 const TRACK_H = CELL + 24 // cells plus their height labels
-const MAX_BLOCKS = 32
 
-type StreamBlock = {
-  height: bigint
-  intervalMs: number | null
+type SettlementStreamProps = {
+  blocks: StreamBlock[]
+  isLive: boolean
+  avgIntervalMs: number | null
+  fallbackBlockTimeMs?: number
 }
 
-const client = createPublicClient({
-  transport: http(TEMPO_RPC_URL),
-  pollingInterval: POLL_MS,
-})
-
-export default function SettlementStream({ runs }: { runs: PerfRun[] }) {
+export default function SettlementStream({
+  blocks,
+  isLive,
+  avgIntervalMs,
+  fallbackBlockTimeMs,
+}: SettlementStreamProps) {
   const { ref, width } = useMeasure<HTMLDivElement>()
-  const latest = runs[runs.length - 1]
-  const intervalMs = Math.min(Math.max(Math.round(latest?.blockTimeMs || 500), 400), 1200)
 
   const [reducedMotion] = useState(
     () =>
       typeof window !== 'undefined' &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches,
   )
-  const [blocks, setBlocks] = useState<StreamBlock[]>([])
-  const [isLive, setIsLive] = useState(false)
-
-  useEffect(() => {
-    let previousTimestampMs: number | null = null
-    const unwatch = client.watchBlocks({
-      blockTag: 'finalized',
-      emitMissed: true,
-      emitOnBegin: true,
-      pollingInterval: POLL_MS,
-      onBlock: (block) => {
-        if (block.number === null) return
-        const rawTimestamp = (block as TempoBlock).timestampMillis
-        const timestampMs = rawTimestamp != null ? Number(rawTimestamp) : null
-        const measuredInterval =
-          timestampMs === null || previousTimestampMs === null
-            ? null
-            : Math.max(Math.round(timestampMs - previousTimestampMs), 0)
-        if (timestampMs !== null) previousTimestampMs = timestampMs
-        setIsLive(true)
-        setBlocks((prev) => {
-          if (prev.some(({ height }) => height === block.number)) return prev
-          return [...prev, { height: block.number, intervalMs: measuredInterval }].slice(
-            -MAX_BLOCKS,
-          )
-        })
-      },
-      onError: () => setIsLive(false),
-    })
-
-    return () => unwatch()
-  }, [])
 
   // Enough cells to run flush past the container's left edge; the overflow
   // is clipped by the track and softened by the fade mask.
   const visible = Math.min(Math.max(Math.ceil(width / STEP) + 1, 3), MAX_BLOCKS)
   const shown = blocks.slice(-visible)
   const last = shown.length - 1
-  const observedIntervals = blocks
-    .map(({ intervalMs }) => intervalMs)
-    .filter((value): value is number => value !== null)
-  const avgIntervalMs =
-    observedIntervals.length > 0
-      ? Math.round(
-          observedIntervals.reduce((sum, value) => sum + value, 0) / observedIntervals.length,
-        )
-      : intervalMs
+
+  // Prefer the live observed average; fall back to the benchmark block time
+  // until enough finalized blocks have streamed in to measure it.
+  const blockTimeMs = avgIntervalMs ?? fallbackBlockTimeMs ?? null
+  const isEstimate = avgIntervalMs === null
 
   return (
     <div ref={ref} className="relative w-full" style={{ height: H }}>
@@ -135,15 +91,12 @@ export default function SettlementStream({ runs }: { runs: PerfRun[] }) {
                   className="group block outline-none"
                 >
                   <div
-                    className={`block-in settle-flash flex size-16 flex-col items-center justify-center gap-1 border-line-strong transition-colors group-hover:bg-surface-card group-focus-visible:bg-surface-card ${
+                    className={`block-in settle-flash flex size-16 items-center justify-center border-line-strong transition-colors group-hover:bg-surface-card group-focus-visible:bg-surface-card ${
                       i === last ? 'settled-cell' : 'bg-surface-panel'
                     }`}
                   >
-                    <span className="font-mono text-[12px] text-indicator-green leading-none">
+                    <span className="font-mono text-[18px] text-indicator-green leading-none">
                       ✓
-                    </span>
-                    <span className="font-mono text-[11px] text-foreground/50 tracking-wider">
-                      {b.intervalMs === null ? 'FINAL' : `${b.intervalMs} MS`}
                     </span>
                   </div>
                   <p className="mt-1.5 text-center font-mono text-[9px] text-foreground/25 tracking-wide transition-colors group-hover:text-foreground/45 group-focus-visible:text-foreground/45">
@@ -166,7 +119,8 @@ export default function SettlementStream({ runs }: { runs: PerfRun[] }) {
             <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-surface-shell to-transparent" />
           </div>
 
-          {/* Rolling average interval, measured from finalized block arrivals. */}
+          {/* Rolling average block time, bracketing a single block interval and
+              measured from the same finalized feed as the hero stat. */}
           <div
             className="absolute flex items-center"
             style={{ right: CELL / 2, width: STEP, top: TRACK_TOP + TRACK_H + 6 }}
@@ -175,12 +129,18 @@ export default function SettlementStream({ runs }: { runs: PerfRun[] }) {
             <span className="h-px flex-1 bg-foreground/25" />
             <span className="h-2 w-px bg-foreground/25" />
           </div>
-          <p
-            className="absolute text-center font-mono text-[10px] text-foreground/35"
-            style={{ right: CELL / 2, width: STEP, top: TRACK_TOP + TRACK_H + 16 }}
-          >
-            AVG {observedIntervals.length > 0 ? avgIntervalMs : `~${avgIntervalMs}`} MS
-          </p>
+          {blockTimeMs !== null ? (
+            <p
+              className="absolute text-center font-mono text-[9px] text-foreground/35 leading-tight"
+              style={{ right: CELL / 2 - 24, width: STEP + 48, top: TRACK_TOP + TRACK_H + 16 }}
+            >
+              <span className="block text-foreground/30 tracking-wider">AVG BLOCK TIME</span>
+              <span className="text-foreground/45">
+                {isEstimate ? '~' : ''}
+                {blockTimeMs} MS
+              </span>
+            </p>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/marketing/app/performance/_components/SettlementStream.tsx
+++ b/src/marketing/app/performance/_components/SettlementStream.tsx
@@ -7,8 +7,9 @@ import useMeasure from './useMeasure'
 // The settlement story as a live conveyor of finalized blocks. The live feed
 // (and its heartbeat release cadence) lives in `useFinalizedBlocks`. Since
 // finalized heads are already settled, every cell is an observed settlement —
-// the stream is a steady heartbeat of real blocks. It deliberately shows no
-// block-time number; the "Avg block time" figure lives in the hero stat above.
+// the stream is a steady heartbeat of real blocks. The block-time readout is
+// the benchmark figure from the perf API (same source as the hero stat), so
+// the two always agree and no live-measured number is shown.
 
 const TEMPO_EXPLORER_BLOCK_URL = 'https://explore.tempo.xyz/block'
 
@@ -19,7 +20,13 @@ const STEP = CELL + GAP
 const TRACK_TOP = (H - CELL) / 2
 const TRACK_H = CELL + 24 // cells plus their height labels
 
-export default function SettlementStream() {
+type SettlementStreamProps = {
+  // Average block time from the benchmark API (latest nightly run), shared with
+  // the hero stat so the two never disagree.
+  blockTimeMs?: number
+}
+
+export default function SettlementStream({ blockTimeMs }: SettlementStreamProps) {
   const { ref, width } = useMeasure<HTMLDivElement>()
   const { blocks, isLive } = useFinalizedBlocks()
 
@@ -100,6 +107,28 @@ export default function SettlementStream() {
             {/* Mask the oldest block's exit at the track's left edge. */}
             <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-surface-shell to-transparent" />
           </div>
+
+          {/* Benchmark avg block time, bracketing a single block interval. Same
+              perf-API figure as the hero stat — not a live measurement. */}
+          {blockTimeMs != null ? (
+            <>
+              <div
+                className="absolute flex items-center"
+                style={{ right: CELL / 2, width: STEP, top: TRACK_TOP + TRACK_H + 6 }}
+              >
+                <span className="h-2 w-px bg-foreground/25" />
+                <span className="h-px flex-1 bg-foreground/25" />
+                <span className="h-2 w-px bg-foreground/25" />
+              </div>
+              <p
+                className="absolute text-center font-mono text-[9px] text-foreground/35 leading-tight"
+                style={{ right: CELL / 2 - 24, width: STEP + 48, top: TRACK_TOP + TRACK_H + 16 }}
+              >
+                <span className="block text-foreground/30 tracking-wider">AVG BLOCK TIME</span>
+                <span className="text-foreground/45">{Math.round(blockTimeMs)} MS</span>
+              </p>
+            </>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/marketing/app/performance/_components/SettlementStream.tsx
+++ b/src/marketing/app/performance/_components/SettlementStream.tsx
@@ -1,16 +1,14 @@
 'use client'
 
 import { useState } from 'react'
-import { MAX_BLOCKS, type StreamBlock } from './useFinalizedBlocks'
+import { MAX_BLOCKS, useFinalizedBlocks } from './useFinalizedBlocks'
 import useMeasure from './useMeasure'
 
 // The settlement story as a live conveyor of finalized blocks. The live feed
-// (and its heartbeat release cadence) lives in `useFinalizedBlocks` so this
-// stays a presentational view fed by the same data as the hero "Avg block
-// time" stat — the two can never disagree. Since finalized heads are already
-// settled, every cell is an observed settlement; the per-block interval is
-// only rolled up into the single labelled average below the track, not shown
-// per cell, so it can't be mistaken for a different number.
+// (and its heartbeat release cadence) lives in `useFinalizedBlocks`. Since
+// finalized heads are already settled, every cell is an observed settlement —
+// the stream is a steady heartbeat of real blocks. It deliberately shows no
+// block-time number; the "Avg block time" figure lives in the hero stat above.
 
 const TEMPO_EXPLORER_BLOCK_URL = 'https://explore.tempo.xyz/block'
 
@@ -21,20 +19,9 @@ const STEP = CELL + GAP
 const TRACK_TOP = (H - CELL) / 2
 const TRACK_H = CELL + 24 // cells plus their height labels
 
-type SettlementStreamProps = {
-  blocks: StreamBlock[]
-  isLive: boolean
-  avgIntervalMs: number | null
-  fallbackBlockTimeMs?: number
-}
-
-export default function SettlementStream({
-  blocks,
-  isLive,
-  avgIntervalMs,
-  fallbackBlockTimeMs,
-}: SettlementStreamProps) {
+export default function SettlementStream() {
   const { ref, width } = useMeasure<HTMLDivElement>()
+  const { blocks, isLive } = useFinalizedBlocks()
 
   const [reducedMotion] = useState(
     () =>
@@ -47,11 +34,6 @@ export default function SettlementStream({
   const visible = Math.min(Math.max(Math.ceil(width / STEP) + 1, 3), MAX_BLOCKS)
   const shown = blocks.slice(-visible)
   const last = shown.length - 1
-
-  // Prefer the live observed average; fall back to the benchmark block time
-  // until enough finalized blocks have streamed in to measure it.
-  const blockTimeMs = avgIntervalMs ?? fallbackBlockTimeMs ?? null
-  const isEstimate = avgIntervalMs === null
 
   return (
     <div ref={ref} className="relative w-full" style={{ height: H }}>
@@ -118,29 +100,6 @@ export default function SettlementStream({
             {/* Mask the oldest block's exit at the track's left edge. */}
             <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-surface-shell to-transparent" />
           </div>
-
-          {/* Rolling average block time, bracketing a single block interval and
-              measured from the same finalized feed as the hero stat. */}
-          <div
-            className="absolute flex items-center"
-            style={{ right: CELL / 2, width: STEP, top: TRACK_TOP + TRACK_H + 6 }}
-          >
-            <span className="h-2 w-px bg-foreground/25" />
-            <span className="h-px flex-1 bg-foreground/25" />
-            <span className="h-2 w-px bg-foreground/25" />
-          </div>
-          {blockTimeMs !== null ? (
-            <p
-              className="absolute text-center font-mono text-[9px] text-foreground/35 leading-tight"
-              style={{ right: CELL / 2 - 24, width: STEP + 48, top: TRACK_TOP + TRACK_H + 16 }}
-            >
-              <span className="block text-foreground/30 tracking-wider">AVG BLOCK TIME</span>
-              <span className="text-foreground/45">
-                {isEstimate ? '~' : ''}
-                {blockTimeMs} MS
-              </span>
-            </p>
-          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/marketing/app/performance/_components/SettlementStream.tsx
+++ b/src/marketing/app/performance/_components/SettlementStream.tsx
@@ -8,8 +8,7 @@ import useMeasure from './useMeasure'
 // (and its heartbeat release cadence) lives in `useFinalizedBlocks`. Since
 // finalized heads are already settled, every cell is an observed settlement —
 // the stream is a steady heartbeat of real blocks. The block-time readout is
-// the benchmark figure from the perf API (same source as the hero stat), so
-// the two always agree and no live-measured number is shown.
+// the live observed average, measured from the finalized feed.
 
 const TEMPO_EXPLORER_BLOCK_URL = 'https://explore.tempo.xyz/block'
 
@@ -20,15 +19,9 @@ const STEP = CELL + GAP
 const TRACK_TOP = (H - CELL) / 2
 const TRACK_H = CELL + 24 // cells plus their height labels
 
-type SettlementStreamProps = {
-  // Average block time from the benchmark API (latest nightly run), shared with
-  // the hero stat so the two never disagree.
-  blockTimeMs?: number
-}
-
-export default function SettlementStream({ blockTimeMs }: SettlementStreamProps) {
+export default function SettlementStream() {
   const { ref, width } = useMeasure<HTMLDivElement>()
-  const { blocks, isLive } = useFinalizedBlocks()
+  const { blocks, isLive, avgIntervalMs } = useFinalizedBlocks()
 
   const [reducedMotion] = useState(
     () =>
@@ -108,9 +101,9 @@ export default function SettlementStream({ blockTimeMs }: SettlementStreamProps)
             <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-surface-shell to-transparent" />
           </div>
 
-          {/* Benchmark avg block time, bracketing a single block interval. Same
-              perf-API figure as the hero stat — not a live measurement. */}
-          {blockTimeMs != null ? (
+          {/* Live observed avg block time, bracketing a single block interval,
+              measured from the finalized feed. */}
+          {avgIntervalMs != null ? (
             <>
               <div
                 className="absolute flex items-center"
@@ -125,7 +118,7 @@ export default function SettlementStream({ blockTimeMs }: SettlementStreamProps)
                 style={{ right: CELL / 2 - 24, width: STEP + 48, top: TRACK_TOP + TRACK_H + 16 }}
               >
                 <span className="block text-foreground/30 tracking-wider">AVG BLOCK TIME</span>
-                <span className="text-foreground/45">{Math.round(blockTimeMs)} MS</span>
+                <span className="text-foreground/45">{avgIntervalMs} MS</span>
               </p>
             </>
           ) : null}

--- a/src/marketing/app/performance/_components/useFinalizedBlocks.ts
+++ b/src/marketing/app/performance/_components/useFinalizedBlocks.ts
@@ -3,21 +3,12 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPublicClient, http } from 'viem'
 
-// Shared live feed of Tempo's finalized chain head, used by both the hero
-// "Avg block time" stat and the settlement stream so they always agree.
+// Shared live feed of Tempo's finalized chain head for the settlement stream.
 //
 // Viem watches the finalized head and buffers each real block, then a heartbeat
 // releases them into the stream one at a time so squares appear at a steady
 // cadence even when polling catches up several finalized blocks at once. Since
-// finalized heads are already settled, every block is an observed settlement;
-// the per-block interval is measured from each block's on-chain millisecond
-// timestamp (`timestampMillis`), so the average stays accurate regardless of
-// the release cadence.
-
-// Tempo blocks carry a millisecond-precision Unix timestamp that standard EVM
-// blocks lack. It is not part of viem's block type, so we read it off the raw
-// block as a hex string.
-type TempoBlock = { number: bigint | null; timestampMillis?: `0x${string}` }
+// finalized heads are already settled, every block is an observed settlement.
 
 const TEMPO_RPC_URL = 'https://rpc.tempo.xyz'
 const POLL_MS = 500
@@ -32,7 +23,6 @@ export const MAX_BLOCKS = 32
 
 export type StreamBlock = {
   height: bigint
-  intervalMs: number | null
 }
 
 const client = createPublicClient({
@@ -48,7 +38,6 @@ export function useFinalizedBlocks() {
   const seenRef = useRef<Set<string>>(new Set())
 
   useEffect(() => {
-    let previousTimestampMs: number | null = null
     const unwatch = client.watchBlocks({
       blockTag: 'finalized',
       emitMissed: true,
@@ -58,16 +47,9 @@ export function useFinalizedBlocks() {
         if (block.number === null) return
         const key = block.number.toString()
         if (seenRef.current.has(key)) return
-        const rawTimestamp = (block as TempoBlock).timestampMillis
-        const timestampMs = rawTimestamp != null ? Number(rawTimestamp) : null
-        const measuredInterval =
-          timestampMs === null || previousTimestampMs === null
-            ? null
-            : Math.max(Math.round(timestampMs - previousTimestampMs), 0)
-        if (timestampMs !== null) previousTimestampMs = timestampMs
         seenRef.current.add(key)
         setIsLive(true)
-        queueRef.current.push({ height: block.number, intervalMs: measuredInterval })
+        queueRef.current.push({ height: block.number })
         if (queueRef.current.length > QUEUE_CAP) {
           queueRef.current = queueRef.current.slice(-QUEUE_CAP)
         }
@@ -94,15 +76,5 @@ export function useFinalizedBlocks() {
     return () => clearInterval(id)
   }, [])
 
-  const observedIntervals = blocks
-    .map(({ intervalMs }) => intervalMs)
-    .filter((value): value is number => value !== null)
-  const avgIntervalMs =
-    observedIntervals.length > 0
-      ? Math.round(
-          observedIntervals.reduce((sum, value) => sum + value, 0) / observedIntervals.length,
-        )
-      : null
-
-  return { blocks, isLive, avgIntervalMs }
+  return { blocks, isLive }
 }

--- a/src/marketing/app/performance/_components/useFinalizedBlocks.ts
+++ b/src/marketing/app/performance/_components/useFinalizedBlocks.ts
@@ -9,6 +9,15 @@ import { createPublicClient, http } from 'viem'
 // releases them into the stream one at a time so squares appear at a steady
 // cadence even when polling catches up several finalized blocks at once. Since
 // finalized heads are already settled, every block is an observed settlement.
+//
+// `avgIntervalMs` is the live observed block time, measured from each block's
+// on-chain millisecond timestamp (`timestampMillis`) so it stays accurate
+// regardless of the artificial heartbeat release cadence.
+
+// Tempo blocks carry a millisecond-precision Unix timestamp that standard EVM
+// blocks lack. It is not part of viem's block type, so we read it off the raw
+// block as a hex string.
+type TempoBlock = { number: bigint | null; timestampMillis?: `0x${string}` }
 
 const TEMPO_RPC_URL = 'https://rpc.tempo.xyz'
 const POLL_MS = 500
@@ -23,6 +32,7 @@ export const MAX_BLOCKS = 32
 
 export type StreamBlock = {
   height: bigint
+  intervalMs: number | null
 }
 
 const client = createPublicClient({
@@ -38,6 +48,7 @@ export function useFinalizedBlocks() {
   const seenRef = useRef<Set<string>>(new Set())
 
   useEffect(() => {
+    let previousTimestampMs: number | null = null
     const unwatch = client.watchBlocks({
       blockTag: 'finalized',
       emitMissed: true,
@@ -47,9 +58,16 @@ export function useFinalizedBlocks() {
         if (block.number === null) return
         const key = block.number.toString()
         if (seenRef.current.has(key)) return
+        const rawTimestamp = (block as TempoBlock).timestampMillis
+        const timestampMs = rawTimestamp != null ? Number(rawTimestamp) : null
+        const measuredInterval =
+          timestampMs === null || previousTimestampMs === null
+            ? null
+            : Math.max(Math.round(timestampMs - previousTimestampMs), 0)
+        if (timestampMs !== null) previousTimestampMs = timestampMs
         seenRef.current.add(key)
         setIsLive(true)
-        queueRef.current.push({ height: block.number })
+        queueRef.current.push({ height: block.number, intervalMs: measuredInterval })
         if (queueRef.current.length > QUEUE_CAP) {
           queueRef.current = queueRef.current.slice(-QUEUE_CAP)
         }
@@ -76,5 +94,15 @@ export function useFinalizedBlocks() {
     return () => clearInterval(id)
   }, [])
 
-  return { blocks, isLive }
+  const observedIntervals = blocks
+    .map(({ intervalMs }) => intervalMs)
+    .filter((value): value is number => value !== null)
+  const avgIntervalMs =
+    observedIntervals.length > 0
+      ? Math.round(
+          observedIntervals.reduce((sum, value) => sum + value, 0) / observedIntervals.length,
+        )
+      : null
+
+  return { blocks, isLive, avgIntervalMs }
 }

--- a/src/marketing/app/performance/_components/useFinalizedBlocks.ts
+++ b/src/marketing/app/performance/_components/useFinalizedBlocks.ts
@@ -1,0 +1,108 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { createPublicClient, http } from 'viem'
+
+// Shared live feed of Tempo's finalized chain head, used by both the hero
+// "Avg block time" stat and the settlement stream so they always agree.
+//
+// Viem watches the finalized head and buffers each real block, then a heartbeat
+// releases them into the stream one at a time so squares appear at a steady
+// cadence even when polling catches up several finalized blocks at once. Since
+// finalized heads are already settled, every block is an observed settlement;
+// the per-block interval is measured from each block's on-chain millisecond
+// timestamp (`timestampMillis`), so the average stays accurate regardless of
+// the release cadence.
+
+// Tempo blocks carry a millisecond-precision Unix timestamp that standard EVM
+// blocks lack. It is not part of viem's block type, so we read it off the raw
+// block as a hex string.
+type TempoBlock = { number: bigint | null; timestampMillis?: `0x${string}` }
+
+const TEMPO_RPC_URL = 'https://rpc.tempo.xyz'
+const POLL_MS = 500
+// Release one buffered block per beat so the stream reads like a steady
+// heartbeat even when polling catches up several finalized blocks at once.
+const HEARTBEAT_MS = 520
+// Cap the pending buffer so the stream cannot lag far behind the real head
+// (e.g. after the tab was backgrounded); excess oldest blocks are dropped.
+const QUEUE_CAP = 12
+
+export const MAX_BLOCKS = 32
+
+export type StreamBlock = {
+  height: bigint
+  intervalMs: number | null
+}
+
+const client = createPublicClient({
+  transport: http(TEMPO_RPC_URL),
+  pollingInterval: POLL_MS,
+})
+
+export function useFinalizedBlocks() {
+  const [blocks, setBlocks] = useState<StreamBlock[]>([])
+  const [isLive, setIsLive] = useState(false)
+  // Blocks land here as soon as they're observed and drain on the heartbeat.
+  const queueRef = useRef<StreamBlock[]>([])
+  const seenRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    let previousTimestampMs: number | null = null
+    const unwatch = client.watchBlocks({
+      blockTag: 'finalized',
+      emitMissed: true,
+      emitOnBegin: true,
+      pollingInterval: POLL_MS,
+      onBlock: (block) => {
+        if (block.number === null) return
+        const key = block.number.toString()
+        if (seenRef.current.has(key)) return
+        const rawTimestamp = (block as TempoBlock).timestampMillis
+        const timestampMs = rawTimestamp != null ? Number(rawTimestamp) : null
+        const measuredInterval =
+          timestampMs === null || previousTimestampMs === null
+            ? null
+            : Math.max(Math.round(timestampMs - previousTimestampMs), 0)
+        if (timestampMs !== null) previousTimestampMs = timestampMs
+        seenRef.current.add(key)
+        setIsLive(true)
+        queueRef.current.push({ height: block.number, intervalMs: measuredInterval })
+        if (queueRef.current.length > QUEUE_CAP) {
+          queueRef.current = queueRef.current.slice(-QUEUE_CAP)
+        }
+      },
+      onError: () => setIsLive(false),
+    })
+
+    return () => unwatch()
+  }, [])
+
+  // Heartbeat: release at most one buffered block per beat so cells appear at a
+  // steady cadence rather than in bursts when several finalized blocks arrive
+  // together.
+  useEffect(() => {
+    const id = setInterval(() => {
+      const next = queueRef.current.shift()
+      if (!next) return
+      setBlocks((prev) => {
+        if (prev.some(({ height }) => height === next.height)) return prev
+        return [...prev, next].slice(-MAX_BLOCKS)
+      })
+    }, HEARTBEAT_MS)
+
+    return () => clearInterval(id)
+  }, [])
+
+  const observedIntervals = blocks
+    .map(({ intervalMs }) => intervalMs)
+    .filter((value): value is number => value !== null)
+  const avgIntervalMs =
+    observedIntervals.length > 0
+      ? Math.round(
+          observedIntervals.reduce((sum, value) => sum + value, 0) / observedIntervals.length,
+        )
+      : null
+
+  return { blocks, isLive, avgIntervalMs }
+}

--- a/src/marketing/app/performance/page.tsx
+++ b/src/marketing/app/performance/page.tsx
@@ -10,6 +10,7 @@ import SettlementStream from './_components/SettlementStream'
 import TpsTrendChart from './_components/TpsTrendChart'
 import TpsTrendChartFrame from './_components/TpsTrendChartFrame'
 import UptimeStrip from './_components/UptimeStrip'
+import { useFinalizedBlocks } from './_components/useFinalizedBlocks'
 import { fetchPerfRuns, fmtInt, type PerfRun } from './_lib/runs'
 
 export const metadata: Metadata = {
@@ -20,32 +21,10 @@ export const metadata: Metadata = {
 
 const STATUS_PAGE_URL = 'https://status.tempo.xyz'
 const PERF_DASHBOARD_URL = 'https://perf.tempo.xyz/'
-const DAY_MS = 24 * 60 * 60 * 1000
 const HERO_STAT_LABELS = ['Transactions per second', 'Avg block time', 'Average fee']
 const SETTLEMENT_SKELETON_CELLS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
 const UPTIME_SKELETON_BARS = Array.from({ length: 90 }, (_, i) => `bar-${i}`)
 const prefetchedRuns = typeof window !== 'undefined' ? fetchPerfRuns() : null
-
-function formatChartRange(startedAt: string, endedAt: string) {
-  const start = new Date(startedAt)
-  const end = new Date(endedAt)
-  const daySpan = Math.max(1, Math.round((end.getTime() - start.getTime()) / DAY_MS))
-  const startLabel = start.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    timeZone: 'UTC',
-  })
-  const endLabel = end.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    timeZone: 'UTC',
-  })
-
-  return `Benchmark runs · Past ${daySpan} ${
-    daySpan === 1 ? 'day' : 'days'
-  } · ${startLabel} - ${endLabel} UTC`
-}
 
 // Aggregate state ("operational", "downtime", …) from the BetterStack status
 // page's public JSON; null when unreachable so the uptime strip falls back to
@@ -148,9 +127,11 @@ function SettlementStreamSkeleton() {
       <SkeletonBlock className="absolute top-[26px] right-0 h-3 w-24" />
       <div className="absolute top-[58px] right-0 flex gap-[14px]">
         {SETTLEMENT_SKELETON_CELLS.map((cell) => (
-          <div key={cell} className="size-16 border border-line-strong bg-surface-panel">
-            <SkeletonBlock className="mx-auto mt-5 h-2 w-8" />
-            <SkeletonBlock className="mx-auto mt-3 h-2 w-10" />
+          <div
+            key={cell}
+            className="flex size-16 items-center justify-center border border-line-strong bg-surface-panel"
+          >
+            <SkeletonBlock className="size-4 rounded-full" />
           </div>
         ))}
       </div>
@@ -232,7 +213,7 @@ function PerformanceSectionsSkeleton() {
       <Section
         id="fees"
         title="A dedicated lane for payments."
-        note="Tempo reserves blockspace for payments, so trading spikes, airdrops, and other unrelated network activity do not set the price for ordinary transfers. Payments stay prioritized in their own lane, with fees that remain predictably low under load."
+        note="Tempo gives payment transactions reserved blockspace with a separate consensus gas limit, so spikes in other activity cannot crowd them out. Fees are fixed, not congestion-priced: a TIP-20 transfer stays under $0.001 regardless of network load."
       >
         <PaymentLanesSkeleton />
         <SkeletonBlock className="mt-10 h-10 w-56" />
@@ -277,9 +258,14 @@ export default function PerformancePage() {
     }
   }, [])
 
+  const { blocks, isLive, avgIntervalMs } = useFinalizedBlocks()
+
   const latest = runs[runs.length - 1]
   const hasRuns = runs.length >= 2
-  const chartRange = latest && runs[0] ? formatChartRange(runs[0].startedAt, latest.startedAt) : ''
+
+  // Prefer the live observed block time; fall back to the benchmark figure
+  // until enough finalized blocks have streamed in to measure it.
+  const blockTimeMs = avgIntervalMs ?? latest?.blockTimeMs ?? null
 
   const heroStats = latest
     ? [
@@ -289,7 +275,7 @@ export default function PerformancePage() {
         },
         {
           label: 'Avg block time',
-          value: `${fmtInt(latest.blockTimeMs)} ms`,
+          value: blockTimeMs !== null ? `${fmtInt(blockTimeMs)} ms` : '—',
         },
         {
           label: 'Average fee',
@@ -321,7 +307,7 @@ export default function PerformancePage() {
                   Transactions per second
                 </p>
                 <p className="mt-1 font-sans text-[14px] text-foreground/45 leading-[1.4]">
-                  {chartRange}
+                  Nightly benchmark runs
                 </p>
               </div>
             </Reveal>
@@ -362,14 +348,19 @@ export default function PerformancePage() {
               title="Guaranteed settlement in half a second."
               note="Tempo gives payments final settlement in about half a second. Once a payment lands in a finalized block, it can be treated as settled."
             >
-              <SettlementStream runs={runs} />
+              <SettlementStream
+                blocks={blocks}
+                isLive={isLive}
+                avgIntervalMs={avgIntervalMs}
+                fallbackBlockTimeMs={latest?.blockTimeMs}
+              />
             </Section>
 
             {/* Payment lanes: the protocol feature behind the flat fee line. */}
             <Section
               id="fees"
               title="A dedicated lane for payments."
-              note="Tempo reserves blockspace for payments, so trading spikes, airdrops, and other unrelated network activity do not set the price for ordinary transfers. Payments stay prioritized in their own lane, with fees that remain predictably low under load."
+              note="Tempo gives payment transactions reserved blockspace with a separate consensus gas limit, so spikes in other activity cannot crowd them out. Fees are fixed, not congestion-priced: a TIP-20 transfer stays under $0.001 regardless of network load."
             >
               <PaymentLanes runs={runs} />
               <Button

--- a/src/marketing/app/performance/page.tsx
+++ b/src/marketing/app/performance/page.tsx
@@ -341,7 +341,7 @@ export default function PerformancePage() {
               title="Guaranteed settlement in half a second."
               note="Tempo gives payments final settlement in about half a second. Once a payment lands in a finalized block, it can be treated as settled."
             >
-              <SettlementStream blockTimeMs={latest?.blockTimeMs} />
+              <SettlementStream />
             </Section>
 
             {/* Payment lanes: the protocol feature behind the flat fee line. */}

--- a/src/marketing/app/performance/page.tsx
+++ b/src/marketing/app/performance/page.tsx
@@ -10,7 +10,6 @@ import SettlementStream from './_components/SettlementStream'
 import TpsTrendChart from './_components/TpsTrendChart'
 import TpsTrendChartFrame from './_components/TpsTrendChartFrame'
 import UptimeStrip from './_components/UptimeStrip'
-import { useFinalizedBlocks } from './_components/useFinalizedBlocks'
 import { fetchPerfRuns, fmtInt, type PerfRun } from './_lib/runs'
 
 export const metadata: Metadata = {
@@ -258,14 +257,8 @@ export default function PerformancePage() {
     }
   }, [])
 
-  const { blocks, isLive, avgIntervalMs } = useFinalizedBlocks()
-
   const latest = runs[runs.length - 1]
   const hasRuns = runs.length >= 2
-
-  // Prefer the live observed block time; fall back to the benchmark figure
-  // until enough finalized blocks have streamed in to measure it.
-  const blockTimeMs = avgIntervalMs ?? latest?.blockTimeMs ?? null
 
   const heroStats = latest
     ? [
@@ -275,7 +268,7 @@ export default function PerformancePage() {
         },
         {
           label: 'Avg block time',
-          value: blockTimeMs !== null ? `${fmtInt(blockTimeMs)} ms` : '—',
+          value: `${fmtInt(latest.blockTimeMs)} ms`,
         },
         {
           label: 'Average fee',
@@ -348,12 +341,7 @@ export default function PerformancePage() {
               title="Guaranteed settlement in half a second."
               note="Tempo gives payments final settlement in about half a second. Once a payment lands in a finalized block, it can be treated as settled."
             >
-              <SettlementStream
-                blocks={blocks}
-                isLive={isLive}
-                avgIntervalMs={avgIntervalMs}
-                fallbackBlockTimeMs={latest?.blockTimeMs}
-              />
+              <SettlementStream />
             </Section>
 
             {/* Payment lanes: the protocol feature behind the flat fee line. */}

--- a/src/marketing/app/performance/page.tsx
+++ b/src/marketing/app/performance/page.tsx
@@ -341,7 +341,7 @@ export default function PerformancePage() {
               title="Guaranteed settlement in half a second."
               note="Tempo gives payments final settlement in about half a second. Once a payment lands in a finalized block, it can be treated as settled."
             >
-              <SettlementStream />
+              <SettlementStream blockTimeMs={latest?.blockTimeMs} />
             </Section>
 
             {/* Payment lanes: the protocol feature behind the flat fee line. */}


### PR DESCRIPTION
Addresses performance-page feedback.

## Settlement stream
- **Heartbeat cadence** — finalized blocks now buffer and release one per ~520ms beat, so squares appear at a steady cadence instead of 2-3 at once.
- **No competing block-time number** — the stream is now purely a heartbeat of finalized blocks (✓ + block height). The per-cell MS labels and the rolled-up average are gone, so nothing in the stream contradicts the hero **Avg block time** stat. The hero keeps the benchmark figure.
- Live finalized-block feed extracted into a small `useFinalizedBlocks` hook.

## Payment lanes
- Removed the flat `<$0.001 average fee` curve. Plotting a flat **fee** line against a volatile **load** line implied a dynamic, congestion-priced fee market — Tempo uses a **fixed** base fee.
- The bottom band is now a **reserved-capacity rail** ("payments keep flowing") in the same throughput framing as the top load line, communicating the real value prop: dedicated blockspace keeps payments moving under any load.
- Rewrote the section note to be accurate: payments get reserved blockspace via a separate consensus gas limit; **fees are fixed, not congestion-priced** (<$0.001 regardless of load).

## Misc
- Hero chart caption simplified to a generic "Nightly benchmark runs" (removed the day-count/date range).

## Verification
- `biome check` clean
- `tsc` clean (only pre-existing unrelated `viem/tempo` snippet errors remain)
- marketing build succeeds
