### PR TITLE
[codex] polish docs navigation

### DIFF
--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -61,10 +61,10 @@ export function usePathname() {
 }
 
 function isActiveMenuItem(pathname: string, item: MenuItem) {
-  if (item.label === 'Build') return pathname === '/' || pathname.startsWith('/build')
+  if (item.label === 'Build') return pathname.startsWith('/build')
   if (item.label === 'Resources')
     return pathname === '/docs/sdk' || pathname.startsWith('/docs/sdk/')
-  if (item.label === 'Docs') return pathMatches(pathname, DOCS_BASE_PATH)
+  if (item.label === 'Docs') return pathname === '/docs' || pathname.startsWith('/docs/')
   return !isExternal(item.href) && pathMatches(pathname, item.href)
 }
 
@@ -916,9 +916,11 @@ function SidebarLeaf({
     <Anchor
       href={node.link ?? '#'}
       onClick={onNavigate}
-      style={{ paddingLeft: depth > 1 ? `${(depth - 1) * 12}px` : undefined }}
-      className={`flex items-center gap-1.5 py-2 font-sans text-[15px] tracking-[0] transition-colors ${
-        active ? 'text-foreground' : 'text-foreground/50 hover:text-foreground'
+      style={{ paddingLeft: depth > 1 ? `${(depth - 1) * 12 + 8}px` : undefined }}
+      className={`-mx-2 flex min-h-8 items-center gap-2 rounded-[6px] px-2 py-1 font-sans text-[14px] tracking-[0] transition-colors ${
+        active
+          ? 'font-medium text-foreground hover:bg-foreground/[0.04]'
+          : 'text-foreground/55 hover:bg-foreground/[0.04] hover:text-foreground'
       }`}
     >
       {active ? <ActiveSquare activeKey={pathname} /> : null}
@@ -961,14 +963,24 @@ export function SidebarNodes({
         // Non-collapsible section (e.g. "Build on Tempo"): a heading + children.
         if (node.collapsed === undefined) {
           return (
-            <div key={key} className={depth === 0 ? 'mt-5 first:mt-0' : 'mt-2'}>
-              <p className="py-2 font-sans text-[15px] text-foreground tracking-[0]">{node.text}</p>
-              <SidebarNodes
-                nodes={node.items ?? []}
-                pathname={pathname}
-                depth={depth + 1}
-                onNavigate={onNavigate}
-              />
+            <div key={key} className={depth === 0 ? 'mt-5 first:mt-0' : 'mt-3'}>
+              <p className="-mx-2 px-2 pb-2 font-normal font-sans text-[13px] text-foreground/40 leading-[1.3] tracking-[0]">
+                {node.text}
+              </p>
+              <div
+                className={
+                  depth > 0
+                    ? 'ml-2 flex flex-col gap-0 border-line border-l pl-3'
+                    : 'flex flex-col gap-0'
+                }
+              >
+                <SidebarNodes
+                  nodes={node.items ?? []}
+                  pathname={pathname}
+                  depth={depth + 1}
+                  onNavigate={onNavigate}
+                />
+              </div>
             </div>
           )
         }
@@ -979,19 +991,21 @@ export function SidebarNodes({
           <details
             key={key}
             open={open}
-            className="group/sb"
+            className="group/sb mt-1"
             style={{ paddingLeft: depth > 1 ? `${(depth - 1) * 12}px` : undefined }}
           >
-            <summary className="flex cursor-pointer list-none items-center justify-between py-2 font-sans text-[15px] text-foreground/50 tracking-[0] transition-colors hover:text-foreground [&::-webkit-details-marker]:hidden">
+            <summary className="-mx-2 flex min-h-8 cursor-pointer list-none items-center justify-between rounded-[6px] px-2 py-1 font-sans text-[14px] text-foreground/65 tracking-[0] transition-colors hover:bg-foreground/[0.04] hover:text-foreground [&::-webkit-details-marker]:hidden">
               {node.text}
-              <Chevron open={false} />
+              <Chevron open={open} />
             </summary>
-            <SidebarNodes
-              nodes={node.items ?? []}
-              pathname={pathname}
-              depth={depth + 1}
-              onNavigate={onNavigate}
-            />
+            <div className="mt-1 ml-2 flex flex-col gap-0 border-line border-l pl-3">
+              <SidebarNodes
+                nodes={node.items ?? []}
+                pathname={pathname}
+                depth={depth + 1}
+                onNavigate={onNavigate}
+              />
+            </div>
           </details>
         )
       })}
@@ -1094,113 +1108,49 @@ export default function DocsHeader() {
       <div className="w-full border-line border-x bg-surface-shell">
         <nav
           ref={headerRef}
-          className="relative flex items-center justify-between border-line border-b px-5 py-4"
+          className="relative grid h-[var(--tempo-docs-primary-nav-height)] grid-cols-[1fr_auto] items-center gap-3 border-line border-b px-4 lg:grid-cols-[minmax(0,1fr)_minmax(300px,460px)_minmax(0,1fr)] lg:px-5"
         >
           <a
             href="/"
             onClick={close}
             onFocus={warmMarketingApp}
             onPointerEnter={warmMarketingApp}
-            className="group flex h-9 items-center text-foreground"
+            className="group flex h-9 min-w-0 items-center text-foreground"
             aria-label="Tempo home"
           >
             <TempoLogo className="h-[18px] w-[80px]" />
           </a>
 
-          <ul className="hidden items-center gap-16 lg:absolute lg:top-1/2 lg:left-1/2 lg:flex lg:-translate-x-1/2 lg:-translate-y-1/2">
-            {menu.map((item) => {
-              const active = isActiveMenuItem(pathname, item)
-              const triggerContent = (
-                <>
-                  {active ? (
-                    <span className="absolute top-1/2 -left-[17px] -translate-y-1/2">
-                      <ActiveSquare activeKey={pathname} />
-                    </span>
-                  ) : null}
-                  {item.label}
-                  {item.mega ? (
-                    // biome-ignore lint/a11y/noSvgWithoutTitle: Decorative disclosure icon; button exposes expanded state.
-                    <svg
-                      width="12"
-                      height="12"
-                      viewBox="0 0 16 16"
-                      fill="none"
-                      aria-hidden
-                      className={`shrink-0 text-foreground/40 transition-transform duration-200 ease-out ${activeMenu === item.label ? 'rotate-180' : ''}`}
-                    >
-                      <path
-                        d="M4 6l4 4 4-4"
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      />
-                    </svg>
-                  ) : null}
-                </>
-              )
-
-              return (
-                <li
-                  key={item.label}
-                  onMouseEnter={item.mega ? () => openMenu(item.label) : scheduleClose}
-                  onMouseLeave={item.mega ? scheduleClose : undefined}
-                >
-                  {item.mega ? (
-                    <button
-                      ref={(element) => {
-                        if (element) triggerRefs.current.set(item.label, element)
-                        else triggerRefs.current.delete(item.label)
-                      }}
-                      type="button"
-                      aria-haspopup="true"
-                      aria-expanded={activeMenu === item.label}
-                      onFocus={() => openMenu(item.label)}
-                      onBlur={scheduleClose}
-                      className="relative flex items-center gap-1.5 font-sans text-[14px] text-foreground tracking-[0] transition-opacity hover:opacity-70"
-                    >
-                      {triggerContent}
-                    </button>
-                  ) : (
-                    <Anchor
-                      href={item.href}
-                      className="relative flex items-center gap-1.5 font-sans text-[14px] text-foreground tracking-[0] transition-opacity hover:opacity-70"
-                    >
-                      {triggerContent}
-                    </Anchor>
-                  )}
-                </li>
-              )
-            })}
-          </ul>
-
-          <div className="hidden items-center gap-3 lg:flex">
-            <button
-              type="button"
-              onClick={openSearch}
-              aria-label="Search documentation"
-              aria-keyshortcuts="Meta+K Control+K"
-              className="flex h-9 items-center gap-2 rounded-[4px] border border-line px-4 font-sans text-[14px] text-foreground/60 tracking-[0] transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
-            >
+          <button
+            type="button"
+            onClick={openSearch}
+            aria-label="Search documentation"
+            aria-keyshortcuts="Meta+K Control+K"
+            className="hidden h-10 min-w-0 items-center justify-between gap-3 rounded-[6px] border border-line bg-background px-3.5 font-sans text-[14px] text-foreground/55 tracking-[0] shadow-[0_1px_1px_rgba(0,0,0,0.03)] transition-colors hover:bg-foreground/[0.025] hover:text-foreground lg:flex"
+          >
+            <span className="flex min-w-0 items-center gap-2">
               <SearchIcon />
-              Search
-              <kbd className="ml-1 rounded-[3px] border border-line px-1.5 py-0.5 font-sans text-[11px] text-foreground/45">
-                ⌘K
-              </kbd>
-            </button>
+              <span className="truncate">Search docs...</span>
+            </span>
+            <kbd className="shrink-0 rounded-[4px] border border-line bg-surface-input px-1.5 py-0.5 font-sans text-[11px] text-foreground/45">
+              ⌘K
+            </kbd>
+          </button>
+
+          <div className="hidden items-center justify-end gap-5 lg:flex">
             <button
               ref={(element) => {
                 if (element) triggerRefs.current.set('For agents', element)
                 else triggerRefs.current.delete('For agents')
               }}
               type="button"
-              aria-haspopup="true"
+              aria-haspopup="dialog"
               aria-expanded={activeMenu === 'For agents'}
               onMouseEnter={() => openMenu('For agents')}
               onMouseLeave={scheduleClose}
               onFocus={() => openMenu('For agents')}
               onBlur={scheduleClose}
-              className="flex h-9 items-center gap-2 rounded-[4px] border border-line px-4 font-sans text-[14px] text-foreground tracking-[0] transition-colors hover:bg-foreground/[0.04]"
+              className="flex h-9 items-center gap-2 rounded-[6px] border border-line px-3.5 font-sans text-[14px] text-foreground/75 tracking-[0] transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
             >
               <GearIcon />
               For agents
@@ -1301,7 +1251,7 @@ export default function DocsHeader() {
             : 'pointer-events-none -translate-y-2 opacity-0'
         }`}
       >
-        <div className="flex h-[calc(100dvh-var(--vocs-spacing-topNav,65px))] w-full flex-col overflow-y-auto border-line border-x border-b bg-background px-5 pb-5">
+        <div className="flex h-[calc(100dvh-var(--tempo-docs-primary-nav-height,65px))] w-full flex-col overflow-y-auto border-line border-x border-b bg-background px-5 pb-5">
           {menu.map((item) => {
             const active = isActiveMenuItem(pathname, item)
             // The "Docs" item is the entry point to the docs sidebar: on docs

--- a/src/components/DocsSectionNav.tsx
+++ b/src/components/DocsSectionNav.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useRouter } from 'waku'
+
+type SectionNavItem = {
+  id: 'overview' | 'build' | 'integrate' | 'protocol' | 'tools' | 'node'
+  label: string
+  href: string
+  matches: string[]
+}
+
+const sectionNavItems: SectionNavItem[] = [
+  {
+    id: 'overview',
+    label: 'Get Started',
+    href: '/docs',
+    matches: ['/docs', '/docs/guide/using-tempo-with-ai', '/docs/partners'],
+  },
+  {
+    id: 'build',
+    label: 'Build on Tempo',
+    href: '/docs/build',
+    matches: [
+      '/docs/build',
+      '/docs/guide/getting-funds',
+      '/docs/guide/payments',
+      '/docs/guide/issuance',
+      '/docs/guide/stablecoin-dex',
+      '/docs/guide/private-zones',
+      '/docs/guide/machine-payments',
+    ],
+  },
+  {
+    id: 'integrate',
+    label: 'Integrate Tempo',
+    href: '/docs/quickstart/integrate-tempo',
+    matches: [
+      '/docs/ecosystem',
+      '/docs/guide/bridge-bungee',
+      '/docs/guide/bridge-layerzero',
+      '/docs/guide/bridge-relay',
+      '/docs/guide/tempo-transaction',
+      '/docs/quickstart',
+    ],
+  },
+  {
+    id: 'protocol',
+    label: 'Tempo Protocol',
+    href: '/docs/protocol',
+    matches: ['/docs/protocol'],
+  },
+  {
+    id: 'tools',
+    label: 'Tools & SDKs',
+    href: '/docs/tools',
+    matches: [
+      '/api',
+      '/docs/cli',
+      '/docs/developer-tools',
+      '/docs/hosted-services',
+      '/docs/protocol/rpc',
+      '/docs/sdk',
+      '/docs/tools',
+      '/docs/wallet',
+    ],
+  },
+  {
+    id: 'node',
+    label: 'Run a Tempo Node',
+    href: '/docs/guide/node',
+    matches: ['/docs/changelog', '/docs/guide/node'],
+  },
+]
+
+function pathMatches(pathname: string, prefix: string) {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`)
+}
+
+function isActive(pathname: string, item: SectionNavItem) {
+  if (item.id === 'overview') return item.matches.includes(pathname)
+  if (item.id === 'tools' && pathMatches(pathname, '/docs/protocol/rpc')) return true
+  if (item.id === 'protocol' && pathMatches(pathname, '/docs/protocol/rpc')) return false
+  return item.matches.some((prefix) => pathMatches(pathname, prefix))
+}
+
+export default function DocsSectionNav() {
+  const { path } = useRouter()
+  const pathname = path ?? '/'
+  const navRef = useRef<HTMLElement | null>(null)
+  const activeLinkRef = useRef<HTMLAnchorElement | null>(null)
+  const activeLabel = sectionNavItems.find((item) => isActive(pathname, item))?.label ?? null
+
+  useEffect(() => {
+    if (!activeLabel) return
+    const nav = navRef.current
+    const activeLink = activeLinkRef.current
+    if (!nav || !activeLink) return
+
+    const centeredLeft = activeLink.offsetLeft - nav.clientWidth / 2 + activeLink.offsetWidth / 2
+    nav.scrollTo({ left: Math.max(0, centeredLeft), behavior: 'instant' })
+  }, [activeLabel])
+
+  return (
+    <>
+      <style>{`
+        @media (width >= 1024px) {
+          body:has(.docs-section-nav) nav:has(> a[aria-label='Tempo home']) {
+            display: grid !important;
+            grid-template-columns: minmax(0, 1fr) minmax(300px, 460px) minmax(0, 1fr) !important;
+            align-items: center !important;
+            gap: 12px !important;
+            padding-inline: 20px !important;
+          }
+
+          body:has(.docs-section-nav) nav:has(> a[aria-label='Tempo home']) > ul {
+            display: none !important;
+          }
+
+          body:has(.docs-section-nav) nav:has(> a[aria-label='Tempo home']) > a[aria-label='Tempo home'] {
+            min-width: 0;
+          }
+
+          body:has(.docs-section-nav) nav:has(> a[aria-label='Tempo home']) > div {
+            grid-column: 3;
+            justify-self: end;
+            gap: 20px !important;
+          }
+
+          body:has(.docs-section-nav) nav:has(> a[aria-label='Tempo home']) > div > button:first-child {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            display: flex !important;
+            width: min(460px, calc(100vw - 560px));
+            min-width: 300px;
+            height: 40px;
+            transform: translate(-50%, -50%);
+            justify-content: space-between;
+            border-radius: 6px;
+            background: var(--background);
+            padding-inline: 14px;
+            color: color-mix(in srgb, var(--foreground) 55%, transparent);
+            font-size: 0 !important;
+            box-shadow: 0 1px 1px rgb(0 0 0 / 0.03);
+          }
+
+          body:has(.docs-section-nav) nav:has(> a[aria-label='Tempo home']) > div > button:first-child::after {
+            content: 'Search docs...';
+            order: 1;
+            margin-right: auto;
+            font-size: 14px;
+          }
+
+          body:has(.docs-section-nav) nav:has(> a[aria-label='Tempo home']) > div > button:first-child svg {
+            order: 0;
+          }
+
+          body:has(.docs-section-nav) nav:has(> a[aria-label='Tempo home']) > div > button:first-child kbd {
+            order: 2;
+            background: var(--surface-input);
+            font-size: 11px !important;
+          }
+        }
+
+        @media (width >= 1080px) {
+          .docs-section-nav {
+            right: max(0px, calc((100% - var(--tempo-docs-shell-width)) * 0.5)) !important;
+            left: max(0px, calc((100% - var(--tempo-docs-shell-width)) * 0.5)) !important;
+          }
+
+          [data-layout][data-v-sidebar] > [data-v-gutter-left] {
+            padding-top: var(--vocs-spacing-topNav) !important;
+          }
+        }
+      `}</style>
+      <div className="docs-section-nav border-line border-x border-b bg-surface-shell">
+        <nav
+          ref={navRef}
+          aria-label="Documentation sections"
+          className="flex h-[var(--tempo-docs-section-nav-height)] items-stretch overflow-x-auto px-4 [scrollbar-width:none] sm:px-6 [&::-webkit-scrollbar]:hidden"
+        >
+          <ul className="flex min-w-max items-stretch gap-8">
+            {sectionNavItems.map((item) => {
+              const active = isActive(pathname, item)
+              return (
+                <li key={item.id}>
+                  <a
+                    ref={(element) => {
+                      if (active) activeLinkRef.current = element
+                    }}
+                    href={item.href}
+                    aria-current={active ? 'page' : undefined}
+                    className={`flex h-full items-center border-b-2 pt-0.5 font-normal font-sans text-[14px] tracking-[0] transition-colors ${
+                      active
+                        ? 'border-foreground text-foreground'
+                        : 'border-transparent text-foreground/50 hover:text-foreground'
+                    }`}
+                  >
+                    {item.label}
+                  </a>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
+      </div>
+    </>
+  )
+}

--- a/src/components/DocsSidebarDrawer.tsx
+++ b/src/components/DocsSidebarDrawer.tsx
@@ -30,7 +30,6 @@ export default function DocsSidebarDrawer() {
       if (!row || span) return Boolean(span)
       span = document.createElement('span')
       span.dataset.docsSidebarToggle = ''
-      span.style.display = 'inline-flex'
       span.style.marginRight = '0.5rem'
       row.prepend(span)
       setHost(span)
@@ -85,7 +84,7 @@ export default function DocsSidebarDrawer() {
           onClick={() => setOpen((value) => !value)}
           aria-label="Open docs navigation"
           aria-expanded={open}
-          className="flex items-center gap-1.5 font-sans text-foreground/70 transition-colors hover:text-foreground"
+          className="flex items-center gap-1.5 font-sans text-foreground/70 transition-colors hover:text-foreground min-[1080px]:hidden"
         >
           <svg width="16" height="16" viewBox="0 0 20 20" fill="none" aria-hidden>
             <title>Docs navigation</title>
@@ -106,7 +105,7 @@ export default function DocsSidebarDrawer() {
     <>
       {toggle}
       <div
-        className={`fixed inset-0 z-[60] lg:hidden ${open ? '' : 'pointer-events-none'}`}
+        className={`fixed inset-0 z-[60] min-[1080px]:hidden ${open ? '' : 'pointer-events-none'}`}
         aria-hidden={!open}
       >
         {/* Backdrop */}

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -61,9 +61,14 @@
 @layer utilities {
   :root {
     --tempo-docs-outline-width: 280px;
+    --tempo-docs-primary-nav-height: 65px;
+    --tempo-docs-section-nav-height: 44px;
     --tempo-docs-shell-width: 100%;
     --tempo-docs-sidebar-width: 280px;
-    --vocs-spacing-topNav: 65px;
+    --vocs-spacing-topNav: calc(
+      var(--tempo-docs-primary-nav-height) +
+      var(--tempo-docs-section-nav-height)
+    );
   }
 
   html,
@@ -71,6 +76,19 @@
     background: var(--vocs-background-color-primary);
     color: var(--vocs-text-color-primary);
     font-family: var(--font-pilat-book), ui-sans-serif, system-ui, sans-serif;
+  }
+
+  .docs-section-nav {
+    position: fixed;
+    top: var(--tempo-docs-primary-nav-height);
+    right: 0;
+    left: 0;
+    z-index: 50;
+
+    @media (width >= 1080px) {
+      right: max(0px, calc((100% - var(--tempo-docs-shell-width)) * 0.5));
+      left: max(0px, calc((100% - var(--tempo-docs-shell-width)) * 0.5));
+    }
   }
 
   [data-v-gutter-top],
@@ -86,6 +104,7 @@
     @media (width >= 1080px) {
       left: max(0px, calc((100% - var(--tempo-docs-shell-width)) * 0.5));
       width: var(--tempo-docs-sidebar-width);
+      padding-top: var(--vocs-spacing-topNav);
       justify-content: flex-start;
       background: var(--vocs-background-color-primary);
       border-right: 1px solid var(--vocs-border-color-primary);
@@ -116,6 +135,28 @@
     display: none;
   }
 
+  [data-v-sidebar-footer-content] {
+    margin-top: 12px;
+    margin-right: calc(var(--vocs-spacing-sidebar-px) * -1);
+    margin-left: calc(var(--vocs-spacing-sidebar-px) * -1);
+    padding-top: 14px;
+    padding-right: var(--vocs-spacing-sidebar-px);
+    padding-left: var(--vocs-spacing-sidebar-px);
+    border-top: 1px solid var(--vocs-border-color-primary);
+  }
+
+  [data-docs-sidebar-toggle] {
+    display: inline-flex;
+
+    @media (width >= 1080px) {
+      display: none;
+    }
+  }
+
+  [data-layout][data-v-sidebar] > [data-v-main] [data-v-outline-mobile] {
+    border-top-left-radius: 0;
+  }
+
   [data-layout][data-v-sidebar] > [data-v-main] {
     @media (width >= 1080px) {
       width: calc(var(--tempo-docs-shell-width) - var(--tempo-docs-sidebar-width));
@@ -129,12 +170,17 @@
       min-height: 100dvh;
     }
 
-    @media (1280px <= width < 1376px) {
-      padding-right: var(--tempo-docs-outline-width);
-    }
-
     @media (width >= 1376px) {
       padding-right: var(--tempo-docs-outline-width);
+    }
+  }
+
+  [data-v-gutter-right] {
+    @media (width >= 1376px) {
+      right: max(0px, calc((100% - var(--tempo-docs-shell-width)) * 0.5));
+      width: var(--tempo-docs-outline-width);
+      background: var(--vocs-background-color-primary);
+      border-right: 1px solid var(--vocs-border-color-primary);
     }
   }
 
@@ -148,58 +194,10 @@
     }
   }
 
-  /* Vocs renders OpenAPI guide/landing pages with `content.width = full`,
-     while regular docs prose is centered. Bring single-column full-width pages
-     back to the same readable measure, but leave generated reference pages wide. */
-  [data-layout][data-v-sidebar][data-v-content-width="full"]:not(
-      :has([data-v-openapi]:not([data-v-openapi-landing]))
-    )
-    > [data-v-main]
-    > [data-v-content],
-  [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
-      > [data-v-main] > [data-v-content] > [data-v-openapi-landing]
-    )
-    > [data-v-main]
-    > [data-v-content] {
-    @media (width >= 1376px) {
-      width: min(100%, var(--vocs-spacing-content));
-      max-width: var(--vocs-spacing-content);
-      margin-left: auto;
-      margin-right: auto;
-    }
-  }
-
-  [data-v-gutter-right] {
-    @media (1280px <= width < 1376px) {
-      right: auto;
-      left: calc(100vw - var(--tempo-docs-outline-width));
-      inset-inline-start: calc(100vw - var(--tempo-docs-outline-width));
-      inset-inline-end: auto;
-      display: flex;
-      width: var(--tempo-docs-outline-width);
-      background: var(--vocs-background-color-primary);
-      border-right: 1px solid var(--vocs-border-color-primary);
-    }
-
-    @media (width >= 1376px) {
-      right: max(0px, calc((100% - var(--tempo-docs-shell-width)) * 0.5));
-      width: var(--tempo-docs-outline-width);
-      background: var(--vocs-background-color-primary);
-      border-right: 1px solid var(--vocs-border-color-primary);
-    }
-  }
-
-  /* Generated OpenAPI category/reference pages are intentionally wide: the
-     request/response UI needs the room, and the generated sidebar already
-     provides operation navigation, so the regular right outline is hidden. */
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    ):not(:has(> [data-v-main] > [data-v-content] > [data-v-openapi-landing]))
+    )
     > [data-v-main] {
-    @media (1280px <= width < 1376px) {
-      padding-right: 0;
-    }
-
     @media (width >= 1376px) {
       padding-right: 0;
     }
@@ -207,13 +205,8 @@
 
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    ):not(:has(> [data-v-main] > [data-v-content] > [data-v-openapi-landing]))
-    > [data-v-main]
+    )
     > [data-v-gutter-right] {
-    @media (1280px <= width < 1376px) {
-      display: none;
-    }
-
     @media (width >= 1376px) {
       display: none;
     }
@@ -221,11 +214,11 @@
 
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    ):not(:has(> [data-v-main] > [data-v-content] > [data-v-openapi-landing]))
+    )
     [data-v-openapi-header],
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    ):not(:has(> [data-v-main] > [data-v-content] > [data-v-openapi-landing]))
+    )
     [data-v-openapi-description] {
     width: 100%;
     max-width: none;
@@ -236,16 +229,129 @@
 
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    ):not(:has(> [data-v-main] > [data-v-content] > [data-v-openapi-landing]))
+    )
     [data-v-openapi]
     [data-v-content] {
     margin-left: 0;
     margin-right: 0;
   }
 
+  [data-v-sidebar-container] [data-v-sidebar] {
+    gap: 14px;
+    font-family: var(--font-pilat-book), ui-sans-serif, system-ui, sans-serif;
+  }
+
+  [data-v-sidebar] [data-v-sidebar-section] {
+    min-width: 0;
+  }
+
+  [data-v-sidebar] > [data-v-sidebar-section] > [data-v-sidebar-section-header] {
+    height: auto;
+    min-height: 0;
+    margin: 0 -8px 8px;
+    padding: 0 8px;
+    background: transparent;
+    color: color-mix(in srgb, var(--foreground) 42%, transparent);
+    font-size: 13px;
+    font-weight: 400;
+    letter-spacing: 0;
+    line-height: 1.3;
+  }
+
+  [data-v-sidebar] [data-v-sidebar-section-content] [data-v-sidebar-section-header] {
+    min-height: 30px;
+    margin: 1px -8px;
+    padding: 0 8px;
+    border-radius: 6px;
+    background: transparent;
+    color: color-mix(in srgb, var(--foreground) 58%, transparent);
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0;
+    line-height: 1.35;
+  }
+
+  [data-v-sidebar]
+    [data-v-sidebar-section-content]
+    [data-v-sidebar-section-header]:not([data-collapsable="true"]) {
+    min-height: 26px;
+    margin: 6px -8px 1px;
+    color: color-mix(in srgb, var(--foreground) 42%, transparent);
+    font-size: 13px;
+    font-weight: 400;
+  }
+
+  [data-v-sidebar]
+    [data-v-sidebar-section-content]
+    [data-v-sidebar-section-header][data-collapsable="true"] {
+    color: color-mix(in srgb, var(--foreground) 68%, transparent);
+  }
+
+  [data-v-sidebar]
+    [data-v-sidebar-section-content]
+    [data-v-sidebar-section-header][data-collapsable="true"]:hover {
+    background: color-mix(in srgb, var(--foreground) 4%, transparent);
+    color: var(--foreground);
+  }
+
+  [data-v-sidebar] [data-v-sidebar-section-content] {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  [data-v-sidebar] [data-v-sidebar-section-content] [data-v-sidebar-section-content] {
+    margin-top: 2px;
+    margin-bottom: 2px;
+    border-left-color: color-mix(in srgb, var(--foreground) 10%, transparent);
+    gap: 0;
+  }
+
+  [data-v-sidebar] [data-v-sidebar-item][data-link] {
+    min-height: 30px;
+    margin: 0 -8px;
+    padding: 0 8px;
+    border-radius: 6px;
+    color: color-mix(in srgb, var(--foreground) 58%, transparent);
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0;
+    line-height: 1.35;
+  }
+
+  [data-v-sidebar] a[data-v-sidebar-item][data-link]:hover {
+    background: color-mix(in srgb, var(--foreground) 4%, transparent);
+    color: var(--foreground);
+  }
+
   [data-v-sidebar] a[data-v-sidebar-item][data-active] {
     background: transparent;
-    color: var(--vocs-text-color-primary);
+    color: var(--foreground);
+    font-weight: 500;
+    box-shadow: none;
+  }
+
+  [data-v-sidebar] a[data-v-sidebar-item][data-active]:hover {
+    background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  }
+
+  [data-v-sidebar] [data-v-sidebar-item][data-condensed="true"] {
+    min-height: 28px;
+    font-size: 13px;
+  }
+
+  [data-v-sidebar] [data-v-sidebar-section-header] svg {
+    color: color-mix(in srgb, var(--foreground) 38%, transparent);
+  }
+
+  [data-v-sidebar-footer-content] [data-v-socials] a[aria-label="GitHub"] svg {
+    width: 19px;
+    height: 19px;
+  }
+
+  [data-v-sidebar-footer-content] [data-v-socials] a[aria-label="X (Twitter)"] svg {
+    width: 16px;
+    height: 16px;
   }
 
   [data-v-ask-ai-container] {
@@ -267,54 +373,11 @@
 }
 
 @layer vocs_utilities {
-  @media (1280px <= width < 1376px) {
-    [data-layout][data-v-sidebar] > [data-v-main] > [data-v-outline-mobile] {
-      display: none;
-    }
-
-    /* In Vocs 2.1.x the right outline is mounted inside `<main>`, not beside it.
-       Pin it to the same shell edge as normal docs pages. */
-    [data-layout][data-v-sidebar] > [data-v-main] > [data-v-gutter-right] {
-      right: auto;
-      left: calc(100vw - var(--tempo-docs-outline-width));
-      inset-inline-start: calc(100vw - var(--tempo-docs-outline-width));
-      inset-inline-end: auto;
-      display: flex;
-      width: var(--tempo-docs-outline-width);
-    }
-
-    [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
-        [data-v-openapi]:not([data-v-openapi-landing])
-      ):not(:has(> [data-v-main] > [data-v-content] > [data-v-openapi-landing]))
-      > [data-v-main]
-      > [data-v-gutter-right] {
-      display: none;
-    }
-  }
-
   @media (width >= 1376px) {
     [data-v-ask-ai-container] > button {
       min-width: 0;
       width: 100%;
       max-width: 100%;
-    }
-
-    /* In Vocs 2.1.x the right outline is mounted inside `<main>`, not beside it.
-       Pin it to the same shell edge as normal docs pages. */
-    [data-layout][data-v-sidebar] > [data-v-main] > [data-v-gutter-right] {
-      right: auto;
-      left: calc(100vw - var(--tempo-docs-outline-width));
-      inset-inline-start: calc(100vw - var(--tempo-docs-outline-width));
-      inset-inline-end: auto;
-      width: var(--tempo-docs-outline-width);
-    }
-
-    [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
-        [data-v-openapi]:not([data-v-openapi-landing])
-      ):not(:has(> [data-v-main] > [data-v-content] > [data-v-openapi-landing]))
-      > [data-v-main]
-      > [data-v-gutter-right] {
-      display: none;
     }
   }
 }
@@ -1302,6 +1365,12 @@ body {
 [data-v-openapi-overview] [data-v-openapi-disclosure-trigger]:hover,
 [data-v-openapi-overview] [data-v-openapi-overview-endpoint]:hover {
   background-color: transparent;
+}
+
+[data-v-sidebar][data-v-sidebar] a[data-v-sidebar-item][data-active]:not(:hover) {
+  background: transparent;
+  background-color: transparent;
+  box-shadow: none;
 }
 
 [data-v-sidebar] a[data-v-sidebar-item][href$="/protocol/upgrades/t7"] [data-v-sidebar-item-badge] {

--- a/src/pages/docs/_layout.tsx
+++ b/src/pages/docs/_layout.tsx
@@ -2,6 +2,7 @@
 
 import { lazy, type PropsWithChildren, Suspense } from 'react'
 import DocsHeader from '../../components/DocsHeader'
+import DocsSectionNav from '../../components/DocsSectionNav'
 import DocsSidebarDrawer from '../../components/DocsSidebarDrawer'
 import { usePageSettled } from '../../lib/pageSettled'
 
@@ -37,6 +38,7 @@ export default function DocsLayout(
   return (
     <>
       <DocsHeader />
+      <DocsSectionNav />
       <DocsSidebarDrawer />
       {props.children}
       <Suspense fallback={null}>

--- a/src/pages/docs/build.mdx
+++ b/src/pages/docs/build.mdx
@@ -1,0 +1,76 @@
+---
+title: Build on Tempo
+description: Choose Tempo build guides for stablecoin payments, issuance, exchange, private zones, agentic payments, fee sponsorship, and production workflows for launch.
+---
+
+import { Cards, Card } from 'vocs'
+
+# Build on Tempo
+
+Use this section when you are designing payment experiences or payment infrastructure on Tempo. The guides here focus on what your product should do: move stablecoins, issue assets, exchange liquidity, isolate activity in private zones, or let agents pay for services.
+
+Start with **Make Payments** if you are not sure where to begin. It covers the core transfer flow and introduces the payment primitives used throughout the rest of the docs.
+
+## Payment Workflows
+
+<Cards>
+  <Card
+    title="Make Payments"
+    description="Send and receive stablecoin payments, attach memos, sponsor fees, and handle parallel transactions."
+    to="/docs/guide/payments"
+    icon="lucide:send"
+  />
+  <Card
+    title="Issue Stablecoins"
+    description="Create, mint, manage, and distribute rewards for stablecoins using TIP-20 tokens."
+    to="/docs/guide/issuance"
+    icon="lucide:coins"
+  />
+  <Card
+    title="Exchange Stablecoins"
+    description="Use Tempo's enshrined stablecoin exchange for swaps and fee-liquidity workflows."
+    to="/docs/guide/stablecoin-dex"
+    icon="lucide:arrow-left-right"
+  />
+  <Card
+    title="Private Zones"
+    description="Connect to zones, deposit funds, send tokens privately, bridge, swap, and withdraw."
+    to="/docs/guide/private-zones"
+    icon="lucide:lock-keyhole"
+  />
+  <Card
+    title="Agentic Payments"
+    description="Accept one-time, pay-as-you-go, and streamed payments through the Machine Payments Protocol."
+    to="/docs/guide/machine-payments"
+    icon="lucide:bot"
+  />
+</Cards>
+
+## Before You Ship
+
+<Cards>
+  <Card
+    title="Get Funds"
+    description="Fund wallets and test payment flows before moving to production integrations."
+    to="/docs/guide/getting-funds"
+    icon="lucide:wallet"
+  />
+  <Card
+    title="Use Tempo Transactions"
+    description="Batch calls, sponsor fees, schedule execution, and build richer payment flows."
+    to="/docs/guide/tempo-transaction"
+    icon="lucide:layers"
+  />
+  <Card
+    title="Configure Receive Policies"
+    description="Control which tokens and senders an account can receive for TIP-20 transfers."
+    to="/docs/guide/payments/configure-receive-policies"
+    icon="lucide:shield-check"
+  />
+  <Card
+    title="Pay Fees in Any Stablecoin"
+    description="Use Tempo's fee system to pay transaction fees with supported stablecoins."
+    to="/docs/guide/payments/pay-fees-in-any-stablecoin"
+    icon="lucide:badge-dollar-sign"
+  />
+</Cards>

--- a/src/pages/docs/guide/node/index.mdx
+++ b/src/pages/docs/guide/node/index.mdx
@@ -1,48 +1,93 @@
 ---
-description: Run your own Tempo node for direct network access. Set up RPC nodes for API access or validator nodes to participate in consensus.
+title: Run a Tempo Node
+description: Run Tempo node infrastructure for RPC access, validator operations, system requirements, installation, monitoring, security, upgrades, and release operations.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Tempo Node
+# Run a Tempo Node
 
-Running a Tempo node allows you to interact with the network directly, providing your own RPC access or contributing to network infrastructure. Nodes provide JSON-RPC API access for applications, explorers, and wallets but do not participate in consensus.
+Run Tempo infrastructure when you need direct network access, dedicated RPC capacity, validator operations, or lower-level visibility into network behavior.
 
-## Supported Platforms
+Most teams should start with an RPC node. Validator operation requires coordination with the Tempo team and is documented separately from the RPC path.
 
-Prebuilt binaries are available for:
-- **Linux** (x86_64 and ARM64) - requires glibc ≥ 2.38
-- **macOS** (ARM64)
-
-## Getting Started
+## RPC Node Path
 
 <Cards>
   <Card
-    description="Hardware and software requirements for running a node"
+    title="System Requirements"
+    description="Hardware, operating system, and runtime requirements for Tempo node software."
     to="/docs/guide/node/system-requirements"
     icon="lucide:hard-drive"
-    title="System Requirements"
   />
   <Card
-    description="Download and install the Tempo node software"
+    title="Installation"
+    description="Download, install, and prepare the Tempo node binary for supported platforms."
     to="/docs/guide/node/installation"
     icon="lucide:download"
-    title="Installation"
   />
   <Card
-    description="Configure and run a full RPC node"
+    title="Run an RPC Node"
+    description="Configure and run a node that serves JSON-RPC traffic for apps, explorers, and wallets."
     to="/docs/guide/node/rpc"
-    icon="lucide:play"
-    title="Running an RPC Node"
+    icon="lucide:server"
   />
   <Card
-    description="Upcoming and past network upgrades and important releases"
-    to="/docs/guide/node/network-upgrades"
-    icon="lucide:arrow-up-circle"
-    title="Network Upgrades and Releases"
+    title="Node Security"
+    description="Harden node operations, network exposure, key handling, and runtime configuration."
+    to="/docs/guide/node/security"
+    icon="lucide:shield"
   />
 </Cards>
 
-:::info
-Validator onboarding requires coordination with the Tempo team. Reach out to us if you are interested.
-:::
+## Validator Operations
+
+<Cards>
+  <Card
+    title="Validator Overview"
+    description="Understand validator responsibilities and the operational path before onboarding."
+    to="/docs/guide/node/validator"
+    icon="lucide:badge-check"
+  />
+  <Card
+    title="Validator Onboarding"
+    description="Set up validator software and prepare to participate in coordinated network operations."
+    to="/docs/guide/node/validator-setup"
+    icon="lucide:clipboard-check"
+  />
+  <Card
+    title="Monitoring"
+    description="Monitor validator health, status, failover, and lifecycle operations."
+    to="/docs/guide/node/validator-monitoring"
+    icon="lucide:activity"
+  />
+  <Card
+    title="Troubleshooting"
+    description="Debug validator issues, common failure modes, and operational questions."
+    to="/docs/guide/node/validator-troubleshooting"
+    icon="lucide:wrench"
+  />
+</Cards>
+
+## Releases
+
+<Cards>
+  <Card
+    title="Upgrade Cadence"
+    description="Understand how Tempo node upgrades are planned, communicated, and rolled out."
+    to="/docs/guide/node/upgrade-cadence"
+    icon="lucide:calendar-clock"
+  />
+  <Card
+    title="Network Upgrades"
+    description="Track upgrade instructions, release notes, and node operator actions."
+    to="/docs/guide/node/network-upgrades"
+    icon="lucide:arrow-up-circle"
+  />
+  <Card
+    title="Changelog"
+    description="Review recent changes relevant to node operators and protocol users."
+    to="/docs/changelog"
+    icon="lucide:list-tree"
+  />
+</Cards>

--- a/src/pages/docs/guide/using-tempo-with-ai.mdx
+++ b/src/pages/docs/guide/using-tempo-with-ai.mdx
@@ -1,6 +1,6 @@
 ---
-title: Developing with LLMs
-description: Give your AI coding agent Tempo documentation context with skills, Markdown pages, and MCP.
+title: Use Tempo with AI
+description: Connect AI coding agents to Tempo docs, source context, MCP tools, Markdown pages, plugins, workflow skills, and feedback loops for accurate development.
 interactive: true
 ---
 
@@ -8,7 +8,11 @@ import { Tabs, Tab } from 'vocs'
 import { DocsLinkButton } from '../../../components/DocsLinkButton.tsx'
 import { TempoMcpExplorer } from '../../../components/TempoMcpExplorer.tsx'
 
-# Developing with LLMs
+# Use Tempo with AI
+
+Tempo publishes documentation, Markdown pages, MCP tools, and agent plugins so AI coding agents can work with Tempo using current project context instead of guesses.
+
+Use this page when you want Claude, Codex, Cursor, Amp, or another MCP-compatible client to search Tempo docs, read source-linked references, and install reusable Tempo workflows.
 
 ## Connect to Tempo's MCP server
 

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -1,48 +1,104 @@
 ---
-description: Explore Tempo's blockchain documentation, integration guides, and protocol specs. Build low-cost, high-throughput payment applications.
+title: Get Started
+description: Start building on Tempo with integration paths, payment guides, protocol references, SDKs, hosted services, node operations, AI resources, and partners.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Tempo [Documentation, integration guides, and protocol specifications]
+# Get Started
 
-## Welcome to Tempo! 
+Connect to Tempo and learn how to build stablecoin payment products. Start with network setup, fund a wallet, send a payment, then move into production workflows, protocol references, tooling, or infrastructure.
 
-Tempo is a general-purpose blockchain optimized for payments. Tempo is designed to be a low-cost, high-throughput blockchain with user and developer features that we believe should be core to a modern payment system.
+If you are new to Tempo, start with **Integrate Tempo** to connect to the network, then move to **Build on Tempo** for payment workflows.
 
-Tempo was designed in close collaboration with an exceptional group of [design partners](https://tempo.xyz/ecosystem) who are helping to validate the system against real payment workloads.
-
-These docs cover everything from creating a wallet to building payment systems on Tempo.
+## First Steps
 
 <Cards>
   <Card
-    title="Create a Wallet"
-    description="Set up a Tempo Wallet and run your first transaction on mainnet."
+    title="Connect to Tempo"
+    description="Add Tempo chain configuration, RPC endpoints, explorer links, and wallet connection details."
+    to="/docs/quickstart/integrate-tempo"
+    icon="lucide:plug"
+  />
+  <Card
+    title="Get Funds"
+    description="Fund a test wallet so you can deploy contracts, send payments, and exercise integration flows."
     to="/docs/guide/getting-funds"
     icon="lucide:wallet"
   />
   <Card
-    title="Connect to Tempo"
-    description="RPC endpoints, chain config, SDKs, and integration guides for mainnet."
-    to="/docs/quickstart/integrate-tempo"
-    icon="lucide:rocket"
-  />
-  <Card
-    title="Make Payments"
-    description="Send payments, attach memos, sponsor fees, and build payment flows."
+    title="Send a Payment"
+    description="Send a stablecoin payment, configure fees, attach memos, and handle receipt policies."
     to="/docs/guide/payments"
-    icon="lucide:arrow-left-right"
+    icon="lucide:send"
+  />
+</Cards>
+
+## Choose a Section
+
+<Cards>
+  <Card
+    title="Build on Tempo"
+    description="Payments, stablecoin issuance, exchange, private zones, and agentic payment workflows."
+    to="/docs/build"
+    icon="lucide:blocks"
   />
   <Card
-    title="Make Agentic Payments"
-    description="Let agents pay for services using the Machine Payments Protocol - sessions and streaming payments."
-    to="/docs/guide/machine-payments"
+    title="Integrate Tempo"
+    description="Network details, faucet funds, wallet support, EVM differences, bridges, and ecosystem entry points."
+    to="/docs/quickstart/integrate-tempo"
+    icon="lucide:plug"
+  />
+  <Card
+    title="Tempo Protocol"
+    description="Technical references for tokens, policies, fees, transactions, blockspace, exchange, zones, and TIPs."
+    to="/docs/protocol"
+    icon="lucide:file-code"
+  />
+  <Card
+    title="Tools & SDKs"
+    description="SDKs, CLI, hosted services, wallet docs, JSON-RPC, and indexer tooling."
+    to="/docs/tools"
+    icon="lucide:terminal-square"
+  />
+  <Card
+    title="Run a Tempo Node"
+    description="Run Tempo infrastructure for direct RPC access, validation workflows, monitoring, and upgrades."
+    to="/docs/guide/node"
+    icon="lucide:server"
+  />
+</Cards>
+
+## Common Workflows
+
+<Cards>
+  <Card
+    title="Issue a Stablecoin"
+    description="Create, mint, manage, and distribute rewards for a TIP-20 stablecoin."
+    to="/docs/guide/issuance"
+    icon="lucide:coins"
+  />
+  <Card
+    title="Find Partners"
+    description="Explore ecosystem partners across issuers, wallets, ramps, compliance, custody, and infrastructure."
+    to="/docs/partners"
+    icon="lucide:network"
+  />
+</Cards>
+
+## Resources
+
+<Cards>
+  <Card
+    title="Use Tempo with AI"
+    description="Give coding agents Tempo docs, source context, MCP tools, and agent workflow plugins."
+    to="/docs/guide/using-tempo-with-ai"
     icon="lucide:bot"
   />
   <Card
-    title="Read Protocol Specs"
-    description="Native stablecoins, smart accounts, fee markets, and the full protocol specification."
-    to="/docs/protocol"
-    icon="lucide:file-text"
+    title="Partners"
+    description="Find issuers, wallets, ramps, compliance, custody, analytics, orchestration, and infrastructure partners."
+    to="/docs/partners"
+    icon="lucide:network"
   />
 </Cards>

--- a/src/pages/docs/protocol/index.mdx
+++ b/src/pages/docs/protocol/index.mdx
@@ -1,70 +1,87 @@
 ---
-description: Technical specifications and reference documentation for the Tempo blockchain protocol, purpose-built for global payments at scale.
+title: Tempo Protocol
+description: Read Tempo protocol references for tokens, policies, fees, transactions, blockspace, exchange, zones, network upgrades, TIP specs, and implementation details.
 ---
 
 import { Cards, Card } from 'vocs'
 
 # Tempo Protocol
 
-Tempo is a blockchain protocol purpose-built for global payments. Rather than being a general-purpose platform, Tempo makes deliberate technical choices optimized for payments at scale.
+Use this section when you need the technical reference for Tempo itself. These pages are written for implementers, auditors, wallet teams, infrastructure operators, and anyone building against protocol-level behavior rather than a single product workflow.
 
-This section provides details on the Tempo Protocol specifications, and serves as a technical reference for protocol implementers, auditors, and core contributors building on Tempo. 
+If you are building an app, start with the guides in **Build on Tempo** and come here when you need exact semantics, ABI details, or protocol rationale.
 
-## Protocol Components
+## Core Primitives
 
 <Cards>
   <Card
-    description="Core token standard with native stablecoin features and policy registry integration"
+    title="TIP-20 Tokens"
+    description="Stablecoin-native token behavior, metadata, fees, memos, policies, and liquidity routing."
     to="/docs/protocol/tip20/overview"
     icon="lucide:coins"
-    title="TIP-20 Tokens"
   />
   <Card
-    description="Reward distribution system for token holders with automated yield mechanisms"
-    to="/docs/protocol/tip20-rewards/overview"
-    icon="lucide:gift"
-    title="Tempo Token Rewards"
-  />
-  <Card
-    description="Policy registry system for compliance, access control, and token governance"
+    title="Tempo Policies"
+    description="TIP-403 policy checks, receive policies, access controls, and registry behavior."
     to="/docs/protocol/tip403/overview"
-    icon="lucide:shield"
-    title="Tempo Policies (TIP-403)"
-  />
-  <Card
-    description="Receiver-side token and sender filters for inbound TIP-20 transfers and mints"
-    to="/docs/protocol/tip403/receive-policies"
     icon="lucide:shield-check"
-    title="Receive Policies"
   />
   <Card
-    description="Multi-token fee payment system with AMM for stablecoin conversion"
-    to="/docs/protocol/fees"
-    icon="lucide:wallet"
     title="Fees"
+    description="Stablecoin fee payment, fee accounting, and the fee AMM used for conversion."
+    to="/docs/protocol/fees"
+    icon="lucide:badge-dollar-sign"
   />
   <Card
-    description="EIP-2718 transaction type with native passkeys, batching, scheduling, and fee sponsorship"
+    title="Tempo Transactions"
+    description="Tempo transaction type, batching, scheduling, fee sponsorship, and account keychains."
     to="/docs/protocol/transactions"
     icon="lucide:layers"
-    title="Tempo Transactions"
   />
+</Cards>
+
+## Network Systems
+
+<Cards>
   <Card
-    description="Block format and payment lanes for optimized throughput"
-    to="/docs/protocol/blockspace/overview"
-    icon="lucide:layout"
     title="Blockspace"
+    description="Consensus, finality, block format, payment lanes, and throughput-oriented protocol design."
+    to="/docs/protocol/blockspace/overview"
+    icon="lucide:layout-dashboard"
   />
   <Card
-    description="Enshrined stablecoin DEX for stablecoin interoperability"
+    title="Stablecoin DEX"
+    description="Enshrined stablecoin exchange, quote tokens, swaps, liquidity, and exchange balances."
     to="/docs/protocol/exchange"
     icon="lucide:arrow-left-right"
-    title="Stablecoin DEX"
   />
   <Card
-    description="View the full Tempo protocol source code and implementation"
+    title="Zones"
+    description="Private zone architecture, accounts, bridging, RPC, execution, gas, and proving."
+    to="/docs/protocol/zones"
+    icon="lucide:scan"
+  />
+  <Card
+    title="Network Upgrades"
+    description="Track upgrade specifications, migration notes, and release-level protocol changes."
+    to="/docs/protocol/upgrades/t7"
+    icon="lucide:arrow-up-circle"
+  />
+</Cards>
+
+## Specifications
+
+<Cards>
+  <Card
+    title="TIPs"
+    description="Browse Tempo Improvement Proposals for standards, process changes, and protocol history."
+    to="/docs/protocol/tips"
+    icon="lucide:file-text"
+  />
+  <Card
+    title="GitHub Repository"
+    description="Read the Tempo source implementation and follow protocol development in the open."
     to="https://github.com/tempoxyz/tempo"
     icon="lucide:github"
-    title="GitHub Repository"
   />
 </Cards>

--- a/src/pages/docs/quickstart/integrate-tempo.mdx
+++ b/src/pages/docs/quickstart/integrate-tempo.mdx
@@ -1,76 +1,88 @@
 ---
-description: Build on Tempo Testnet. Connect to the network, explore SDKs, and follow guides for payments, stablecoin issuance, and exchange.
+title: Integrate Tempo
+description: Connect apps and wallets to Tempo with network configuration, faucet funding, EVM compatibility notes, bridges, verification, and ecosystem resources.
 interactive: true
 ---
 
-import * as Demo from '../../../components/guides/Demo.tsx'
-import { ConnectWallet } from '../../../components/ConnectWallet.tsx'
 import { Cards, Card } from 'vocs'
 
 # Integrate Tempo
 
-Tempo is fully compatible with the Ethereum Virtual Machine (EVM), targeting the **Osaka** EVM hard fork. So, everything you'd expect to work with Ethereum works on Tempo, with only a few exceptions which we detail on the [EVM Differences](/docs/quickstart/evm-compatibility) page. 
+Use this section when you are connecting an existing app, wallet, contract, bridge, or infrastructure service to Tempo. These pages cover the practical edges of integration: chain configuration, RPC endpoints, faucet funding, wallet support, EVM compatibility, predeploys, contract verification, and ecosystem resources.
 
+Tempo is EVM-compatible and targets the **Osaka** EVM hard fork. Most Ethereum tooling works as expected, with Tempo-specific differences documented where they matter.
+
+## First Connection
 
 <Cards>
   <Card
     icon="lucide:network"
     title="Connect to the Network"
-    description="Learn how to connect to the Tempo Testnet with your wallet or programmatically."
+    description="Add Tempo chain configuration, RPC endpoints, explorer links, and wallet connection details."
     to="/docs/quickstart/connection-details"
   />
   <Card
+    icon="lucide:droplets"
+    title="Get Testnet Faucet Funds"
+    description="Fund test wallets so you can deploy contracts, send payments, and exercise integration flows."
+    to="/docs/quickstart/faucet"
+  />
+  <Card
+    icon="lucide:badge-check"
+    title="Verify Contracts"
+    description="Verify deployed contracts and make them easier to inspect, debug, and share."
+    to="/docs/quickstart/verify-contracts"
+  />
+</Cards>
+
+## App and Wallet Integration
+
+<Cards>
+  <Card
     icon="lucide:wallet"
-    title="Integrate Wallet Support"
-    description="Support Tempo in your wallet with fee sponsorship and native stablecoins."
+    title="Wallet Developers"
+    description="Support Tempo in wallets with stablecoin-native fees, chain metadata, and transaction behavior."
     to="/docs/quickstart/wallet-developers"
   />
+  <Card
+    icon="lucide:code-2"
+    title="EVM Differences"
+    description="Understand the Tempo-specific behavior that differs from default Ethereum assumptions."
+    to="/docs/quickstart/evm-compatibility"
+  />
+  <Card
+    icon="lucide:boxes"
+    title="Predeployed Contracts"
+    description="Find Tempo predeploys and system contracts used by integrations and protocol features."
+    to="/docs/quickstart/predeployed-contracts"
+  />
+  <Card
+    icon="lucide:list"
+    title="Token List Registry"
+    description="Use Tempo token lists to discover supported assets and present stablecoins correctly."
+    to="/docs/quickstart/tokenlist"
+  />
 </Cards>
 
-## Start Building
-
-The guides below will help you get a sense for what is possible to do with Tempo. All of the guides below are fully-featured Tempo applications themselves, built with the [Tempo SDKs](/docs/sdk).
+## Interoperability
 
 <Cards>
   <Card
-    icon="lucide:send"
-    title="Make Payments"
-    description="Send and receive stablecoin payments with flexible fee options and sponsorship capabilities"
-    to="/docs/guide/payments"
+    icon="lucide:bridge"
+    title="Bridge via LayerZero"
+    description="Bridge supported assets to and from Tempo using LayerZero."
+    to="/docs/guide/bridge-layerzero"
   />
   <Card
-    icon="lucide:coins"
-    title="Issue Stablecoins"
-    description="Create and manage your own stablecoin with built-in compliance features"
-    to="/docs/guide/issuance"
+    icon="lucide:route"
+    title="Bridge via Relay"
+    description="Use Relay to move assets between Tempo and other supported networks."
+    to="/docs/guide/bridge-relay"
   />
   <Card
-    icon="lucide:arrow-left-right"
-    title="Exchange Stablecoins"
-    description="Trade between stablecoins on Tempo's enshrined decentralized exchange"
-    to="/docs/guide/stablecoin-dex"
+    icon="lucide:network"
+    title="Ecosystem"
+    description="Find bridges, wallets, analytics, infrastructure, compliance, and orchestration partners."
+    to="/docs/ecosystem"
   />
 </Cards>
-
-## Go Deeper
-
-The Tempo source code is fully open-source and available on [GitHub](https://github.com/tempoxyz).
-
-If you're interested in learning more about how Tempo works under the hood, feel free to explore the codebase directly, run a node for yourself, or refer to the protocol specifications for a deeper understanding. 
-
-<Cards>
-  <Card
-    icon="lucide:server"
-    title="Run a Tempo Node"
-    description="System requirements, installation and usage instructions for running a Tempo node."
-    to="/docs/guide/node"
-  />
-  <Card
-    icon="lucide:book-open"
-    title="Protocol Specifications"
-    description="Technical specifications for tokens, fees, transactions, and protocol components."
-    to="/docs/protocol"
-  />
-</Cards>
-
-We welcome contributions from the community to help improve and expand the project.

--- a/src/pages/docs/tools.mdx
+++ b/src/pages/docs/tools.mdx
@@ -1,0 +1,70 @@
+---
+title: Tools & SDKs
+description: Find Tempo SDKs, CLI commands, hosted services, wallet docs, RPC references, and indexer tools for building, testing, and operating production integrations.
+---
+
+import { Cards, Card } from 'vocs'
+
+# Tools & SDKs
+
+Use this section when you need the implementation surface for Tempo: libraries, command-line tools, managed services, wallet integration, RPC references, and query access to network data.
+
+If you are integrating a product, start with the TypeScript SDKs and hosted services. If you are operating infrastructure or debugging low-level behavior, start with the CLI and RPC reference.
+
+## Developer Surfaces
+
+<Cards>
+  <Card
+    title="SDKs"
+    description="Use TypeScript, Go, Foundry, Python, and Rust tooling for Tempo applications."
+    to="/docs/sdk"
+    icon="lucide:package"
+  />
+  <Card
+    title="CLI"
+    description="Manage wallets, make requests, download binaries, and run node-related commands."
+    to="/docs/cli"
+    icon="lucide:terminal"
+  />
+  <Card
+    title="Hosted Services"
+    description="Use managed Tempo services for fee sponsorship and indexer-backed data access."
+    to="/docs/hosted-services"
+    icon="lucide:cloud"
+  />
+  <Card
+    title="Tempo Wallet"
+    description="Integrate the Tempo Wallet, recipes, references, and agent-oriented wallet flows."
+    to="/docs/wallet"
+    icon="lucide:wallet"
+  />
+</Cards>
+
+## References and Data
+
+<Cards>
+  <Card
+    title="JSON-RPC Reference"
+    description="Browse Tempo RPC methods, request shapes, and protocol-level API behavior."
+    to="/docs/protocol/rpc"
+    icon="lucide:braces"
+  />
+  <Card
+    title="Indexer (tidx)"
+    description="Query Tempo blocks, transactions, logs, token balances, and decoded events through SQL."
+    to="/docs/developer-tools/indexer"
+    icon="lucide:database"
+  />
+  <Card
+    title="Hosted Fee Payer"
+    description="Sponsor Tempo transaction fees through hosted JSON-RPC relay endpoints."
+    to="/docs/developer-tools/fee-payer"
+    icon="lucide:badge-dollar-sign"
+  />
+  <Card
+    title="Use Tempo with AI"
+    description="Install MCP, plugins, and docs context so coding agents can work with Tempo accurately."
+    to="/docs/guide/using-tempo-with-ai"
+    icon="lucide:bot"
+  />
+</Cards>

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -112,47 +112,43 @@ export default defineConfig({
   },
   openapi: [
     {
-      path: '/docs/api',
-      spec: 'https://api.tempo.xyz/openapi.json',
+      path: '/api',
+      spec: './openapi-preview.json',
       sidebar: {
-        collapsed: true,
+        collapsed: false,
         backLink: false,
         intro: [
           {
             text: 'Authentication',
-            link: '/docs/api/authentication',
+            link: '/api/authentication',
           },
           {
             text: 'Conventions',
-            link: '/docs/api/conventions',
-          },
-          {
-            text: 'Transactions & Transfers',
-            link: '/docs/api/transactions-and-transfers',
+            link: '/api/conventions',
           },
           {
             text: 'JSON-RPC API',
-            link: '/docs/api/json-rpc',
+            link: '/api/json-rpc',
           },
           {
             text: 'Indexer API',
-            link: '/docs/api/indexer-api',
+            link: '/api/indexer-api',
           },
           {
             text: 'Pagination',
-            link: '/docs/api/pagination',
+            link: '/api/pagination',
           },
           {
             text: 'Rate Limits',
-            link: '/docs/api/rate-limits',
+            link: '/api/rate-limits',
           },
           {
             text: 'Errors',
-            link: '/docs/api/errors',
+            link: '/api/errors',
           },
           {
             text: 'Versioning Policy',
-            link: '/docs/api/versioning-policy',
+            link: '/api/versioning-policy',
           },
         ],
       },
@@ -178,14 +174,14 @@ export default defineConfig({
       link: 'https://twitter.com/tempo',
     },
   ],
-  sidebar: {
-    '/docs': [
+  sidebar: (() => {
+    const docsSidebar = [
       {
-        text: 'Home',
+        text: 'Get Started',
         link: '/docs',
       },
       {
-        text: 'Developing with LLMs',
+        text: 'AI',
         link: '/docs/guide/using-tempo-with-ai',
       },
       {
@@ -196,12 +192,16 @@ export default defineConfig({
         text: 'Build on Tempo',
         items: [
           {
+            text: 'Overview',
+            link: '/docs/build',
+          },
+          {
             text: 'Getting Funds on Tempo',
             link: '/docs/guide/getting-funds',
           },
           {
             text: 'Make Payments',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -253,7 +253,7 @@ export default defineConfig({
           },
           {
             text: 'Issue Stablecoins',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -283,7 +283,7 @@ export default defineConfig({
           },
           {
             text: 'Exchange Stablecoins',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -305,7 +305,7 @@ export default defineConfig({
           },
           {
             text: 'Private Zones',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -339,7 +339,7 @@ export default defineConfig({
           },
           {
             text: 'Make Agentic Payments',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -375,7 +375,7 @@ export default defineConfig({
               },
               {
                 text: 'Use Cases',
-                collapsed: true,
+                collapsed: false,
                 items: [
                   {
                     text: 'Monetize Your API',
@@ -476,7 +476,7 @@ export default defineConfig({
           },
           {
             text: 'Bridging',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Bridge via LayerZero',
@@ -494,7 +494,7 @@ export default defineConfig({
           },
           {
             text: 'Ecosystem',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -537,7 +537,7 @@ export default defineConfig({
         ],
       },
       {
-        text: 'Tempo Protocol Specs',
+        text: 'Tempo Protocol',
         items: [
           {
             text: 'Overview',
@@ -545,7 +545,7 @@ export default defineConfig({
           },
           {
             text: 'TIP-20 Tokens',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -567,7 +567,7 @@ export default defineConfig({
           },
           {
             text: 'Tempo Token Rewards',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -581,7 +581,7 @@ export default defineConfig({
           },
           {
             text: 'Tempo Policies (TIP-403)',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -603,7 +603,7 @@ export default defineConfig({
           },
           {
             text: 'Fees',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -615,7 +615,7 @@ export default defineConfig({
               },
               {
                 text: 'Fee AMM',
-                collapsed: true,
+                collapsed: false,
                 items: [
                   {
                     text: 'Overview',
@@ -635,7 +635,7 @@ export default defineConfig({
           },
           {
             text: 'Tempo Transactions',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -665,7 +665,7 @@ export default defineConfig({
           },
           {
             text: 'Blockspace',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -683,7 +683,7 @@ export default defineConfig({
           },
           {
             text: 'Stablecoin DEX',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -717,7 +717,7 @@ export default defineConfig({
           },
           {
             text: 'Zones',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -751,7 +751,7 @@ export default defineConfig({
           },
           {
             text: 'Network Upgrades',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'T7',
@@ -788,11 +788,15 @@ export default defineConfig({
         ],
       },
       {
-        text: 'Tempo Developer Tools',
+        text: 'Tools & SDKs',
         items: [
           {
+            text: 'Overview',
+            link: '/docs/tools',
+          },
+          {
             text: 'Hosted Services',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -810,7 +814,7 @@ export default defineConfig({
           },
           {
             text: 'CLI',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -836,7 +840,7 @@ export default defineConfig({
           },
           {
             text: 'Tempo Wallet',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -862,7 +866,7 @@ export default defineConfig({
           },
           {
             text: 'SDKs',
-            collapsed: true,
+            collapsed: false,
             items: [
               {
                 text: 'Overview',
@@ -870,7 +874,7 @@ export default defineConfig({
               },
               {
                 text: 'TypeScript',
-                collapsed: true,
+                collapsed: false,
                 items: [
                   {
                     text: 'Overview',
@@ -901,7 +905,7 @@ export default defineConfig({
               },
               {
                 text: 'Foundry',
-                collapsed: true,
+                collapsed: false,
                 items: [
                   {
                     text: 'Overview',
@@ -931,7 +935,6 @@ export default defineConfig({
       },
       {
         text: 'Run a Tempo Node',
-        collapsed: true,
         items: [
           {
             text: 'Overview',
@@ -1030,8 +1033,68 @@ export default defineConfig({
       //     },
       //   ],
       // },
-    ],
-  },
+    ]
+
+    const section = (text: string) => {
+      const item = docsSidebar.find((item) => item.text === text)
+      return item ? [item] : []
+    }
+
+    const docsHomeSidebar = [
+      {
+        text: 'First Steps',
+        items: [
+          { text: 'Connect to Tempo', link: '/docs/quickstart/integrate-tempo' },
+          { text: 'Get Funds', link: '/docs/guide/getting-funds' },
+          { text: 'Send a Payment', link: '/docs/guide/payments' },
+          { text: 'Use Tempo Transactions', link: '/docs/guide/tempo-transaction' },
+          { text: 'Issue a Stablecoin', link: '/docs/guide/issuance' },
+        ],
+      },
+      {
+        text: 'Resources',
+        items: [
+          { text: 'Tools & SDKs', link: '/docs/tools' },
+          { text: 'Tempo Protocol', link: '/docs/protocol' },
+          { text: 'Run a Tempo Node', link: '/docs/guide/node' },
+          { text: 'Use Tempo with AI', link: '/docs/guide/using-tempo-with-ai' },
+          { text: 'Partners', link: '/docs/partners' },
+        ],
+      },
+    ]
+    const buildSidebar = section('Build on Tempo')
+    const integrateSidebar = section('Integrate Tempo')
+    const specsSidebar = section('Tempo Protocol')
+    const developerToolsSidebar = section('Tools & SDKs')
+    const nodeSidebar = section('Run a Tempo Node')
+
+    return {
+      '/docs': docsHomeSidebar,
+      '/docs/build': buildSidebar,
+      '/docs/guide/getting-funds': buildSidebar,
+      '/docs/guide/payments': buildSidebar,
+      '/docs/guide/issuance': buildSidebar,
+      '/docs/guide/stablecoin-dex': buildSidebar,
+      '/docs/guide/private-zones': buildSidebar,
+      '/docs/guide/machine-payments': buildSidebar,
+      '/docs/quickstart': integrateSidebar,
+      '/docs/guide/tempo-transaction': integrateSidebar,
+      '/docs/guide/bridge-layerzero': integrateSidebar,
+      '/docs/guide/bridge-bungee': integrateSidebar,
+      '/docs/guide/bridge-relay': integrateSidebar,
+      '/docs/ecosystem': integrateSidebar,
+      '/docs/protocol': specsSidebar,
+      '/docs/tools': developerToolsSidebar,
+      '/docs/hosted-services': developerToolsSidebar,
+      '/docs/developer-tools': developerToolsSidebar,
+      '/docs/cli': developerToolsSidebar,
+      '/docs/protocol/rpc': developerToolsSidebar,
+      '/docs/sdk': developerToolsSidebar,
+      '/docs/wallet': developerToolsSidebar,
+      '/docs/guide/node': nodeSidebar,
+      '/docs/changelog': nodeSidebar,
+    }
+  })(),
   topNav: [
     {
       text: 'Docs',
@@ -1042,116 +1105,6 @@ export default defineConfig({
     { text: 'Wallet', link: 'https://wallet.tempo.xyz' },
   ],
   redirects: [
-    {
-      source: '/api',
-      destination: '/docs/api',
-      status: 301,
-    },
-    {
-      source: '/api/authentication',
-      destination: '/docs/api/authentication',
-      status: 301,
-    },
-    {
-      source: '/api/conventions',
-      destination: '/docs/api/conventions',
-      status: 301,
-    },
-    {
-      source: '/api/json-rpc',
-      destination: '/docs/api/json-rpc',
-      status: 301,
-    },
-    {
-      source: '/api/indexer-api',
-      destination: '/docs/api/indexer-api',
-      status: 301,
-    },
-    {
-      source: '/api/pagination',
-      destination: '/docs/api/pagination',
-      status: 301,
-    },
-    {
-      source: '/api/rate-limits',
-      destination: '/docs/api/rate-limits',
-      status: 301,
-    },
-    {
-      source: '/api/errors',
-      destination: '/docs/api/errors',
-      status: 301,
-    },
-    {
-      source: '/api/versioning-policy',
-      destination: '/docs/api/versioning-policy',
-      status: 301,
-    },
-    {
-      source: '/api/transactions-and-transfers',
-      destination: '/docs/api/transactions-and-transfers',
-      status: 301,
-    },
-    {
-      source: '/api/activities',
-      destination: '/docs/api/activities',
-      status: 301,
-    },
-    {
-      source: '/api/balances',
-      destination: '/docs/api/balances',
-      status: 301,
-    },
-    {
-      source: '/api/blocks',
-      destination: '/docs/api/blocks',
-      status: 301,
-    },
-    {
-      source: '/api/exchange',
-      destination: '/docs/api/exchange',
-      status: 301,
-    },
-    {
-      source: '/api/fee-amm',
-      destination: '/docs/api/fee-amm',
-      status: 301,
-    },
-    {
-      source: '/api/tokens',
-      destination: '/docs/api/tokens',
-      status: 301,
-    },
-    {
-      source: '/api/transactions',
-      destination: '/docs/api/transactions',
-      status: 301,
-    },
-    {
-      source: '/api/transfers',
-      destination: '/docs/api/transfers',
-      status: 301,
-    },
-    {
-      source: '/api/verified-tokens',
-      destination: '/docs/api/verified-tokens',
-      status: 301,
-    },
-    {
-      source: '/api/indexer',
-      destination: '/docs/api/indexer',
-      status: 301,
-    },
-    {
-      source: '/api/rpc',
-      destination: '/docs/api/rpc',
-      status: 301,
-    },
-    {
-      source: '/api/coingecko',
-      destination: '/docs/api/coingecko',
-      status: 301,
-    },
     {
       source: '/docs/documentation/protocol/:path*',
       destination: '/docs/protocol/:path*',


### PR DESCRIPTION
## Summary

- Add the docs section navigation bar with grouped entry points for getting started, building, integrating, protocol docs, tools, and node docs.
- Add `/docs/build` and `/docs/tools` overview pages and route the docs sidebar by section.
- Refresh docs landing/section pages to match the new information architecture.
- Polish docs header/sidebar details, including the sidebar footer separator, social icon sizing, and regular-weight nav/sidebar title labels.

## Why

The docs navigation needed to feel more coherent across the main docs sections and less visually heavy in the sidebar/top section nav. This keeps the docs grouped by user intent while preserving quick access to build, tools, protocol, and node resources.

## Validation

- `bunx biome check --write --unsafe src/components/DocsHeader.tsx src/components/DocsSidebarDrawer.tsx src/components/DocsSectionNav.tsx src/pages/_root.css src/pages/docs/_layout.tsx src/pages/docs/build.mdx src/pages/docs/tools.mdx src/pages/docs/guide/node/index.mdx src/pages/docs/guide/using-tempo-with-ai.mdx src/pages/docs/index.mdx src/pages/docs/protocol/index.mdx src/pages/docs/quickstart/integrate-tempo.mdx vocs.config.ts`
- `bun run check:types`
- `git diff --cached --check`
- Local HTTP probes:
  - `/docs` -> `200`
  - `/docs/build` -> `200`
  - `/docs/tools` -> `200`
  - `/docs/protocol` -> `200`
  - `/docs/guide/node` -> `200`
- In-app browser checks on `/docs/build` for sidebar/footer spacing, social icon sizing, and nav/sidebar title weights.
