### PR TITLE
[codex] fix docs api openapi config

### DIFF
--- a/src/components/DocsSectionNav.tsx
+++ b/src/components/DocsSectionNav.tsx
@@ -55,7 +55,7 @@ const sectionNavItems: SectionNavItem[] = [
     label: 'Tools & SDKs',
     href: '/docs/tools',
     matches: [
-      '/api',
+      '/docs/api',
       '/docs/cli',
       '/docs/developer-tools',
       '/docs/hosted-services',

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -112,43 +112,47 @@ export default defineConfig({
   },
   openapi: [
     {
-      path: '/api',
-      spec: './openapi-preview.json',
+      path: '/docs/api',
+      spec: 'https://api.tempo.xyz/openapi.json',
       sidebar: {
-        collapsed: false,
+        collapsed: true,
         backLink: false,
         intro: [
           {
             text: 'Authentication',
-            link: '/api/authentication',
+            link: '/docs/api/authentication',
           },
           {
             text: 'Conventions',
-            link: '/api/conventions',
+            link: '/docs/api/conventions',
+          },
+          {
+            text: 'Transactions & Transfers',
+            link: '/docs/api/transactions-and-transfers',
           },
           {
             text: 'JSON-RPC API',
-            link: '/api/json-rpc',
+            link: '/docs/api/json-rpc',
           },
           {
             text: 'Indexer API',
-            link: '/api/indexer-api',
+            link: '/docs/api/indexer-api',
           },
           {
             text: 'Pagination',
-            link: '/api/pagination',
+            link: '/docs/api/pagination',
           },
           {
             text: 'Rate Limits',
-            link: '/api/rate-limits',
+            link: '/docs/api/rate-limits',
           },
           {
             text: 'Errors',
-            link: '/api/errors',
+            link: '/docs/api/errors',
           },
           {
             text: 'Versioning Policy',
-            link: '/api/versioning-policy',
+            link: '/docs/api/versioning-policy',
           },
         ],
       },


### PR DESCRIPTION
## Summary
- restore the generated OpenAPI docs to /docs/api
- use the live Tempo OpenAPI spec instead of the local preview scratch file
- make the docs section nav treat /docs/api as part of Tools & SDKs

## Verification
- pnpm exec biome check --write --unsafe vocs.config.ts src/components/DocsSectionNav.tsx
- node fetch/parse check for https://api.tempo.xyz/openapi.json
- pnpm run check:types
- pnpm exec vite build
- pnpm exec vite build --config vite.marketing.config.ts