### PR TITLE
Set docs production base URL to developers path

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -31,6 +31,8 @@ exclude = [
   "^https?://0\\.0\\.0\\.0",
   "^https?://\\[::1\\]",
   "^https?://([a-z0-9-]+\\.)*example\\.(com|org|net)",
+  # Future canonical docs URL. It becomes live after the main-site proxy PR lands.
+  "^https://tempo\\.xyz/developers/?$",
   # SVG xmlns reference, not a real link.
   "^http://www\\.w3\\.org/2000/svg$",
 ]

--- a/src/marketing/seo.ts
+++ b/src/marketing/seo.ts
@@ -23,7 +23,7 @@ export function resolveBaseUrl(): string {
   if (URL.canParse(process.env.VITE_BASE_URL ?? '')) {
     return (process.env.VITE_BASE_URL as string).replace(/\/$/, '')
   }
-  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
+  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz/developers'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   if (productionUrl) return `https://${productionUrl}`
   return ''

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -6,7 +6,7 @@ import { createFeedbackAdapter } from './src/lib/feedback-adapter'
 const baseUrl = (() => {
   if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') return ''
   if (URL.canParse(process.env.VITE_BASE_URL)) return process.env.VITE_BASE_URL.replace(/\/$/, '')
-  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
+  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz/developers'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   if (productionUrl) return `https://${productionUrl}`
   return ''


### PR DESCRIPTION
## Summary
- update production docs base URL helpers from `https://docs.tempo.xyz` to `https://tempo.xyz/developers`
- leave `docs.tempo.xyz` traffic in place so this can deploy before the main-site proxy and final host redirect

## Validation
- `jq empty vercel.json`
- `pnpm check:types`

## Merge order
Merge this first, then `tempoxyz/tempo-web#373`, then the redirect-only docs PR.

Prompted by: @alexrisch