### PR TITLE
Fix docs sitemap template routes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -122,6 +122,7 @@ function llmsFeedbackPreamble(): Plugin {
       ]
 
       await Promise.all(candidates.map(prependFeedbackNotice))
+      await removeTemplateRoutesFromSitemap(path.join(publicDir, 'sitemap.xml'))
     },
   }
 }
@@ -148,6 +149,19 @@ async function prependFeedbackNotice(filePath: string) {
     const content = await fs.readFile(filePath, 'utf-8')
     if (content.startsWith(llmsFeedbackNotice)) return
     await fs.writeFile(filePath, `${llmsFeedbackNotice}${content}`, 'utf-8')
+  } catch {
+    return
+  }
+}
+
+async function removeTemplateRoutesFromSitemap(filePath: string) {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8')
+    const filtered = content.replaceAll(
+      /<url>\s*<loc>[^<]*\/\[[^\]]+\][^<]*<\/loc>[\s\S]*?<\/url>\s*/g,
+      '',
+    )
+    if (filtered !== content) await fs.writeFile(filePath, filtered, 'utf-8')
   } catch {
     return
   }


### PR DESCRIPTION
## Summary
- filter generated sitemap entries that still contain bracketed dynamic route segments like `/blog/[slug]`
- keep valid generated blog post URLs from the marketing route copy build intact

## Verification
- `bunx biome check vite.config.ts`
- `bun run check:types`
- focused Node regex check: removes `/blog/[slug]` while preserving `/blog/t6`

## Note
- `VITE_BASE_URL=https://docs.tempo.xyz bun run build` is currently blocked before sitemap emission by `[plugin vocs:llms] TypeError: fetch failed` / `ETIMEDOUT`.

Prompted by: @juandolealt