### PR TITLE
Redirect docs host to developers path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,28 @@
       "has": [
         {
           "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
           "value": "faucet.tempo.xyz"
         }
       ],


### PR DESCRIPTION
## Summary
- redirect `docs.tempo.xyz` root and catchall traffic to `https://tempo.xyz/developers`

## Validation
- `jq empty vercel.json`
- redirect assertion script

## Merge order
Merge after `tempoxyz/docs#580` and `tempoxyz/tempo-web#373` are both deployed and `https://tempo.xyz/developers/docs` has been verified in production.

Prompted by: @alexrisch