### PR TITLE
docs: update RPC trustless defaults

### DIFF
--- a/src/pages/docs/guide/node/index.mdx
+++ b/src/pages/docs/guide/node/index.mdx
@@ -27,8 +27,8 @@ Most teams should start with an RPC node. Validator operation requires coordinat
     icon="lucide:download"
   />
   <Card
-    title="Run an RPC Node"
-    description="Configure and run a node that serves JSON-RPC traffic for apps, explorers, and wallets."
+    title="Run RPC and Standby Nodes"
+    description="Configure and run nodes that serve JSON-RPC traffic or stay ready for validator failover."
     to="/docs/guide/node/rpc"
     icon="lucide:server"
   />

--- a/src/pages/docs/guide/node/rpc.mdx
+++ b/src/pages/docs/guide/node/rpc.mdx
@@ -27,7 +27,7 @@ tempo node \
 
 An RPC node running in follow mode is a **full node**. It first verifies consensus finalization certificates from the upstream before accepting followed blocks. Those certificates prove the data is backed by a validator quorum, not just the upstream node's local view of the chain. After verification, it fetches blocks from the upstream RPC endpoint, executes every transaction locally through the EVM, validates each block after execution, and stores complete block data with full state. All execution and validation happens locally on your machine.
 
-By default, RPC nodes run in archive mode, meaning they do not prune historical state.
+By default, RPC nodes run in archive mode, meaning they do not prune historical state. Any pruning default defines the minimal window of synchrony for which Tempo guarantees that nodes can sync to the network.
 
 The upstream must serve consensus finalization certificates. For RPC-to-RPC following, follow a validator-backed RPC node or another RPC node that is already serving certified consensus data.
 

--- a/src/pages/docs/guide/node/rpc.mdx
+++ b/src/pages/docs/guide/node/rpc.mdx
@@ -1,10 +1,10 @@
 ---
-description: Set up and run a Tempo RPC node for API access. Download snapshots, configure systemd services, and monitor node health and sync status.
+description: Set up and run Tempo RPC and standby nodes. Download snapshots, configure systemd services, and monitor node health and sync status.
 ---
 
 import { Callout } from 'vocs'
 
-# Running an RPC Node
+# Running RPC and Standby Nodes
 
 RPC nodes provide API access to the Tempo network without participating in consensus.
 

--- a/src/pages/docs/guide/node/rpc.mdx
+++ b/src/pages/docs/guide/node/rpc.mdx
@@ -25,7 +25,7 @@ tempo node \
   --http.api eth,net,web3,txpool,trace
 ```
 
-An RPC node running in follow mode is a **full node**. It fetches blocks from an upstream RPC endpoint, executes every transaction locally through the EVM, validates each block after execution, and stores complete block data with full state. By default, it also verifies consensus finalization certificates from the upstream before accepting followed blocks. Those certificates prove the data is backed by a validator quorum, not just the upstream node's local view of the chain. All execution and validation happens locally on your machine.
+An RPC node running in follow mode is a **full node**. It first verifies consensus finalization certificates from the upstream before accepting followed blocks. Those certificates prove the data is backed by a validator quorum, not just the upstream node's local view of the chain. After verification, it fetches blocks from the upstream RPC endpoint, executes every transaction locally through the EVM, validates each block after execution, and stores complete block data with full state. All execution and validation happens locally on your machine.
 
 By default, RPC nodes run in archive mode, meaning they do not prune historical state.
 

--- a/src/pages/docs/guide/node/rpc.mdx
+++ b/src/pages/docs/guide/node/rpc.mdx
@@ -27,7 +27,7 @@ tempo node \
 
 An RPC node running in follow mode is a **full node**. It first verifies consensus finalization certificates from the upstream before accepting followed blocks. Those certificates prove the data is backed by a validator quorum, not just the upstream node's local view of the chain. After verification, it fetches blocks from the upstream RPC endpoint, executes every transaction locally through the EVM, validates each block after execution, and stores complete block data with full state. All execution and validation happens locally on your machine.
 
-By default, RPC nodes run in archive mode, meaning they do not prune historical state. Any pruning default defines the minimal window of synchrony for which Tempo guarantees that nodes can sync to the network.
+By default, RPC nodes run in archive mode, meaning they do not prune historical state.
 
 The upstream must serve consensus finalization certificates. For RPC-to-RPC following, follow a validator-backed RPC node or another RPC node that is already serving certified consensus data.
 

--- a/src/pages/docs/guide/node/rpc.mdx
+++ b/src/pages/docs/guide/node/rpc.mdx
@@ -11,7 +11,7 @@ RPC nodes provide API access to the Tempo network without participating in conse
 ## Quick Start
 
 <Callout type="info">
-Trusted (uncertified) RPC nodes will be deprecated. To run without trusting the RPC endpoint, use [Trustless RPC Nodes](#trustless-rpc-nodes).
+All RPC nodes are trustless by default.
 </Callout>
 
 ```bash /dev/null/quickstart.sh#L1-15
@@ -25,27 +25,9 @@ tempo node \
   --http.api eth,net,web3,txpool,trace
 ```
 
-An RPC node running in follow mode is a **full node**. It fetches blocks from a trusted RPC endpoint, executes every transaction locally through the EVM, validates each block after execution, and stores complete block data with full state. The only trust assumption is block ordering: your node trusts the RPC endpoint to provide the correct sequence of blocks. All execution and validation happens locally on your machine.
+An RPC node running in follow mode is a **full node**. It fetches blocks from an upstream RPC endpoint, executes every transaction locally through the EVM, validates each block after execution, and stores complete block data with full state. By default, it also verifies consensus finalization certificates from the upstream before accepting followed blocks. Those certificates prove the data is backed by a validator quorum, not just the upstream node's local view of the chain. All execution and validation happens locally on your machine.
 
 By default, RPC nodes run in archive mode, meaning they do not prune historical state.
-
-### Trustless RPC Nodes
-
-<Callout type="info">
-Trustless RPC nodes are supported in release 1.7.1 and onward. RPC-to-RPC following is currently only supported on Moderato testnet.
-</Callout>
-
-By default, a following RPC node trusts its upstream RPC endpoint for block ordering. Trustless RPC mode reduces that trust assumption by requiring consensus finalization certificates from the upstream before accepting followed blocks. Those certificates prove the data is backed by a validator quorum, not just the upstream node's local view of the chain.
-
-Enable certificate verification with the `--follow.experimental.certify` flag:
-
-```bash
-tempo node \
-  --follow \
-  --follow.experimental.certify \
-  --http --http.port 8545 \
-  --http.api eth,net,web3,txpool,trace
-```
 
 The upstream must serve consensus finalization certificates. For RPC-to-RPC following, follow a validator-backed RPC node or another RPC node that is already serving certified consensus data.
 

--- a/src/pages/docs/guide/node/validator-failover.mdx
+++ b/src/pages/docs/guide/node/validator-failover.mdx
@@ -17,26 +17,15 @@ Only one node may run with a validator signing key at a time. Before promoting t
 
 ### Run the follower
 
-Use a dedicated data directory for the follower. The upstream must be a validator or RPC node that exposes the `consensus` RPCs.
+Use a dedicated data directory for the follower. Trustless RPC-to-RPC following is the default, and the upstream must be a validator or RPC node that exposes the `consensus` RPCs. If following a validator, the upstream validator must also expose WebSockets with `--ws`.
 
-Trustless RPC-to-RPC following is currently only supported on Moderato testnet. If following on Mainnet, follow against the existing validator. See more about [running an RPC node](/docs/guide/node/rpc).
-
-::::code-group
-```bash [Testnet]
+```bash
 tempo node --datadir <datadir> \
-  --chain testnet \
-  --follow <WS_URL> \
+  --chain <CHAIN> \
+  --follow ws://example.url:8546 \
   --http --http.port 8545 \
   --http.api eth,net,web3,txpool,trace,consensus
 ```
-```bash [Mainnet]
-tempo node --datadir <datadir> \
-  --chain mainnet \
-  --follow <WS_URL> \
-  --http --http.port 8545 \
-  --http.api eth,net,web3,txpool,trace,consensus
-```
-::::
 
 Do not pass `--consensus.signing-key` while the standby is running as a follower. The standby is syncing certified consensus state, not participating in consensus.
 

--- a/src/pages/docs/guide/node/validator-failover.mdx
+++ b/src/pages/docs/guide/node/validator-failover.mdx
@@ -19,14 +19,13 @@ Only one node may run with a validator signing key at a time. Before promoting t
 
 Use a dedicated data directory for the follower. The upstream must be a validator or RPC node that exposes the `consensus` RPCs.
 
-Trustless RPC-to-RPC following is currently only supported on Moderato testnet. If following on Mainnet, follow against the existing validator. See more about [trustless rpc nodes](/docs/guide/node/rpc#trustless-rpc-nodes).
+Trustless RPC-to-RPC following is currently only supported on Moderato testnet. If following on Mainnet, follow against the existing validator. See more about [running an RPC node](/docs/guide/node/rpc).
 
 ::::code-group
 ```bash [Testnet]
 tempo node --datadir <datadir> \
   --chain testnet \
   --follow <WS_URL> \
-  --follow.experimental.certify \
   --http --http.port 8545 \
   --http.api eth,net,web3,txpool,trace,consensus
 ```
@@ -34,7 +33,6 @@ tempo node --datadir <datadir> \
 tempo node --datadir <datadir> \
   --chain mainnet \
   --follow <WS_URL> \
-  --follow.experimental.certify \
   --http --http.port 8545 \
   --http.api eth,net,web3,txpool,trace,consensus
 ```
@@ -85,7 +83,7 @@ If the follower is not managed by systemd, send `SIGINT` or `SIGTERM` and wait f
 
 ### Restart the standby in validator mode
 
-Restart the same data directory without `--follow` or `--follow.experimental.certify`, and add the validator signing key.
+Restart the same data directory without `--follow`, and add the validator signing key.
 
 Use the same consensus signing key as the validator you are failing over from. This procedure moves an existing validator identity to the standby; it does not rotate the identity. To use a different signing key,
 the validator's onchain configuration must be rotated. Follow the [rotate the validator identity](/docs/guide/node/validator-lifecycle#rotate-validator-identity) procedure.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -953,7 +953,7 @@ export default defineConfig({
             link: '/docs/guide/node/installation',
           },
           {
-            text: 'Running an RPC Node',
+            text: 'Running RPC and Standby Nodes',
             link: '/docs/guide/node/rpc',
           },
           {


### PR DESCRIPTION
## Summary
- state in Quick Start that all RPC nodes are trustless by default
- merge the trustless RPC explanation into Quick Start and remove the old certify flag example
- remove stale certify flag usage from validator failover docs and update the removed anchor link

## Tests
- bun run check
- bun run check:types

Prompted by: @SuperFluffy