### PR TITLE
Revert docs developers rollout

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -31,8 +31,6 @@ exclude = [
   "^https?://0\\.0\\.0\\.0",
   "^https?://\\[::1\\]",
   "^https?://([a-z0-9-]+\\.)*example\\.(com|org|net)",
-  # Future canonical docs URL. It becomes live after the main-site proxy PR lands.
-  "^https://tempo\\.xyz/developers/?$",
   # SVG xmlns reference, not a real link.
   "^http://www\\.w3\\.org/2000/svg$",
 ]

--- a/src/marketing/seo.ts
+++ b/src/marketing/seo.ts
@@ -23,7 +23,7 @@ export function resolveBaseUrl(): string {
   if (URL.canParse(process.env.VITE_BASE_URL ?? '')) {
     return (process.env.VITE_BASE_URL as string).replace(/\/$/, '')
   }
-  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz/developers'
+  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   if (productionUrl) return `https://${productionUrl}`
   return ''

--- a/vercel.json
+++ b/vercel.json
@@ -5,28 +5,6 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
-        }
-      ],
-      "destination": "https://tempo.xyz/developers",
-      "permanent": true
-    },
-    {
-      "source": "/:path*",
-      "has": [
-        {
-          "type": "host",
-          "value": "docs.tempo.xyz"
-        }
-      ],
-      "destination": "https://tempo.xyz/developers/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/",
-      "has": [
-        {
-          "type": "host",
           "value": "faucet.tempo.xyz"
         }
       ],

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -6,7 +6,7 @@ import { createFeedbackAdapter } from './src/lib/feedback-adapter'
 const baseUrl = (() => {
   if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') return ''
   if (URL.canParse(process.env.VITE_BASE_URL)) return process.env.VITE_BASE_URL.replace(/\/$/, '')
-  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz/developers'
+  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   if (productionUrl) return `https://${productionUrl}`
   return ''


### PR DESCRIPTION
## Summary
- Reverts #582, removing the docs.tempo.xyz host redirect to tempo.xyz/developers
- Reverts #580, restoring docs production base URLs to docs.tempo.xyz and removing the temporary Lychee exclusion

## Validation
- jq empty vercel.json
- git diff --check
- pnpm check:types

Prompted by: @alexrisch