### PR TITLE
Remove docs host redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,28 +5,6 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
-        }
-      ],
-      "destination": "https://tempo.xyz/developers",
-      "permanent": true
-    },
-    {
-      "source": "/:path*",
-      "has": [
-        {
-          "type": "host",
-          "value": "docs.tempo.xyz"
-        }
-      ],
-      "destination": "https://tempo.xyz/developers/:path*",
-      "permanent": true
-    },
-    {
-      "source": "/",
-      "has": [
-        {
-          "type": "host",
           "value": "faucet.tempo.xyz"
         }
       ],


### PR DESCRIPTION
## Summary
- Reverts #582 only, removing the docs.tempo.xyz host redirect that loops through tempo.xyz/developers
- Keeps #580 in place so docs production base URLs remain under tempo.xyz/developers

## Validation
- jq empty vercel.json
- git diff --check
- pnpm check:types

Prompted by: @alexrisch