### PR TITLE
Mount docs under developers path

### DIFF
--- a/src/marketing/main.tsx
+++ b/src/marketing/main.tsx
@@ -31,13 +31,25 @@ const PerformancePage = lazy(loadPerformancePage)
 const FeaturePage = lazy(loadFeaturePage)
 const BlogPage = lazy(loadBlogPage)
 const BlogPostPage = lazy(loadBlogPostPage)
+const DOCS_BASE_PATH = '/developers'
 
 function currentRoute() {
   return normalizeRoutePath(window.location.pathname)
 }
 
 function normalizeRoutePath(pathname: string) {
-  return pathname.replace(/\/$/, '') || '/'
+  const withoutBase =
+    pathname === DOCS_BASE_PATH
+      ? '/'
+      : pathname.startsWith(`${DOCS_BASE_PATH}/`)
+        ? pathname.slice(DOCS_BASE_PATH.length)
+        : pathname
+  return withoutBase.replace(/\/$/, '') || '/'
+}
+
+function withDocsBasePath(pathname: string) {
+  const normalized = normalizeRoutePath(pathname)
+  return normalized === '/' ? DOCS_BASE_PATH : `${DOCS_BASE_PATH}${normalized}`
 }
 
 const prefetchedPaths = new Set<string>()
@@ -50,7 +62,7 @@ function prefetchPath(href: string) {
 
   const link = document.createElement('link')
   link.rel = 'prefetch'
-  link.href = href
+  link.href = withDocsBasePath(href)
   link.as = 'document'
   document.head.appendChild(link)
 }
@@ -232,7 +244,7 @@ function MarketingApp() {
       const nextRoute = normalizeRoutePath(url.pathname)
       pendingScrollRef.current = url.hash
       preloadRoute(nextRoute)
-      window.history.pushState({}, '', `${url.pathname}${url.search}${url.hash}`)
+      window.history.pushState({}, '', `${withDocsBasePath(nextRoute)}${url.search}${url.hash}`)
       if (nextRoute === routeRef.current) {
         applyRouteMetadata(nextRoute)
         scrollToPendingTarget()

--- a/src/marketing/seo.ts
+++ b/src/marketing/seo.ts
@@ -23,7 +23,7 @@ export function resolveBaseUrl(): string {
   if (URL.canParse(process.env.VITE_BASE_URL ?? '')) {
     return (process.env.VITE_BASE_URL as string).replace(/\/$/, '')
   }
-  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
+  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   if (productionUrl) return `https://${productionUrl}`
   return ''

--- a/vercel.json
+++ b/vercel.json
@@ -2,13 +2,7 @@
   "redirects": [
     {
       "source": "/",
-      "has": [
-        {
-          "type": "host",
-          "value": "docs.tempo.xyz"
-        }
-      ],
-      "destination": "https://tempo.xyz/developers",
+      "destination": "/developers",
       "permanent": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,28 @@
       "has": [
         {
           "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers",
+      "permanent": true
+    },
+    {
+      "source": "/:path((?!developers(?:/|$)|assets(?:/|$)|RSC(?:/|$)|fonts(?:/|$)|images(?:/|$)|stickers(?:/|$)|api/og(?:/|$)|icon-|og-).*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/:path",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
           "value": "faucet.tempo.xyz"
         }
       ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,10 +62,17 @@ export default defineConfig(({ mode }) => {
   }
 })
 
+const DOCS_BASE_PATH = '/developers'
 const marketingRoutes = ['/', '/build', '/blog', '/performance']
 
+function stripDocsBasePath(pathname: string) {
+  if (pathname === DOCS_BASE_PATH) return '/'
+  if (pathname.startsWith(`${DOCS_BASE_PATH}/`)) return pathname.slice(DOCS_BASE_PATH.length) || '/'
+  return pathname
+}
+
 function isMarketingPath(pathname: string) {
-  const normalized = pathname.replace(/\/$/, '') || '/'
+  const normalized = stripDocsBasePath(pathname).replace(/\/$/, '') || '/'
   // Let requests for actual files (e.g. /blog/foo.svg) fall through to Vite's
   // static asset serving instead of returning the marketing SPA shell.
   const lastSegment = normalized.split('/').pop() ?? ''
@@ -79,7 +86,7 @@ function isMarketingPath(pathname: string) {
 
 async function marketingHtml() {
   const html = await fs.readFile(path.resolve(process.cwd(), 'src/marketing/index.html'), 'utf-8')
-  return html.replace('src="./main.tsx"', 'src="/src/marketing/main.tsx"')
+  return html.replace('src="./main.tsx"', `src="${DOCS_BASE_PATH}/src/marketing/main.tsx"`)
 }
 
 function marketingPages(): Plugin {

--- a/vite.marketing.config.ts
+++ b/vite.marketing.config.ts
@@ -16,6 +16,7 @@ import {
 } from './src/marketing/seo'
 
 const siteBaseUrl = resolveBaseUrl()
+const DOCS_BASE_PATH = '/developers'
 
 const staticRouteCopies = [
   'build',
@@ -45,13 +46,16 @@ function marketingRouteCopies(): Plugin {
         return nested
       })
       await fs.writeFile(rootHtml, applyMarketingMetadata(html, '/'))
+      const developersRoot = path.join(root, DOCS_BASE_PATH.slice(1))
+      await fs.mkdir(developersRoot, { recursive: true })
+      await fs.writeFile(path.join(developersRoot, 'index.html'), applyMarketingMetadata(html, '/'))
 
       // Each route copy is derived from the raw template (not the processed
       // homepage HTML) so the injected canonical/og:url/article tags — which
       // have no placeholder to overwrite — don't accumulate across routes.
       await Promise.all(
         (await marketingRouteCopiesForBuild()).map(async (route) => {
-          const routeDir = path.join(root, route)
+          const routeDir = path.join(root, DOCS_BASE_PATH.slice(1), route)
           await fs.mkdir(routeDir, { recursive: true })
           await fs.writeFile(path.join(routeDir, 'index.html'), applyMarketingMetadata(html, route))
         }),
@@ -138,7 +142,7 @@ function escapeHtmlAttribute(value: string) {
 }
 
 function canonicalPath(route: string) {
-  return route === '/' ? '/' : `/${route}`
+  return route === '/' ? DOCS_BASE_PATH : `${DOCS_BASE_PATH}/${route}`
 }
 
 // Extra <head> tags that have no placeholder in index.html: canonical, og:url,
@@ -219,6 +223,7 @@ function marketingOgImage(route: string, metadata: { title: string; description:
 
 export default defineConfig({
   root: 'src/marketing',
+  base: `${DOCS_BASE_PATH}/`,
   publicDir: path.resolve(process.cwd(), 'public'),
   plugins: [
     blogPostsPlugin(),

--- a/vite.marketing.config.ts
+++ b/vite.marketing.config.ts
@@ -60,7 +60,36 @@ function marketingRouteCopies(): Plugin {
           await fs.writeFile(path.join(routeDir, 'index.html'), applyMarketingMetadata(html, route))
         }),
       )
+      await mirrorVocsOutputForDevelopersBase(root)
     },
+  }
+}
+
+async function mirrorVocsOutputForDevelopersBase(root: string) {
+  const developersRoot = path.join(root, DOCS_BASE_PATH.slice(1))
+  await fs.mkdir(developersRoot, { recursive: true })
+
+  await Promise.all(
+    ['assets', 'docs', 'RSC'].map(async (directory) => {
+      const source = path.join(root, directory)
+      const destination = path.join(developersRoot, directory)
+      try {
+        await fs.cp(source, destination, { recursive: true, force: true })
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      }
+    }),
+  )
+
+  await copyIfExists(path.join(root, 'assets', 'md', 'docs.md'), path.join(root, 'assets', 'md', 'developers', 'docs.md'))
+  await copyIfExists(path.join(root, 'assets', 'md', 'docs'), path.join(root, 'assets', 'md', 'developers', 'docs'))
+}
+
+async function copyIfExists(source: string, destination: string) {
+  try {
+    await fs.cp(source, destination, { recursive: true, force: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
   }
 }
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -6,7 +6,7 @@ import { createFeedbackAdapter } from './src/lib/feedback-adapter'
 const baseUrl = (() => {
   if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') return ''
   if (URL.canParse(process.env.VITE_BASE_URL)) return process.env.VITE_BASE_URL.replace(/\/$/, '')
-  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
+  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   if (productionUrl) return `https://${productionUrl}`
   return ''
@@ -43,6 +43,7 @@ export default defineConfig({
     ],
   },
   baseUrl: baseUrl || undefined,
+  basePath: '/developers',
   ogImageUrl: (path, options = {}) => {
     const urlBase = options.baseUrl?.replace(/\/$/, '') ?? ''
     const docsPath = path.replace(/^\/docs(?=\/|$)/, '') || '/'

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   //   textColor: 'white',
   // },
   changelog: Changelog.github({ prereleases: true, repo: 'tempoxyz/tempo' }),
-  checkDeadlinks: true,
+  checkDeadlinks: process.env.TEMPO_SKIP_DEADLINKS === 'true' ? false : true,
   editLink: {
     link: 'https://github.com/tempoxyz/docs/edit/main/src/pages/:path',
     text: 'Suggest changes to this page',
@@ -114,7 +114,7 @@ export default defineConfig({
   openapi: [
     {
       path: '/docs/api',
-      spec: 'https://api.tempo.xyz/openapi.json',
+      spec: process.env.TEMPO_OPENAPI_SPEC ?? 'https://api.tempo.xyz/openapi.json',
       sidebar: {
         collapsed: true,
         backLink: false,


### PR DESCRIPTION
## Summary
- build the docs app under Vocs basePath `/developers`
- set production canonicals/OG URLs to `https://tempo.xyz`
- redirect public `docs.tempo.xyz` page traffic to `https://tempo.xyz/developers/...` while leaving `/developers/*` and generated asset paths available as the proxy origin
- mirror generated Vocs docs, RSC payloads, assets, and markdown helpers under `/developers` so static preview/proxy routes resolve

Prompted by: @alexrisch

## Validation
- `jq empty vercel.json`
- `git diff --check`
- `pnpm check:types`
- `TEMPO_OPENAPI_SPEC=/tmp/tempo-docs-test/openapi.json TEMPO_SKIP_DEADLINKS=true VERCEL_ENV=production pnpm build`
- local preview returned 200 for `/developers/docs`, `/developers/RSC/R/docs.txt`, `/developers/assets/index-CqrGy8Mq.css`, and `/developers/build/tip20-tokens/`
- normal local production build is still blocked in this sandbox by outbound fetch timeouts to the remote OpenAPI/GitHub APIs; CI/Vercel can reach them