### PR TITLE
docs: update wallet cli docs

### DIFF
--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -306,8 +306,8 @@ const developersMenu: MegaMenuData = {
       title: 'Tools',
       items: [
         {
-          label: 'Wallet',
-          desc: 'A Tempo-first wallet for your agents',
+          label: 'Tempo Wallet',
+          desc: 'A Tempo-first wallet',
           href: 'https://wallet.tempo.xyz',
           icon: <WalletIcon />,
         },
@@ -328,6 +328,12 @@ const developersMenu: MegaMenuData = {
           desc: 'Search blocks, txs & tokens',
           href: 'https://explorer.tempo.xyz',
           icon: <ExplorerIcon />,
+        },
+        {
+          label: 'Wallet CLI',
+          desc: 'Use Tempo Wallet from the command line for agents',
+          href: `${DOCS_BASE_PATH}/cli/wallet`,
+          icon: <TerminalIcon />,
         },
       ],
     },

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -70,8 +70,8 @@ const developersMenu: MegaMenuData = {
       title: 'Tools',
       items: [
         {
-          label: 'Wallet',
-          desc: 'A Tempo-first wallet for your agents',
+          label: 'Tempo Wallet',
+          desc: 'A Tempo-first wallet',
           href: 'https://wallet.tempo.xyz',
           icon: <WalletIcon />,
         },
@@ -92,6 +92,12 @@ const developersMenu: MegaMenuData = {
           desc: 'Search blocks, txs & tokens',
           href: 'https://explorer.tempo.xyz',
           icon: <ExplorerIcon />,
+        },
+        {
+          label: 'Wallet CLI',
+          desc: 'Use Tempo Wallet from the command line for agents',
+          href: '/docs/cli/wallet',
+          icon: <TerminalIcon />,
         },
       ],
     },

--- a/src/pages/docs/cli/index.mdx
+++ b/src/pages/docs/cli/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tempo CLI
-description: A single binary for using Tempo Wallet from the terminal, making paid HTTP requests, and running a Tempo node.
+description: Use the Tempo CLI for Tempo Wallet CLI, paid HTTP requests with MPP, and Tempo node operations from your terminal.
 ---
 
 import { Cards, Card } from 'vocs'
@@ -9,7 +9,7 @@ import { Cards, Card } from 'vocs'
 
 The `tempo` binary covers three core workflows:
 
-- **`tempo wallet`** — use Tempo Wallet from the terminal: balances, funding, access keys, and service discovery
+- **Tempo Wallet CLI (`tempo wallet`)** — use Tempo Wallet from the terminal: balances, funding, access keys, service discovery, and agent-ready wallet operations
 - **`tempo request`** — make paid HTTP requests with automatic [MPP](https://mpp.dev/overview) payment negotiation
 - **`tempo node`** / **`tempo download`** — run and sync a Tempo node
 
@@ -25,7 +25,7 @@ To update later, run `tempoup`.
 
 ## Teach your agent to use Tempo
 
-Paste this into your AI agent to set up Tempo Wallet and start making paid requests:
+Paste this into your AI agent to set up Tempo Wallet CLI and start making paid requests:
 
 :::code-group
 ```bash [Claude Code]
@@ -39,7 +39,7 @@ codex exec "Read https://tempo.xyz/SKILL.md and set up tempo"
 ```
 :::
 
-All commands support `--help` for documentation and `--describe` for JSON command schemas. For scripts and agents, pass `-t` (`--toon-output`) to get compact, machine-readable output.
+All commands support `--help` for documentation and `--describe` for JSON command schemas. For scripts and agents, pass `-t` (`--toon-output`) to get compact, machine-readable output, and use `--dry-run` or `--max-spend` before paid calls.
 
 ## Commands
 
@@ -53,8 +53,8 @@ Dive into each command:
     icon="lucide:download"
   />
   <Card
-    title="tempo wallet"
-    description="Authenticate, manage keys and balances, discover paid services"
+    title="Wallet CLI"
+    description="Use Tempo Wallet CLI from the command line for agents and scripts"
     to="/docs/cli/wallet"
     icon="lucide:wallet"
   />

--- a/src/pages/docs/cli/request.mdx
+++ b/src/pages/docs/cli/request.mdx
@@ -1,15 +1,15 @@
 ---
 title: tempo request
-description: A curl-like HTTP client that handles MPP payment negotiation automatically.
+description: Make curl-compatible HTTP requests that automatically negotiate Machine Payments Protocol payments.
 ---
 
 import { Cards, Card } from 'vocs'
 
 # `tempo request`
 
-A curl-like HTTP client that handles [Machine Payments Protocol](https://mpp.dev/overview) negotiation transparently. When a server responds with [`402 Payment Required`](https://mpp.dev/protocol/http-402), `tempo request` reads the [challenge](https://mpp.dev/protocol/challenges), signs and submits the payment onchain, then retries with the [credential](https://mpp.dev/protocol/credentials) — all in one command.
+A curl-compatible HTTP client that handles [Machine Payments Protocol](https://mpp.dev/overview) negotiation transparently. When a server responds with [`402 Payment Required`](https://mpp.dev/protocol/http-402), `tempo request` reads the [challenge](https://mpp.dev/protocol/challenges), signs and submits the payment onchain, then retries with the [credential](https://mpp.dev/protocol/credentials) in one command.
 
-Requires [`tempo wallet login`](/docs/cli/wallet) first.
+Requires [`tempo wallet login`](/docs/cli/wallet) first. Use [`tempo wallet services`](/docs/cli/wallet#discover-services) before calling paid endpoints so agents and scripts use registered URLs, methods, pricing, and request schemas instead of guessing.
 
 ## Usage
 
@@ -17,6 +17,7 @@ Requires [`tempo wallet login`](/docs/cli/wallet) first.
 | --- | --- |
 | `tempo request <url>` | Make an HTTP request with automatic payment |
 | `tempo request --dry-run <url>` | Preview cost without executing payment |
+| `tempo request --max-spend <amount> <url>` | Set a hard cap for cumulative payment spend |
 | `tempo request -X POST <url> --json '{...}'` | Send a JSON body |
 | `tempo request <url> -H 'Header: Value'` | Add a custom header |
 
@@ -28,6 +29,8 @@ Requires [`tempo wallet login`](/docs/cli/wallet) first.
 | `--json <body>` | Send a JSON body (implies `-X POST`) |
 | `-H <header>` | Add a custom header |
 | `--dry-run` | Preview the payment cost and validate the request without spending |
+| `--max-spend <amount>` | Stop if the request would exceed a spend cap |
+| `-D <file>` / `--dump-header <file>` | Write response headers, useful for inspecting MPP challenges |
 | `-t` / `--toon-output` | Compact machine-readable output for scripts and agents |
 
 ## Examples
@@ -48,7 +51,16 @@ tempo request -X POST \
   https://fal.mpp.tempo.xyz/fal-ai/flux/dev
 ```
 
-Discover the right URL and request schema first with [`tempo wallet services`](/docs/cli/wallet#service-discovery).
+Capture headers for an agent-controlled MPP Credits flow:
+
+```bash
+headers="$(mktemp)"
+tempo request -t --dry-run -D "$headers" -X POST \
+  --json '{"input":"hello"}' \
+  <SERVICE_URL>/<ENDPOINT_PATH>
+```
+
+Discover the right URL and request schema first with [`tempo wallet services`](/docs/cli/wallet#discover-services).
 
 ## Learn more
 
@@ -60,7 +72,7 @@ Discover the right URL and request schema first with [`tempo wallet services`](/
     icon="lucide:book-open"
   />
   <Card
-    title="tempo wallet"
+    title="Wallet CLI"
     description="Authenticate and discover services"
     to="/docs/cli/wallet"
     icon="lucide:wallet"

--- a/src/pages/docs/cli/wallet.mdx
+++ b/src/pages/docs/cli/wallet.mdx
@@ -1,18 +1,18 @@
 ---
-title: tempo wallet
-description: Use Tempo Wallet from the terminal — authenticate, check balances, manage access keys, and discover services.
+title: Tempo Wallet CLI
+description: Use Tempo Wallet CLI from the terminal for wallet auth, balances, access keys, MPP service discovery, paid requests, and agent workflows.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# `tempo wallet`
+# Tempo Wallet CLI
 
-CLI interface for [Tempo Wallet](https://wallet.tempo.xyz), Tempo's web-based passkey wallet. Authenticate in your browser, then manage balances, access keys, funding, service discovery, and payment sessions from the terminal.
+Tempo Wallet CLI is the command-line way to use [Tempo Wallet](https://wallet.tempo.xyz) from scripts, terminals, and AI agents. Use `tempo wallet` to authenticate, manage balances and access keys, discover [MPP](https://mpp.dev/overview) services, fund token or credit balances, and manage payment sessions. Use [`tempo request`](/docs/cli/request) when you want the CLI to make the paid HTTP call.
 
 <Cards>
   <Card
     title="Download"
-    description="Install the Tempo CLI"
+    description="Install the Tempo launcher and wallet extensions"
     to="#download"
     icon="lucide:download"
   />
@@ -23,9 +23,15 @@ CLI interface for [Tempo Wallet](https://wallet.tempo.xyz), Tempo's web-based pa
     icon="lucide:log-in"
   />
   <Card
-    title="Check Balances"
-    description="View your address, balances, and key state"
-    to="#check-balances"
+    title="Agent Mode"
+    description="Use TOON output, dry runs, and spend caps"
+    to="#agent-and-script-mode"
+    icon="lucide:bot"
+  />
+  <Card
+    title="Balances"
+    description="View your address, balances, credits, and key state"
+    to="#balances-and-credits"
     icon="lucide:coins"
   />
   <Card
@@ -54,7 +60,7 @@ CLI interface for [Tempo Wallet](https://wallet.tempo.xyz), Tempo's web-based pa
 curl -fsSL https://tempo.xyz/install | bash
 ```
 
-To update later, run `tempoup`. Verify with `tempo --version`.
+The launcher manages `tempo wallet` and `tempo request` extensions. To update later, run `tempoup`. Verify with `tempo --version`.
 
 ## Authenticate
 
@@ -64,6 +70,12 @@ tempo wallet login
 
 Opens a browser flow to connect to your [Tempo Wallet](https://wallet.tempo.xyz). If you don't have one, the flow creates it.
 
+For remote hosts where the browser is on another device:
+
+```bash
+tempo wallet login --no-browser
+```
+
 Once logged in, verify everything works:
 
 ```bash
@@ -72,39 +84,51 @@ tempo wallet whoami
 
 If `ready=true`, the wallet is ready for [`tempo request`](/docs/cli/request).
 
+Refresh a stale access key without logging out:
+
+```bash
+tempo wallet refresh
+```
+
 To disconnect:
 
 ```bash
-tempo wallet logout
+tempo wallet logout --yes
 ```
 
-## Check balances
+## Balances and credits
 
 ```bash
 tempo wallet whoami
+tempo wallet whoami --credits
 ```
 
-Shows your address, token balances, and key state.
+Shows your address, token balances, key state, and optional MPP Credits balance. Credits are separate from token balances and only apply to eligible one-time MPP charges.
 
 ## Manage access keys
 
 ```bash
 tempo wallet keys
+tempo wallet revoke <ACCESS_KEY_ADDRESS> --dry-run
+tempo wallet revoke <ACCESS_KEY_ADDRESS>
 ```
 
-Each wallet can have multiple access keys with independent spending limits. Use these to constrain what an agent or script can spend.
+Each wallet can have multiple access keys with independent spending limits. Use scoped keys to constrain what an agent or script can spend, and revoke keys that are stale or no longer needed.
 
 ## Add funds
 
 ```bash
 tempo wallet fund
+tempo wallet fund --credits
+tempo wallet fund --crypto
 ```
 
-On testnet, this opens the faucet. On mainnet, it opens bridging and onramp options.
+On testnet, the default flow opens the faucet. On mainnet, it opens available funding options. `--crypto` opens direct crypto funding. `--credits` opens MPP Credits purchase for eligible one-time services.
 
 To transfer tokens to another address:
 
 ```bash
+tempo wallet transfer <amount> <token> <to> --dry-run
 tempo wallet transfer <amount> <token> <to>
 ```
 
@@ -118,24 +142,60 @@ tempo wallet services --search <query>
 tempo wallet services <id>
 ```
 
-The [Machine Payments Protocol](https://mpp.dev/overview) (MPP) lets any HTTP endpoint accept payments inline. The service directory indexes MPP-registered providers — each entry shows endpoint URLs, HTTP methods, pricing, and request schemas. Use it to find the right URL and payload for [`tempo request`](/docs/cli/request).
+The [Machine Payments Protocol](https://mpp.dev/overview) (MPP) lets HTTP endpoints accept payments inline. The service directory indexes MPP-registered providers. Each entry shows endpoint URLs, HTTP methods, pricing, whether credits are supported, and request schemas. Use it to find the exact URL and payload for [`tempo request`](/docs/cli/request).
 
 Agents that support MCP can also use the read-only services MCP server at `https://mpp.dev/mcp/services`. See [Discover MPP services](/docs/guide/machine-payments/discover-services) for MCP setup, JSON-RPC examples, and the public catalog API.
+
+Agent workflow:
+
+```bash
+tempo wallet -t services --search ai
+tempo wallet -t services <SERVICE_ID>
+tempo request -t --dry-run -X POST --json '{"input":"hello"}' <SERVICE_URL>/<ENDPOINT_PATH>
+tempo request -t -X POST --json '{"input":"hello"}' <SERVICE_URL>/<ENDPOINT_PATH>
+```
 
 ## Manage payment sessions
 
 When you use [pay-as-you-go](/docs/guide/machine-payments/pay-as-you-go) services, MPP opens a [session](https://mpp.dev/payment-methods/tempo/session) — a payment channel where your wallet deposits funds into a reserve contract, then pays per request using signed [vouchers](https://mpp.dev/protocol/credentials) off-chain. This avoids an on-chain transaction for every request, giving sub-100ms latency and near-zero per-request fees.
 
-The CLI tracks session state locally:
+Tempo Wallet CLI tracks session state locally:
 
 ```bash
 tempo wallet sessions list
 tempo wallet sessions sync
 tempo wallet sessions close --all
 tempo wallet sessions close --orphaned
+tempo wallet sessions close --finalize
 ```
 
-`sync` reconciles local records with onchain state. `close --orphaned` cleans up sessions whose counterparty is unreachable. Use `--dry-run` with any close command to preview before executing.
+`sync` reconciles local records with onchain state. `close --orphaned` cleans up sessions whose counterparty is unreachable. `close --finalize` finalizes channels already pending close. Use `--dry-run` with any close command to preview before executing.
+
+## Agent and script mode
+
+Use [TOON](https://toonformat.dev/) output for compact, machine-readable responses:
+
+```bash
+tempo wallet -t whoami
+tempo wallet -t services --search ai
+tempo wallet -t services <SERVICE_ID>
+```
+
+Before spending, preview and cap paid requests:
+
+```bash
+tempo request -t --dry-run -X POST --json '{"input":"hello"}' <SERVICE_URL>/<ENDPOINT_PATH>
+tempo request -t --max-spend 1.00 -X POST --json '{"input":"hello"}' <SERVICE_URL>/<ENDPOINT_PATH>
+```
+
+If a service supports MPP Credits, inspect the challenge first, then pay with credits:
+
+```bash
+headers="$(mktemp)"
+tempo request -t --dry-run -D "$headers" -X POST --json '{"input":"hello"}' <SERVICE_URL>/<ENDPOINT_PATH>
+tempo wallet -t transfer --credits --dry-run --mpp-challenge-file "$headers"
+tempo wallet -t transfer --credits --mpp-challenge-file "$headers"
+```
 
 ## Command reference
 
@@ -144,21 +204,29 @@ tempo wallet sessions close --orphaned
 | Command | Description |
 | --- | --- |
 | `tempo wallet login` | Connect or create a wallet via browser auth |
+| `tempo wallet login --no-browser` | Print an auth URL for remote-host login |
+| `tempo wallet refresh` | Refresh the current access key |
 | `tempo wallet logout` | Disconnect and clear local credentials |
 | `tempo wallet whoami` | Print readiness, address, balances, and key state |
+| `tempo wallet whoami --credits` | Print MPP Credits balance |
 
 ### Keys
 
 | Command | Description |
 | --- | --- |
 | `tempo wallet keys` | List keys and their spending limits |
+| `tempo wallet revoke <access-key> --dry-run` | Preview access-key revocation |
+| `tempo wallet revoke <access-key>` | Revoke an access key |
 
 ### Funds
 
 | Command | Description |
 | --- | --- |
 | `tempo wallet fund` | Fund wallet (faucet on testnet, bridge on mainnet) |
+| `tempo wallet fund --crypto` | Open direct crypto funding |
+| `tempo wallet fund --credits` | Buy MPP Credits for eligible one-time services |
 | `tempo wallet transfer <amount> <token> <to>` | Transfer tokens to another address |
+| `tempo wallet transfer --credits --mpp-challenge-file <file>` | Pay an MPP challenge with credits |
 
 ### Services
 
@@ -176,12 +244,14 @@ tempo wallet sessions close --orphaned
 | `tempo wallet sessions sync` | Reconcile local sessions with onchain state |
 | `tempo wallet sessions close --all` | Close all sessions |
 | `tempo wallet sessions close --orphaned` | Close sessions whose counterparty is unreachable |
+| `tempo wallet sessions close --finalize` | Finalize channels pending close |
 
 ### Advanced
 
 | Command | Description |
 | --- | --- |
-| `tempo wallet mpp-sign` | Sign an MPP payment challenge (used internally by `tempo request`) |
+| `tempo wallet debug` | Collect debug info for support |
+| `tempo wallet completions <shell>` | Generate shell completions |
 
 ## Learn more
 
@@ -206,8 +276,8 @@ tempo wallet sessions close --orphaned
   />
   <Card
     title="Source code"
-    description="tempoxyz/wallet on GitHub"
-    to="https://github.com/tempoxyz/wallet"
+    description="tempoxyz/wallet-cli on GitHub"
+    to="https://github.com/tempoxyz/wallet-cli"
     icon="lucide:github"
   />
 </Cards>

--- a/src/pages/docs/wallet/index.mdx
+++ b/src/pages/docs/wallet/index.mdx
@@ -1,13 +1,13 @@
 ---
-title: Tempo CLI
-description: A terminal client for Tempo wallet management, service discovery, and paid HTTP requests via the Machine Payments Protocol.
+title: Tempo Wallet CLI
+description: Use Tempo Wallet CLI from the command line for wallet management, MPP service discovery, paid requests, and AI agent workflows.
 ---
 
-# Tempo CLI
+# Tempo Wallet CLI
 
-The `tempo` CLI is a terminal client for Tempo. It has two command families:
+Tempo Wallet CLI is the command-line way to use Tempo Wallet from scripts, terminals, and AI agents. It has two command families:
 
-- **`tempo wallet`**: manages your onchain identity: authentication, key management, balances, funding, and transfers. It also provides a service directory for discovering [MPP](https://mpp.dev)-compatible endpoints and their request schemas.
+- **`tempo wallet`**: manages your onchain identity: authentication, key management, balances, funding, transfers, MPP Credits, service discovery, and payment sessions. It also provides a service directory for discovering [MPP](https://mpp.dev)-compatible endpoints and their request schemas.
 - **`tempo request`**: a curl-like HTTP client that handles [Machine Payments Protocol](https://mpp.dev) negotiation automatically. It sends your request, intercepts `402 Payment Required` challenges, signs and submits the payment onchain, then retries with the credential, all in a single command.
 
 Together they let you browse paid APIs, preview costs, and execute paid requests from a terminal, script, or AI agent without writing any integration code.
@@ -22,10 +22,12 @@ curl -fsSL https://tempo.xyz/install | bash
 
 ```bash
 tempo wallet login
+tempo wallet login --no-browser
 tempo wallet whoami
+tempo wallet whoami --credits
 ```
 
-`login` opens a browser flow that creates or connects a Tempo wallet. `whoami` confirms readiness, prints your address, and shows token balances.
+`login` opens a browser flow that creates or connects a Tempo Wallet. Use `--no-browser` on remote hosts. `whoami` confirms readiness, prints your address, and shows token balances. `whoami --credits` shows MPP Credits separately from token balances.
 
 ## Discover and call a paid API
 
@@ -47,12 +49,15 @@ tempo request -X POST \
   https://fal.mpp.tempo.xyz/fal-ai/flux/dev
 ```
 
+Always build request URLs from `tempo wallet services <SERVICE_ID>` output. Service entries include URLs, methods, pricing, request schemas, and credit support when available.
+
 ## Scripting and agents
 
-The CLI is designed for non-interactive use. Two features matter here:
+Tempo Wallet CLI is designed for non-interactive use. Three features matter here:
 
-- **`-t` (TOON output)**: compact, machine-readable output that minimizes token usage when consumed by an LLM or parsed by a script.
+- **`-t` ([TOON](https://toonformat.dev/) output)**: compact, machine-readable output that minimizes token usage when consumed by an LLM or parsed by a script.
 - **`--dry-run`**: previews the payment cost and validates the request shape without spending funds. Useful for agents that need to confirm cost before committing.
+- **`--max-spend`**: caps paid `tempo request` workflows so an agent cannot exceed a caller-provided budget.
 
 To set up an AI agent (Claude Code, Amp, Codex) with wallet and request capabilities:
 
@@ -72,4 +77,5 @@ This installs `tempo-wallet` and `tempo-request` skills automatically. The agent
 
 ## Next
 
-- [Reference](/docs/wallet/reference): complete command and flag reference
+- [Wallet CLI](/docs/cli/wallet): canonical docs and command reference
+- [Reference](/docs/wallet/reference): legacy command reference

--- a/src/pages/docs/wallet/recipes.mdx
+++ b/src/pages/docs/wallet/recipes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tempo Wallet CLI Recipes
-description: Use practical Tempo Wallet CLI recipes for service discovery, paid requests, session management, and funding or transfers.
+description: Use Tempo Wallet CLI recipes for agent setup, MPP service discovery, paid requests, credits, sessions, funding, and transfers.
 ---
 
 # Recipes
@@ -9,10 +9,11 @@ description: Use practical Tempo Wallet CLI recipes for service discovery, paid 
 
 ```bash
 tempo wallet -t whoami
+tempo wallet -t whoami --credits
 tempo wallet services --search ai
 tempo wallet services <SERVICE_ID>
 tempo request --dry-run <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
-tempo request <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
+tempo request --max-spend 1.00 <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 ```
 
 ## Wallet Operations
@@ -20,14 +21,18 @@ tempo request <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 ```bash
 # Wallet readiness and balances
 tempo wallet whoami
+tempo wallet whoami --credits
 
 # Key and spending-limit state
 tempo wallet keys
+tempo wallet revoke <ACCESS_KEY_ADDRESS> --dry-run
 
 # Fund wallet
 tempo wallet fund
+tempo wallet fund --credits
 
 # Transfer tokens
+tempo wallet transfer <AMOUNT> <TOKEN> <TO_ADDRESS> --dry-run
 tempo wallet transfer <AMOUNT> <TOKEN> <TO_ADDRESS>
 ```
 
@@ -35,8 +40,11 @@ For machine-readable output:
 
 ```bash
 tempo wallet -t whoami
+tempo wallet -t whoami --credits
 tempo wallet -t keys
 ```
+
+Use access-key spending limits and `tempo request --max-spend` for agent workflows. Credits are separate from token balances and only work with eligible one-time MPP charges.
 
 ## Service Discovery
 
@@ -50,6 +58,8 @@ tempo wallet services <SERVICE_ID>
 
 Tip: copy endpoint URL, method, and payload shape directly from service details.
 
+Service details also show pricing, payment mode, and whether `supportsCredits: true` is available.
+
 ## Request Execution
 
 Preview before paying:
@@ -61,7 +71,16 @@ tempo request --dry-run <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 Execute paid request:
 
 ```bash
-tempo request <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
+tempo request --max-spend 1.00 <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
+```
+
+Capture headers for a credits flow:
+
+```bash
+headers="$(mktemp)"
+tempo request -t --dry-run -D "$headers" -X POST --json '{"input":"hello"}' <SERVICE_ENDPOINT_URL>
+tempo wallet -t transfer --credits --dry-run --mpp-challenge-file "$headers"
+tempo wallet -t transfer --credits --mpp-challenge-file "$headers"
 ```
 
 ## Session Management
@@ -78,7 +97,12 @@ tempo wallet sessions close --dry-run --all
 
 # Close orphaned sessions
 tempo wallet sessions close --orphaned
+
+# Finalize channels pending close
+tempo wallet sessions close --finalize
 ```
+
+Sessions are MPP payment channels used by pay-as-you-go services. One-time charges may use direct token payment or MPP Credits when the service supports credits.
 
 ## Agent and Script Mode
 
@@ -88,6 +112,7 @@ Use TOON output (`-t`) when command output is consumed by agents or scripts.
 tempo wallet -t whoami
 tempo wallet -t services --search ai
 tempo wallet -t services <SERVICE_ID>
+tempo request -t --dry-run --max-spend 1.00 <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 ```
 
 ## Failure Recovery Shortcuts
@@ -101,12 +126,17 @@ tempo wallet -t whoami
 tempo wallet logout --yes
 tempo wallet login
 tempo wallet keys
+tempo wallet refresh
 
 # Request failing due to payload/path mismatch
 tempo wallet services <SERVICE_ID>
 
 # Insufficient funds
 tempo wallet fund
+
+# Credit-eligible one-time MPP charge
+tempo wallet -t whoami --credits
+tempo wallet fund --credits
 ```
 
 If issues persist, continue with [Troubleshooting](/docs/cli/wallet).
@@ -123,12 +153,12 @@ tempo wallet -t services --search ai
 # 3) Preview cost
 tempo request --dry-run <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 
-# 4) Execute
-tempo request <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
+# 4) Execute with a spend cap
+tempo request --max-spend 1.00 <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 ```
 
 ## See Also
 
 1. [Reference](/docs/wallet/reference)
-2. [CLI Reference](/docs/cli/wallet)
+2. [Wallet CLI Reference](/docs/cli/wallet)
 3. [Use with Agents](/docs/wallet/use-with-agents)

--- a/src/pages/docs/wallet/reference.mdx
+++ b/src/pages/docs/wallet/reference.mdx
@@ -1,9 +1,9 @@
 ---
-title: Tempo CLI Reference
-description: Complete command and flag reference for tempo wallet and tempo request.
+title: Tempo Wallet CLI Reference
+description: Complete reference for Tempo Wallet CLI, tempo wallet, tempo request, MPP service discovery, credits, and agent flags.
 ---
 
-# Reference
+# Tempo Wallet CLI Reference
 
 ## `tempo wallet`
 
@@ -14,8 +14,11 @@ Manages your onchain identity and provides service discovery for [MPP](https://m
 | Command | Description |
 | --- | --- |
 | `tempo wallet login` | Connect or create wallet via browser auth |
+| `tempo wallet login --no-browser` | Print an auth URL for remote-host login |
+| `tempo wallet refresh` | Refresh your access key without logging out |
 | `tempo wallet logout` | Disconnect wallet and clear local credentials |
 | `tempo wallet whoami` | Print readiness, address, balances, and key state |
+| `tempo wallet whoami --credits` | Show MPP Credits balance |
 
 ### Keys
 
@@ -24,17 +27,23 @@ Each wallet can have multiple access keys with independent spending limits. This
 | Command | Description |
 | --- | --- |
 | `tempo wallet keys` | List keys and their spending limits |
+| `tempo wallet revoke <access-key> --dry-run` | Preview access-key revocation |
+| `tempo wallet revoke <access-key>` | Revoke an access key |
 
 ### Funds
 
 | Command | Description |
 | --- | --- |
 | `tempo wallet fund` | Fund wallet (faucet on testnet, bridge on mainnet) |
+| `tempo wallet fund --crypto` | Open direct crypto funding |
+| `tempo wallet fund --credits` | Buy credits for eligible one-time MPP charges |
 | `tempo wallet transfer <amount> <token> <to>` | Transfer tokens to another address |
+| `tempo wallet transfer <amount> <token> <to> --dry-run` | Preview a token transfer |
+| `tempo wallet transfer --credits --mpp-challenge-file <file>` | Pay a captured MPP challenge with credits |
 
 ### Services
 
-The service directory indexes [MPP](https://mpp.dev)-registered providers. Each service entry includes endpoint URLs, HTTP methods, and expected request schemas, enough to construct a valid `tempo request` call.
+The service directory indexes [MPP](https://mpp.dev)-registered providers. Each service entry includes endpoint URLs, HTTP methods, pricing, request schemas, payment mode, and credit support when available.
 
 | Command | Description |
 | --- | --- |
@@ -44,7 +53,7 @@ The service directory indexes [MPP](https://mpp.dev)-registered providers. Each 
 
 ### Sessions
 
-Sessions are the local state for [pay-as-you-go](/docs/guide/machine-payments/pay-as-you-go) payment channels. The CLI tracks them locally and can reconcile against onchain state.
+Sessions are the local state for [pay-as-you-go](/docs/guide/machine-payments/pay-as-you-go) payment channels. Tempo Wallet CLI tracks them locally and can reconcile against onchain state.
 
 | Command | Description |
 | --- | --- |
@@ -52,12 +61,15 @@ Sessions are the local state for [pay-as-you-go](/docs/guide/machine-payments/pa
 | `tempo wallet sessions sync` | Reconcile local sessions with onchain state |
 | `tempo wallet sessions close --all` | Close all sessions |
 | `tempo wallet sessions close --orphaned` | Close sessions whose counterparty is unreachable |
+| `tempo wallet sessions close --finalize` | Finalize channels pending close |
+| `tempo wallet sessions close --cooperative <url>` | Use cooperative close for a target session |
 
-### Other
+### Agent setup and diagnostics
 
 | Command | Description |
 | --- | --- |
-| `tempo wallet mpp-sign` | Sign an MPP payment challenge (used internally by `tempo request`) |
+| `tempo wallet debug` | Collect debug info for support |
+| `tempo wallet completions <shell>` | Generate shell completions |
 
 ## `tempo request`
 
@@ -67,19 +79,23 @@ A curl-like HTTP client that handles [MPP](https://mpp.dev) payment negotiation 
 | --- | --- |
 | `tempo request <url>` | Make an HTTP request with automatic payment |
 | `tempo request --dry-run <url>` | Preview cost without executing payment |
+| `tempo request --max-spend <amount> <url>` | Cap cumulative payment spend |
 | `tempo request <url> --json '{...}'` | Send a JSON body (implies `-X POST`) |
 | `tempo request <url> -H 'Header: Value'` | Add a custom header |
+| `tempo request -D <file> <url>` | Write response headers to a file |
 
 ## Global flags
 
 | Flag | Scope | Description |
 | --- | --- | --- |
 | `-t` / `--toon-output` | `tempo wallet`, `tempo request` | Compact machine-readable output for scripts and agents |
-| `--dry-run` | `tempo request`, `tempo wallet fund`, `tempo wallet sessions close` | Preview the action without executing |
+| `--dry-run` | `tempo request`, `tempo wallet transfer`, `tempo wallet sessions close` | Preview the action without executing |
+| `--max-spend` | `tempo request` | Hard cap for cumulative payment spend |
 | `--help` | all commands | Show command documentation |
 | `--describe` | supported commands | Output command schema as JSON for programmatic tooling |
+| `--schema` | supported built-in setup commands | Output command schema for programmatic tooling |
 
 ## Source
 
-- Repository: [`tempoxyz/wallet`](https://github.com/tempoxyz/wallet)
+- Repository: [`tempoxyz/wallet-cli`](https://github.com/tempoxyz/wallet-cli)
 - Full help: `tempo wallet --help`, `tempo request --help`

--- a/src/pages/docs/wallet/use-with-agents.mdx
+++ b/src/pages/docs/wallet/use-with-agents.mdx
@@ -1,13 +1,13 @@
 ---
 title: Use Tempo Wallet CLI with Agents
-description: Connect Tempo Wallet CLI to your agent and understand the built-in features that make agent-driven paid requests reliable and safe.
+description: Connect Tempo Wallet CLI to AI agents for MPP service discovery, payment previews, spend caps, credits, and paid HTTP requests.
 ---
 
 # Use with Agents
 
 ## Quickstart
 
-Paste this into your agent to set up Tempo Wallet:
+Paste this into your agent to set up Tempo Wallet CLI:
 
 
 
@@ -25,7 +25,7 @@ codex exec "Read https://tempo.xyz/SKILL.md and set up tempo"
 
 ## Auto-installed Skills
 
-When you run the setup prompt, your agent installs Tempo's built-in skills automatically — no manual skill wiring required.
+When you run the setup prompt, your agent installs Tempo's built-in skills automatically. No manual skill wiring required.
 
 - `tempo-wallet`: gives your agent wallet-aware capabilities like readiness checks, balances, service discovery, and session/funding actions.
 - `tempo-request`: gives your agent paid HTTP request capabilities with payment preview (`--dry-run`) and execution support.
@@ -36,8 +36,28 @@ This works in supported skill-enabled agents including **Claude Code**, **Amp**,
 
 1. **TOON output mode (`-t` / `--toon-output`)** gives compact, machine-readable, token-efficient output so agent tooling can parse command responses reliably.
 2. **Built-in service discovery** (`tempo wallet services`) lets agents search providers, inspect endpoint details, and use verified method/path metadata instead of guessing URLs or payload shapes.
-3. **`--dry-run` payment previews** let agents validate endpoint reachability, request shape, and expected payment cost before committing funds, which reduces failed paid calls in multi-step workflows.
-4. **Scoped access keys and spend controls** let you enforce spending limits per key so agents can only spend within defined budgets, which contains risk if a prompt, endpoint choice, or loop goes wrong.
+3. **`--dry-run` payment previews** let agents validate endpoint reachability, request shape, and expected payment cost before committing funds.
+4. **`--max-spend` and scoped access keys** let you enforce budgets per request and per key.
+5. **MPP Credits support** lets agents pay eligible one-time charges from a separate credits balance after checking `tempo wallet -t whoami --credits`.
+
+## Agent Pattern
+
+```bash
+tempo wallet -t whoami
+tempo wallet -t services --search <query>
+tempo wallet -t services <SERVICE_ID>
+tempo request -t --dry-run --max-spend 1.00 -X POST --json '{"input":"hello"}' <SERVICE_URL>/<ENDPOINT_PATH>
+tempo request -t --max-spend 1.00 -X POST --json '{"input":"hello"}' <SERVICE_URL>/<ENDPOINT_PATH>
+```
+
+For credit-eligible one-time charges:
+
+```bash
+tempo wallet -t whoami --credits
+headers="$(mktemp)"
+tempo request -t --dry-run -D "$headers" -X POST --json '{"input":"hello"}' <SERVICE_URL>/<ENDPOINT_PATH>
+tempo wallet -t transfer --credits --dry-run --mpp-challenge-file "$headers"
+```
 
 ## Troubleshooting
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -825,7 +825,7 @@ export default defineConfig({
                 link: '/docs/cli',
               },
               {
-                text: 'Wallet',
+                text: 'Wallet CLI',
                 link: '/docs/cli/wallet',
               },
               {
@@ -1197,6 +1197,61 @@ export default defineConfig({
     {
       source: '/docs/protocol/exchange/pathUSD',
       destination: '/docs/protocol/exchange/quote-tokens#pathusd',
+      status: 301,
+    },
+    {
+      source: '/wallet',
+      destination: '/docs/cli/wallet',
+      status: 301,
+    },
+    {
+      source: '/wallet/reference',
+      destination: '/docs/cli/wallet',
+      status: 301,
+    },
+    {
+      source: '/wallet/:path*',
+      destination: '/docs/cli/wallet',
+      status: 301,
+    },
+    {
+      source: '/cli/reference',
+      destination: '/docs/cli/wallet',
+      status: 301,
+    },
+    {
+      source: '/cli/wallet',
+      destination: '/docs/cli/wallet',
+      status: 301,
+    },
+    {
+      source: '/cli/:path*',
+      destination: '/docs/cli/:path*',
+      status: 301,
+    },
+    {
+      source: '/sdk/typescript/prool',
+      destination: '/docs/sdk/typescript/prool/setup',
+      status: 301,
+    },
+    {
+      source: '/guide/use-accounts/fee-sponsorship',
+      destination: '/docs/guide/payments/sponsor-user-fees',
+      status: 301,
+    },
+    {
+      source: '/quickstart/tip20',
+      destination: '/docs/protocol/tip20/overview',
+      status: 301,
+    },
+    {
+      source: '/protocol/exchange/pathUSD',
+      destination: '/docs/protocol/exchange/quote-tokens#pathusd',
+      status: 301,
+    },
+    {
+      source: '/protocol/zones/overview',
+      destination: '/docs/protocol/zones',
       status: 301,
     },
   ],


### PR DESCRIPTION
## Summary

- Reframe wallet docs around Tempo Wallet CLI and agent workflows
- Add current examples for MPP service discovery, credits, sessions, dry runs, and spend caps
- Update wallet source links, home page cards, navigation labels, and legacy wallet redirects

## Motivation

Keep wallet documentation aligned with the wallet-cli repository and clarify how Tempo Wallet CLI, Tempo Wallet, and MPP fit together for command-line and agent workflows.

## Key design considerations

- Keep `/cli/wallet` as the canonical Wallet CLI page
- Redirect legacy `/wallet` routes to the canonical Wallet CLI docs
- Use service discovery output as the source of truth for paid request examples