### PR TITLE
feat: instrument docs crawler requests

### DIFF
--- a/e2e/docs-request-classifier.test.ts
+++ b/e2e/docs-request-classifier.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from '@playwright/test'
+import {
+  classifyDocsRequest,
+  type DocsRequestAgentKind,
+  type DocsRequestMatchSource,
+  type DocsRequestSurface,
+} from '../src/lib/docs-request-classifier'
+
+type ClassificationCase = {
+  name: string
+  input: Parameters<typeof classifyDocsRequest>[0]
+  expected: {
+    agent_family?: string
+    agent_kind?: DocsRequestAgentKind
+    match_source: DocsRequestMatchSource
+    shouldTrack: boolean
+    surface: DocsRequestSurface
+  }
+}
+
+const cases: ClassificationCase[] = [
+  {
+    name: 'OpenAI search crawler',
+    input: { path: '/guide/payments', userAgent: 'Mozilla/5.0; OAI-SearchBot/1.0' },
+    expected: {
+      agent_family: 'openai',
+      agent_kind: 'search',
+      match_source: 'official_ua',
+      shouldTrack: true,
+      surface: 'docs',
+    },
+  },
+  {
+    name: 'Anthropic user fetcher',
+    input: { path: '/guide/payments.md', userAgent: 'Claude-User/1.0' },
+    expected: {
+      agent_family: 'anthropic',
+      agent_kind: 'user_fetch',
+      match_source: 'official_ua',
+      shouldTrack: true,
+      surface: 'markdown',
+    },
+  },
+  {
+    name: 'Perplexity crawler',
+    input: { path: '/llms-full.txt', userAgent: 'PerplexityBot/1.0' },
+    expected: {
+      agent_family: 'perplexity',
+      agent_kind: 'crawler',
+      match_source: 'official_ua',
+      shouldTrack: true,
+      surface: 'llms',
+    },
+  },
+  {
+    name: 'Google crawler',
+    input: { path: '/.well-known/ai-plugin.json', userAgent: 'Google-CloudVertexBot' },
+    expected: {
+      agent_family: 'google',
+      agent_kind: 'crawler',
+      match_source: 'official_ua',
+      shouldTrack: true,
+      surface: 'well_known',
+    },
+  },
+  {
+    name: 'Claude Code MCP client',
+    input: { path: '/api/mcp', userAgent: 'claude-code/1.0.0 (cli)' },
+    expected: {
+      agent_family: 'anthropic',
+      agent_kind: 'developer_tool',
+      match_source: 'managed_list',
+      shouldTrack: true,
+      surface: 'mcp',
+    },
+  },
+  {
+    name: 'Codex MCP client',
+    input: { path: '/api/mcp', userAgent: 'codex-mcp-client/0.1.0' },
+    expected: {
+      agent_family: 'openai',
+      agent_kind: 'developer_tool',
+      match_source: 'managed_list',
+      shouldTrack: true,
+      surface: 'mcp',
+    },
+  },
+  {
+    name: 'AI referrer',
+    input: { path: '/guide/payments', referer: 'https://chatgpt.com/c/abc' },
+    expected: {
+      agent_kind: 'unknown_ai',
+      match_source: 'ai_referrer',
+      shouldTrack: true,
+      surface: 'docs',
+    },
+  },
+  {
+    name: 'MCP surface with unknown user agent',
+    input: { path: '/api/mcp', userAgent: 'UnknownAgent/1.0' },
+    expected: {
+      match_source: 'agent_surface',
+      shouldTrack: true,
+      surface: 'mcp',
+    },
+  },
+  {
+    name: 'skill surface with unknown user agent',
+    input: { path: '/SKILL.md', userAgent: 'curl/8.0' },
+    expected: {
+      match_source: 'agent_surface',
+      shouldTrack: true,
+      surface: 'skill',
+    },
+  },
+  {
+    name: 'normal human docs page',
+    input: { path: '/guide/payments', userAgent: 'Mozilla/5.0' },
+    expected: {
+      agent_kind: 'human',
+      match_source: 'none',
+      shouldTrack: false,
+      surface: 'docs',
+    },
+  },
+]
+
+for (const item of cases) {
+  test(`classifies docs request: ${item.name}`, () => {
+    expect(classifyDocsRequest(item.input)).toMatchObject(item.expected)
+  })
+}

--- a/src/lib/docs-request-classifier.ts
+++ b/src/lib/docs-request-classifier.ts
@@ -1,0 +1,213 @@
+export type DocsRequestSurface =
+  /** Root LLM indexes: /llms.txt and /llms-full.txt. */
+  | 'llms'
+  /** Markdown renderings of docs pages, requested with a .md suffix. */
+  | 'markdown'
+  /** Built-in Vocs MCP endpoint under /api/mcp. */
+  | 'mcp'
+  /** Agent skill entrypoint, currently /SKILL.md. */
+  | 'skill'
+  /** Standards discovery paths such as /.well-known/oauth-protected-resource. */
+  | 'well_known'
+  /** Human-readable docs pages without file extensions. */
+  | 'docs'
+  /** Static assets, unrelated APIs, and anything outside known docs surfaces. */
+  | 'other'
+
+export type DocsRequestAgentKind =
+  /** Background crawler that may index content for future model/search use. */
+  | 'crawler'
+  /** Search/index fetcher used to power cited or search-grounded answers. */
+  | 'search'
+  /** User-triggered URL fetch from an AI product. */
+  | 'user_fetch'
+  /** Local or hosted coding-agent client, such as Claude Code MCP transport. */
+  | 'developer_tool'
+  /** AI-looking request without a more specific known client signal. */
+  | 'unknown_ai'
+  /** Ordinary browser/docs traffic that should not be server-side tracked here. */
+  | 'human'
+
+export type DocsRequestMatchSource =
+  /** UA token documented by the crawler/vendor as an official bot/fetcher. */
+  | 'official_ua'
+  /** UA token observed or documented for developer clients, but not crawler-official. */
+  | 'managed_list'
+  /** Referer host belongs to a known AI product. */
+  | 'ai_referrer'
+  /** Unknown client requested a machine-readable agent surface. */
+  | 'agent_surface'
+  /** No server-side agent signal matched. */
+  | 'none'
+
+export type DocsRequestClassification = {
+  surface: DocsRequestSurface
+  agent_family?: string
+  agent_kind?: DocsRequestAgentKind
+  match_source: DocsRequestMatchSource
+  referer_host?: string
+  shouldTrack: boolean
+}
+
+type UserAgentRule = {
+  token: string
+  agent_family: string
+  agent_kind: Exclude<DocsRequestAgentKind, 'human' | 'unknown_ai'>
+}
+
+/** Official crawler/search/fetch user-agent tokens from provider documentation. */
+const OFFICIAL_USER_AGENT_RULES: readonly UserAgentRule[] = [
+  /** OpenAI search crawler for linking/citation surfaces. */
+  { token: 'OAI-SearchBot', agent_family: 'openai', agent_kind: 'search' },
+  /** OpenAI training/indexing crawler. */
+  { token: 'GPTBot', agent_family: 'openai', agent_kind: 'crawler' },
+  /** OpenAI user-triggered fetcher from ChatGPT browsing/actions. */
+  { token: 'ChatGPT-User', agent_family: 'openai', agent_kind: 'user_fetch' },
+  /** Anthropic search crawler for Claude search/citation surfaces. */
+  { token: 'Claude-SearchBot', agent_family: 'anthropic', agent_kind: 'search' },
+  /** Anthropic user-triggered fetcher from Claude. */
+  { token: 'Claude-User', agent_family: 'anthropic', agent_kind: 'user_fetch' },
+  /** Anthropic training/indexing crawler. */
+  { token: 'ClaudeBot', agent_family: 'anthropic', agent_kind: 'crawler' },
+  /** Perplexity background crawler. */
+  { token: 'PerplexityBot', agent_family: 'perplexity', agent_kind: 'crawler' },
+  /** Perplexity user-triggered fetcher. */
+  { token: 'Perplexity-User', agent_family: 'perplexity', agent_kind: 'user_fetch' },
+  /** Google Vertex AI crawler. */
+  { token: 'Google-CloudVertexBot', agent_family: 'google', agent_kind: 'crawler' },
+  /** Google generic crawler used by non-search products. */
+  { token: 'GoogleOther', agent_family: 'google', agent_kind: 'crawler' },
+  /** Google Search crawler. */
+  { token: 'Googlebot', agent_family: 'google', agent_kind: 'search' },
+]
+
+/**
+ * Developer-tool clients that are useful for docs analytics but are not
+ * official crawler identities. Keep these prefix-like and sparse.
+ */
+const MANAGED_CLIENT_USER_AGENT_RULES: readonly UserAgentRule[] = [
+  /** Claude Code CLI HTTP/MCP transport, versioned as claude-code/<version> (cli). */
+  { token: 'claude-code/', agent_family: 'anthropic', agent_kind: 'developer_tool' },
+  /** Proposed/forked Codex MCP UA; current Codex may omit UA on remote MCP requests. */
+  { token: 'codex-mcp-client/', agent_family: 'openai', agent_kind: 'developer_tool' },
+  /** Common Codex MCP workaround UA set manually via http_headers. */
+  { token: 'codex-mcp/', agent_family: 'openai', agent_kind: 'developer_tool' },
+]
+
+/** AI product hosts that can refer humans into the docs after an answer/citation. */
+const AI_REFERRER_HOSTS = [
+  /** ChatGPT web app and shared conversations. */
+  'chatgpt.com',
+  /** Claude web app. */
+  'claude.ai',
+  /** Perplexity answer pages. */
+  'perplexity.ai',
+  /** Gemini web app. */
+  'gemini.google.com',
+  /** Microsoft Copilot web app. */
+  'copilot.microsoft.com',
+  /** Poe bot/chat pages. */
+  'poe.com',
+]
+
+export function classifyDocsRequest(input: {
+  path: string
+  userAgent?: string
+  referer?: string
+}): DocsRequestClassification {
+  const surface = classifySurface(input.path)
+  const userAgentMatch = matchUserAgent(input.userAgent)
+  const refererHost = getRefererHost(input.referer)
+  const hasAiReferrer = refererHost ? isAiReferrerHost(refererHost) : false
+  const isAgentSurface = surface !== 'docs' && surface !== 'other'
+
+  if (userAgentMatch) {
+    return {
+      ...userAgentMatch,
+      surface,
+      referer_host: refererHost,
+      shouldTrack: true,
+    }
+  }
+
+  if (hasAiReferrer) {
+    return {
+      agent_kind: 'unknown_ai',
+      match_source: 'ai_referrer',
+      referer_host: refererHost,
+      surface,
+      shouldTrack: true,
+    }
+  }
+
+  if (isAgentSurface) {
+    return {
+      match_source: 'agent_surface',
+      referer_host: refererHost,
+      surface,
+      shouldTrack: true,
+    }
+  }
+
+  return {
+    agent_kind: 'human',
+    match_source: 'none',
+    referer_host: refererHost,
+    surface,
+    shouldTrack: false,
+  }
+}
+
+function classifySurface(path: string): DocsRequestSurface {
+  const pathname = path.toLowerCase()
+
+  if (pathname === '/llms.txt' || pathname === '/llms-full.txt') return 'llms'
+  if (pathname === '/api/mcp' || pathname.startsWith('/api/mcp/')) return 'mcp'
+  if (pathname === '/skill.md') return 'skill'
+  if (pathname.startsWith('/.well-known/')) return 'well_known'
+  if (pathname.endsWith('.md')) return 'markdown'
+  if (isDocsPage(pathname)) return 'docs'
+  return 'other'
+}
+
+function isDocsPage(pathname: string) {
+  const lastSegment = pathname.split('/').pop() ?? ''
+  return !lastSegment.includes('.')
+}
+
+function matchUserAgent(userAgent = '') {
+  const normalizedUserAgent = userAgent.toLowerCase()
+  const officialRule = OFFICIAL_USER_AGENT_RULES.find((candidate) =>
+    normalizedUserAgent.includes(candidate.token.toLowerCase()),
+  )
+
+  if (officialRule) return formatUserAgentMatch(officialRule, 'official_ua')
+
+  const managedRule = MANAGED_CLIENT_USER_AGENT_RULES.find((candidate) =>
+    normalizedUserAgent.includes(candidate.token.toLowerCase()),
+  )
+
+  if (managedRule) return formatUserAgentMatch(managedRule, 'managed_list')
+}
+
+function formatUserAgentMatch(rule: UserAgentRule, matchSource: 'official_ua' | 'managed_list') {
+  return {
+    agent_family: rule.agent_family,
+    agent_kind: rule.agent_kind,
+    match_source: matchSource,
+  }
+}
+
+function getRefererHost(referer?: string) {
+  if (!referer) return
+
+  try {
+    return new URL(referer).hostname.toLowerCase()
+  } catch {
+    return
+  }
+}
+
+function isAiReferrerHost(host: string) {
+  return AI_REFERRER_HOSTS.some((candidate) => host === candidate || host.endsWith(`.${candidate}`))
+}

--- a/src/middleware/posthog.ts
+++ b/src/middleware/posthog.ts
@@ -1,76 +1,62 @@
 /**
- * Middleware for tracking AI crawlers server-side.
+ * Server-side tracking for machine-readable docs requests.
  *
- * AI crawlers (GPTBot, ClaudeBot, etc.) don't execute JavaScript,
- * so they're invisible to PostHog's client-side tracking.
- * This middleware runs server-side on every request to capture them.
+ * Crawlers and agent clients do not run browser analytics, so this captures
+ * only high-signal docs consumption paths and official crawler user agents.
  */
 import type { MiddlewareHandler } from 'vocs/server'
+import { classifyDocsRequest } from '../lib/docs-request-classifier'
 
-const AI_CRAWLERS = [
-  'GPTBot',
-  'OAI-SearchBot',
-  'ChatGPT-User',
-  'anthropic-ai',
-  'ClaudeBot',
-  'claude-web',
-  'PerplexityBot',
-  'Perplexity-User',
-  'Google-Extended',
-  'Googlebot',
-  'Bingbot',
-  'Amazonbot',
-  'Applebot',
-  'Applebot-Extended',
-  'FacebookBot',
-  'meta-externalagent',
-  'LinkedInBot',
-  'Bytespider',
-  'DuckAssistBot',
-  'cohere-ai',
-  'AI2Bot',
-  'CCBot',
-  'Diffbot',
-  'omgili',
-  'Timpibot',
-  'YouBot',
-  'MistralAI-User',
-  'GoogleAgent-Mariner',
-]
-
-export default function test(): MiddlewareHandler {
+export default function posthog(): MiddlewareHandler {
   return async (c, next) => {
-    const ua = c.req.header('user-agent') || ''
-    const matchedCrawler = AI_CRAWLERS.find((crawler) => ua.includes(crawler))
-    if (!matchedCrawler) return next()
-
+    const startedAt = performance.now()
     const url = new URL(c.req.url)
+    const userAgent = c.req.header('user-agent') || ''
+    const referer = c.req.header('referer') || c.req.header('referrer')
+    const classification = classifyDocsRequest({
+      path: url.pathname,
+      referer,
+      userAgent,
+    })
+
+    await next()
+
+    if (!classification.shouldTrack) return
+
     const posthogKey = import.meta.env.VITE_POSTHOG_KEY
     const posthogHost = import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com'
 
-    if (!posthogKey) return next()
-
-    const ip = c.req.header('x-forwarded-for')?.split(',')[0]?.trim()
+    if (!posthogKey) return
 
     const event = {
       api_key: posthogKey,
-      event: 'crawler_pageview',
-      distinct_id: `crawler_${matchedCrawler}`,
+      distinct_id: getDistinctId(classification),
+      event: 'docs_request',
       properties: {
-        crawler_name: matchedCrawler,
-        user_agent: ua,
+        site: 'docs',
         path: url.pathname,
-        $current_url: c.req.url,
-        $ip: ip,
+        method: c.req.method,
+        status: c.res.status,
+        duration_ms: Math.round(performance.now() - startedAt),
+        surface: classification.surface,
+        agent_family: classification.agent_family,
+        agent_kind: classification.agent_kind,
+        match_source: classification.match_source,
+        referer_host: classification.referer_host,
+        user_agent: userAgent || undefined,
       },
     }
 
     fetch(`${posthogHost}/capture/`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(event),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
     }).catch(() => {})
-
-    await next()
   }
+}
+
+function getDistinctId(classification: ReturnType<typeof classifyDocsRequest>) {
+  if (classification.agent_family)
+    return `docs:${classification.agent_family}:${classification.agent_kind ?? 'unknown'}`
+  return `docs:${classification.match_source}:${classification.surface}`
 }


### PR DESCRIPTION
## Summary

- Add server-side docs request classification for AI crawlers, AI referrers, and agent surfaces
- Emit a minimal PostHog `docs_request` event from Vocs middleware
- Add classifier coverage for official crawler UAs and Claude Code/Codex MCP client signals

## Motivation

Crawler and agent traffic does not run browser analytics, so machine-readable docs usage needs lightweight server-side instrumentation.

## Key design considerations

- Keep the event shape minimal and avoid request body parsing
- Separate official crawler UAs from managed developer-tool client UAs
- Track unknown clients on agent surfaces to catch new tools without maintaining an exhaustive bot list