### PR TITLE
Redirect docs domain to developers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,28 @@
       "has": [
         {
           "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
           "value": "faucet.tempo.xyz"
         }
       ],


### PR DESCRIPTION
## Summary
- Redirect docs.tempo.xyz root to tempo.xyz/developers
- Redirect docs.tempo.xyz paths to tempo.xyz/developers/:path
- Scope redirects to the docs.tempo.xyz host so preview and other vanity hosts are unaffected

## Test
- pnpm check:types

Prompted by: @alexrisch