### PR TITLE
Guard docs domain redirects from proxy loop

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,42 @@
       "has": [
         {
           "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "missing": [
+        {
+          "type": "header",
+          "key": "x-forwarded-host",
+          "value": "tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "missing": [
+        {
+          "type": "header",
+          "key": "x-forwarded-host",
+          "value": "tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
           "value": "faucet.tempo.xyz"
         }
       ],


### PR DESCRIPTION
## Summary
- Restore docs.tempo.xyz -> tempo.xyz/developers redirects
- Add a missing x-forwarded-host guard so redirects do not fire for tempo.xyz/developers proxy requests

## Validation
- pnpm check:types
- jq . vercel.json
- pnpm build still blocked by existing Vocs OpenAPI fetch timeout

Prompted by: @alexrisch