### PR TITLE
Redirect direct docs domain in browser

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -4,6 +4,11 @@ const normalizeProxiedRscFetch = `
 (() => {
   if (window.__tempoNormalizeProxiedRscFetch) return;
   window.__tempoNormalizeProxiedRscFetch = true;
+  if (window.location.hostname === 'docs.tempo.xyz') {
+    const suffix = window.location.pathname === '/' ? '' : window.location.pathname;
+    window.location.replace('https://tempo.xyz/developers' + suffix + window.location.search + window.location.hash);
+    return;
+  }
   const originalFetch = window.fetch.bind(window);
   window.fetch = (input, init) => {
     const url = typeof input === 'string'


### PR DESCRIPTION
## Summary
- Redirect browser visits on `docs.tempo.xyz` to the matching `tempo.xyz/developers` path
- Keep proxied docs under `tempo.xyz/developers` out of the redirect path by keying off `window.location.hostname`

## Validation
- `pnpm check:types`

Prompted by: @alexrisch