### PR TITLE
Update docs base URL to tempo.xyz/developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 This repository contains documentation for the Tempo blockchain, including the Protocol Specifications, Litepaper, and Getting Started guides.
 
-[docs.tempo.xyz](https://docs.tempo.xyz)
+[tempo.xyz/developers](https://tempo.xyz/developers)
 
 ## Usage
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,8 +11,8 @@ Skill for navigating Tempo documentation and source code.
 
 Before using MCP tools, try fetching context directly:
 
-- **llms.txt** – Concise index of all pages: `https://docs.tempo.xyz/llms.txt`
-- **Markdown pages** – Append `.md` to any page URL (e.g. `https://docs.tempo.xyz/quickstart/integrate-tempo.md`)
+- **llms.txt** – Concise index of all pages: `https://tempo.xyz/developers/llms.txt`
+- **Markdown pages** – Append `.md` to any page URL (e.g. `https://tempo.xyz/developers/quickstart/integrate-tempo.md`)
 
 Use `read_web_page` to fetch these when you need broad context or a quick answer.
 
@@ -31,7 +31,7 @@ Use these tools for structured exploration:
 | `mcp__tempo_mcp__get_file_tree` | Get recursive file tree |
 | `mcp__tempo_mcp__search_source` | Search source code |
 
-If a user reports stale, missing, or confusing Tempo docs while using MCP context, send sanitized feedback to `https://docs.tempo.xyz/api/feedback` with `source: "mcp"`, `message`, and any relevant `toolName` or `relatedResource`.
+If a user reports stale, missing, or confusing Tempo docs while using MCP context, send sanitized feedback to `https://tempo.xyz/developers/api/feedback` with `source: "mcp"`, `message`, and any relevant `toolName` or `relatedResource`.
 
 ## Available Sources
 
@@ -44,7 +44,7 @@ If a user reports stale, missing, or confusing Tempo docs while using MCP contex
 
 ## Workflow
 
-1. **Quick lookup**: Use `read_web_page` on `https://docs.tempo.xyz/llms.txt` for an overview, or fetch a specific page as Markdown
+1. **Quick lookup**: Use `read_web_page` on `https://tempo.xyz/developers/llms.txt` for an overview, or fetch a specific page as Markdown
 2. **Search docs**: Use `mcp__tempo_mcp__search_docs` to find relevant pages
 3. **Read pages**: Use `mcp__tempo_mcp__read_page` with the page path
 4. **Explore source**: Use `mcp__tempo_mcp__search_source` or `mcp__tempo_mcp__get_file_tree` to find implementations

--- a/ai/README.md
+++ b/ai/README.md
@@ -22,7 +22,7 @@ The current server exposes docs search, page discovery, and cleaned page reads. 
 Feedback from MCP clients should be sent to the shared docs ingress:
 
 ```txt
-POST https://docs.tempo.xyz/api/feedback
+POST https://tempo.xyz/developers/api/feedback
 ```
 
 Use `source: "mcp"` plus a short `message`, and include `toolName`, `relatedResource`, or `client` when available.

--- a/ai/plugins/tempo/skills/tempo/SKILL.md
+++ b/ai/plugins/tempo/skills/tempo/SKILL.md
@@ -14,7 +14,7 @@ description: >
 
 Use this skill to build applications on Tempo. Prefer Tempo docs from the
 hosted MCP server first; if MCP is unavailable, read the relevant page from
-`https://docs.tempo.xyz` or append `.md` to the docs URL. Do not guess current
+`https://tempo.xyz/developers` or append `.md` to the docs URL. Do not guess current
 RPC URLs, contract addresses, chain IDs, package APIs, or protocol details;
 verify them from docs before writing code.
 
@@ -57,11 +57,11 @@ code. Use the docs page’s linked examples when available.
 
 ## Useful Docs
 
-- Getting started: `https://docs.tempo.xyz/docs/quickstart/integrate-tempo`
-- Connection details: `https://docs.tempo.xyz/docs/quickstart/connection-details`
-- Wallet: `https://docs.tempo.xyz/docs/wallet`
-- Payments: `https://docs.tempo.xyz/docs/guide/payments`
-- Machine payments: `https://docs.tempo.xyz/docs/guide/machine-payments`
-- Hosted services: `https://docs.tempo.xyz/docs/hosted-services`
-- SDKs: `https://docs.tempo.xyz/docs/sdk`
-- Protocol specs: `https://docs.tempo.xyz/docs/protocol`
+- Getting started: `https://tempo.xyz/developers/docs/quickstart/integrate-tempo`
+- Connection details: `https://tempo.xyz/developers/docs/quickstart/connection-details`
+- Wallet: `https://tempo.xyz/developers/docs/wallet`
+- Payments: `https://tempo.xyz/developers/docs/guide/payments`
+- Machine payments: `https://tempo.xyz/developers/docs/guide/machine-payments`
+- Hosted services: `https://tempo.xyz/developers/docs/hosted-services`
+- SDKs: `https://tempo.xyz/developers/docs/sdk`
+- Protocol specs: `https://tempo.xyz/developers/docs/protocol`

--- a/lychee.toml
+++ b/lychee.toml
@@ -9,7 +9,7 @@ timeout = 20
 retry_wait_time = 2
 
 # Some hosts (Twitter, LinkedIn, Cloudflare-protected sites) reject the default UA.
-user_agent = "Mozilla/5.0 (compatible; tempo-docs-link-checker/1.0; +https://docs.tempo.xyz)"
+user_agent = "Mozilla/5.0 (compatible; tempo-docs-link-checker/1.0; +https://tempo.xyz/developers)"
 
 # Auth-walled or rate-limited statuses are still "reachable".
 accept = ["200..=299", "401", "403", "429"]

--- a/src/components/TempoMcpExplorer.tsx
+++ b/src/components/TempoMcpExplorer.tsx
@@ -377,7 +377,7 @@ export function TempoMcpExplorer() {
               <input
                 value={state.url}
                 onChange={(event) => updateState('url', event.target.value)}
-                placeholder="https://docs.tempo.xyz/..."
+                placeholder="https://tempo.xyz/developers/..."
                 className="w-full rounded-md border border-gray6 bg-gray1 px-3 py-2 font-mono text-gray12"
               />
             </label>

--- a/src/lib/faucet-api.test.ts
+++ b/src/lib/faucet-api.test.ts
@@ -37,7 +37,7 @@ describe('faucet API', () => {
 
   it('rejects invalid JSON', async () => {
     const response = await POST(
-      new Request('https://docs.tempo.xyz/api/faucet', {
+      new Request('https://tempo.xyz/developers/api/faucet', {
         method: 'POST',
         body: '{',
       }),
@@ -70,10 +70,10 @@ describe('faucet API', () => {
   })
 
   it('allows docs and Vercel origins for CORS', async () => {
-    const docsResponse = await OPTIONS(requestWithOrigin('https://docs.tempo.xyz'))
+    const docsResponse = await OPTIONS(requestWithOrigin('https://tempo.xyz'))
     const vercelResponse = await OPTIONS(requestWithOrigin('https://docs-git-branch.vercel.app'))
 
-    expect(docsResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://docs.tempo.xyz')
+    expect(docsResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://tempo.xyz')
     expect(vercelResponse.headers.get('Access-Control-Allow-Origin')).toBe(
       'https://docs-git-branch.vercel.app',
     )
@@ -87,18 +87,18 @@ describe('faucet API', () => {
 })
 
 function jsonRequest(body: unknown) {
-  return new Request('https://docs.tempo.xyz/api/faucet', {
+  return new Request('https://tempo.xyz/developers/api/faucet', {
     method: 'POST',
     body: JSON.stringify(body),
     headers: {
       'content-type': 'application/json',
-      origin: 'https://docs.tempo.xyz',
+      origin: 'https://tempo.xyz',
     },
   })
 }
 
 function requestWithOrigin(origin: string) {
-  return new Request('https://docs.tempo.xyz/api/faucet', {
+  return new Request('https://tempo.xyz/developers/api/faucet', {
     method: 'OPTIONS',
     headers: { origin },
   })

--- a/src/lib/feedback.test.ts
+++ b/src/lib/feedback.test.ts
@@ -25,7 +25,7 @@ describe('normalizeFeedback', () => {
       helpful: false,
       category: ' Missing information ',
       message: ' Needs  more detail about token setup. ',
-      pageUrl: 'https://docs.tempo.xyz/docs/guide/payments#send',
+      pageUrl: 'https://tempo.xyz/developers/docs/guide/payments#send',
       timestamp: '2026-06-19T12:00:00.000Z',
     })
 
@@ -34,7 +34,7 @@ describe('normalizeFeedback', () => {
       sentiment: 'negative',
       category: 'Missing information',
       message: 'Needs more detail about token setup.',
-      pageUrl: 'https://docs.tempo.xyz/docs/guide/payments',
+      pageUrl: 'https://tempo.xyz/developers/docs/guide/payments',
       path: '/guide/payments',
       timestamp: '2026-06-19T12:00:00.000Z',
     })
@@ -64,8 +64,8 @@ describe('normalizeFeedback', () => {
   })
 
   it('requires docs helpful value', () => {
-    expect(() => normalizeFeedback({ source: 'docs', pageUrl: 'https://docs.tempo.xyz' })).toThrow(
-      FeedbackError,
-    )
+    expect(() =>
+      normalizeFeedback({ source: 'docs', pageUrl: 'https://tempo.xyz/developers' }),
+    ).toThrow(FeedbackError)
   })
 })

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -144,7 +144,8 @@ function cleanText(value: string | undefined, maxLength: number) {
 function cleanPath(value: string | undefined) {
   const cleaned = cleanText(value, 512)
   if (!cleaned) return undefined
-  return cleaned.startsWith('/') ? cleaned : `/${cleaned}`
+  const path = cleaned.startsWith('/') ? cleaned : `/${cleaned}`
+  return path.replace(/^\/developers(?=\/|$)/, '').replace(/^\/docs(?=\/|$)/, '') || '/'
 }
 
 function cleanUrl(value: string | undefined) {
@@ -213,7 +214,10 @@ function compact<T>(values: Array<T | false | undefined>): T[] {
 }
 
 function urlFromPath(path: string | undefined) {
-  if (!path) return 'https://docs.tempo.xyz/'
+  if (!path) return 'https://tempo.xyz/developers/'
   if (URL.canParse(path)) return path
-  return new URL(path.startsWith('/') ? path : `/${path}`, 'https://docs.tempo.xyz').toString()
+  return new URL(
+    path.startsWith('/') ? path : `/${path}`,
+    'https://tempo.xyz/developers',
+  ).toString()
 }

--- a/src/marketing/seo.ts
+++ b/src/marketing/seo.ts
@@ -23,7 +23,7 @@ export function resolveBaseUrl(): string {
   if (URL.canParse(process.env.VITE_BASE_URL ?? '')) {
     return (process.env.VITE_BASE_URL as string).replace(/\/$/, '')
   }
-  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
+  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz/developers'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   if (productionUrl) return `https://${productionUrl}`
   return ''

--- a/src/pages/_api/api/faucet.ts
+++ b/src/pages/_api/api/faucet.ts
@@ -54,7 +54,7 @@ async function fund(address: `0x${string}`, headers: Record<string, string>): Pr
 }
 
 function cors(origin: string | null): Record<string, string> {
-  const allowedOrigins = ['https://docs.tempo.xyz']
+  const allowedOrigins = ['https://tempo.xyz']
 
   if (origin?.includes('vercel.app')) allowedOrigins.push(origin)
   if (process.env.NODE_ENV === 'development') allowedOrigins.push('http://localhost:5173')

--- a/src/pages/_api/api/index-supply.ts
+++ b/src/pages/_api/api/index-supply.ts
@@ -120,7 +120,7 @@ export async function OPTIONS(request: Request): Promise<Response> {
 }
 
 function cors(origin: string | null): Record<string, string> {
-  const allowedOrigins = ['https://docs.tempo.xyz', 'https://mainnet.docs.tempo.xyz']
+  const allowedOrigins = ['https://tempo.xyz', 'https://mainnet.docs.tempo.xyz']
 
   if (origin?.includes('vercel.app')) allowedOrigins.push(origin)
   if (process.env.NODE_ENV === 'development') allowedOrigins.push('http://localhost:5173')

--- a/src/pages/docs/api/versioning-policy.mdx
+++ b/src/pages/docs/api/versioning-policy.mdx
@@ -54,7 +54,7 @@ We will not deprecate a stable endpoint or version until a replacement is availa
 ```http
 Deprecation: true
 Sunset: Wed, 15 Jan 2027 00:00:00 GMT
-Link: <https://docs.tempo.xyz/docs/api/versioning-policy>; rel="deprecation"
+Link: <https://tempo.xyz/developers/docs/api/versioning-policy>; rel="deprecation"
 ```
 
 ## Communicating Changes

--- a/src/pages/docs/guide/using-tempo-with-ai.mdx
+++ b/src/pages/docs/guide/using-tempo-with-ai.mdx
@@ -130,7 +130,7 @@ The MCP endpoint exposes these tools to connected agents:
 
 ### MCP feedback
 
-MCP clients can also post feedback directly to `https://docs.tempo.xyz/api/feedback`:
+MCP clients can also post feedback directly to `https://tempo.xyz/developers/api/feedback`:
 
 ```json
 {
@@ -180,12 +180,12 @@ Once installed, the agent uses it automatically when relevant tasks are detected
 Every page on this site is available as plain Markdown — append `.md` to any URL:
 
 ```
-https://docs.tempo.xyz/docs/quickstart/integrate-tempo.md
+https://tempo.xyz/developers/docs/quickstart/integrate-tempo.md
 ```
 
 For LLM consumption, two [`llms.txt`](https://llmstxt.org/) files are served at the root:
 
 | URL | Contents |
 | --- | --- |
-| [`/llms.txt`](https://docs.tempo.xyz/llms.txt) | Concise index of all pages with titles and descriptions |
-| [`/llms-full.txt`](https://docs.tempo.xyz/llms-full.txt) | Complete documentation in a single file |
+| [`/llms.txt`](https://tempo.xyz/developers/llms.txt) | Concise index of all pages with titles and descriptions |
+| [`/llms-full.txt`](https://tempo.xyz/developers/llms-full.txt) | Complete documentation in a single file |

--- a/src/pages/docs/protocol/tip20/spec.mdx
+++ b/src/pages/docs/protocol/tip20/spec.mdx
@@ -561,7 +561,7 @@ interface ITIP20Factory {
     /// @notice Creates and deploys a new TIP-20 token
     /// @param name The token's ERC-20 name
     /// @param symbol The token's ERC-20 symbol
-    /// @param currency The token's currency identifier (ISO 4217 code, when available). Immutable after creation. See Currency Declaration (https://docs.tempo.xyz/docs/protocol/tip20/overview#currency-declaration).
+    /// @param currency The token's currency identifier (ISO 4217 code, when available). Immutable after creation. See Currency Declaration (https://tempo.xyz/developers/docs/protocol/tip20/overview#currency-declaration).
     /// @param quoteToken The TIP-20 quote token used for exchange pricing
     /// @param admin The address to receive DEFAULT_ADMIN_ROLE on the new token
     /// @param salt A unique salt for deterministic address derivation

--- a/src/pages/docs/protocol/tips/tip-1011.mdx
+++ b/src/pages/docs/protocol/tips/tip-1011.mdx
@@ -621,8 +621,8 @@ Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 
 ## References
 
-- [AccountKeychain docs](https://docs.tempo.xyz/docs/protocol/transactions/AccountKeychain)
-- [Tempo Transactions](https://docs.tempo.xyz/docs/guide/tempo-transaction)
+- [AccountKeychain docs](https://tempo.xyz/developers/docs/protocol/transactions/AccountKeychain)
+- [Tempo Transactions](https://tempo.xyz/developers/docs/guide/tempo-transaction)
 - [IAccountKeychain.sol](https://github.com/tempoxyz/tempo/blob/main/tips/verify/src/interfaces/IAccountKeychain.sol)
 - [GitHub Issue #1865](https://github.com/tempoxyz/tempo/issues/1865) - Periodic spending limits
 - [GitHub Issue #1491](https://github.com/tempoxyz/tempo/issues/1491) - Destination address scoping

--- a/src/pages/docs/protocol/tips/tip-1020.mdx
+++ b/src/pages/docs/protocol/tips/tip-1020.mdx
@@ -54,7 +54,7 @@ interface ISignatureVerifier {
 
 ### Signature Encoding
 
-Signatures MUST be encoded using the same format as [Tempo Transaction signatures](https://docs.tempo.xyz/docs/protocol/transactions/spec-tempo-transaction#signature-types):
+Signatures MUST be encoded using the same format as [Tempo Transaction signatures](https://tempo.xyz/developers/docs/protocol/transactions/spec-tempo-transaction#signature-types):
 
 | Type | Format | Length |
 |------|--------|--------|
@@ -64,7 +64,7 @@ Signatures MUST be encoded using the same format as [Tempo Transaction signature
 
 ### Verification Logic
 
-The precompile MUST use the same verification logic as Tempo transaction signature validation. See the [Tempo Transaction Signature Validation spec](https://docs.tempo.xyz/docs/protocol/transactions/spec-tempo-transaction#signature-validation) for details.
+The precompile MUST use the same verification logic as Tempo transaction signature validation. See the [Tempo Transaction Signature Validation spec](https://tempo.xyz/developers/docs/protocol/transactions/spec-tempo-transaction#signature-validation) for details.
 
 #### Keychain Signature Rejection
 
@@ -86,7 +86,7 @@ The precompile MUST enforce strict size limits on the `signature` argument **bef
 
 The precompile MUST charge gas and verify sufficient gas is available **before** performing any cryptographic verification. The precompile MUST revert with out-of-gas if the call has insufficient gas for the signature type.
 
-All calls pay the standard Tempo precompile calldata cost of 6 gas per 32-byte word (rounded up) on the full ABI-encoded input, consistent with all other Tempo precompiles. The verification gas per signature type is in-line with the [Tempo Transaction Signature Gas Schedule](https://docs.tempo.xyz/docs/protocol/transactions/spec-tempo-transaction#signature-verification-gas-schedule):
+All calls pay the standard Tempo precompile calldata cost of 6 gas per 32-byte word (rounded up) on the full ABI-encoded input, consistent with all other Tempo precompiles. The verification gas per signature type is in-line with the [Tempo Transaction Signature Gas Schedule](https://tempo.xyz/developers/docs/protocol/transactions/spec-tempo-transaction#signature-verification-gas-schedule):
 
 | Type | Verification Gas |
 |------|-----------------|

--- a/src/pages/docs/quickstart/faucet.mdx
+++ b/src/pages/docs/quickstart/faucet.mdx
@@ -54,7 +54,7 @@ Request tokens programmatically via the faucet API.
 <div className="h-4"/>
 
 ```bash
-curl -X POST https://docs.tempo.xyz/api/faucet \
+curl -X POST https://tempo.xyz/developers/api/faucet \
   -H "Content-Type: application/json" \
   -d '{"address": "<YOUR_ADDRESS>"}'
 ```

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
           "value": "faucet.tempo.xyz"
         }
       ],
-      "destination": "https://docs.tempo.xyz/docs/quickstart/faucet",
+      "destination": "https://tempo.xyz/developers/docs/quickstart/faucet",
       "permanent": false
     },
     {
@@ -19,7 +19,7 @@
           "value": "faucet.tempo.xyz"
         }
       ],
-      "destination": "https://docs.tempo.xyz/docs/quickstart/faucet",
+      "destination": "https://tempo.xyz/developers/docs/quickstart/faucet",
       "permanent": false
     },
     {
@@ -30,7 +30,7 @@
           "value": "bridge.tempo.xyz"
         }
       ],
-      "destination": "https://docs.tempo.xyz/docs/guide/getting-funds",
+      "destination": "https://tempo.xyz/developers/docs/guide/getting-funds",
       "permanent": false
     },
     {
@@ -41,7 +41,7 @@
           "value": "bridge.tempo.xyz"
         }
       ],
-      "destination": "https://docs.tempo.xyz/docs/guide/getting-funds",
+      "destination": "https://tempo.xyz/developers/docs/guide/getting-funds",
       "permanent": false
     },
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -197,7 +197,7 @@ function marketingPages(): Plugin {
 }
 
 const llmsFeedbackNotice = [
-  '> Feedback: If these docs are stale, missing, or confusing, post sanitized feedback to `https://docs.tempo.xyz/api/feedback` with `source: "mcp"`, a short `message`, and any relevant `toolName`, `relatedResource`, or `client`.',
+  '> Feedback: If these docs are stale, missing, or confusing, post sanitized feedback to `https://tempo.xyz/developers/api/feedback` with `source: "mcp"`, a short `message`, and any relevant `toolName`, `relatedResource`, or `client`.',
   '',
 ].join('\n')
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -6,7 +6,7 @@ import { createFeedbackAdapter } from './src/lib/feedback-adapter'
 const baseUrl = (() => {
   if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') return ''
   if (URL.canParse(process.env.VITE_BASE_URL)) return process.env.VITE_BASE_URL.replace(/\/$/, '')
-  if (process.env.VERCEL_ENV === 'production') return 'https://docs.tempo.xyz'
+  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz/developers'
   const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
   if (productionUrl) return `https://${productionUrl}`
   return ''


### PR DESCRIPTION
## Summary
- switch production docs base URL and SEO mirror to https://tempo.xyz/developers
- update absolute docs links, redirects, MCP/AI references, and feedback/faucet URLs
- update CORS tests/allowlists to use the tempo.xyz origin for the new /developers path

## Validation
- pnpm install --frozen-lockfile
- pnpm run check:types
- pnpm exec biome check --write --unsafe <changed files>
- VITE_USE_HTTP=true pnpm exec vitest run src/lib/feedback.test.ts src/lib/faucet-api.test.ts (blocked: Vocs OpenAPI plugin failed to fetch remote spec during startup)

Prompted by: @alexrisch