### PR TITLE
Fix create stablecoin marketing links

### DIFF
--- a/src/marketing/app/_components/TokensShowcase.tsx
+++ b/src/marketing/app/_components/TokensShowcase.tsx
@@ -310,7 +310,7 @@ export default function TokensShowcase() {
             <Button href="/docs/protocol/tip20/overview" variant="primary">
               Explore TIP-20
             </Button>
-            <Button href="/docs/guide/issuance/create-a-stablecoin" arrow>
+            <Button href="/developers/docs/guide/issuance/create-a-stablecoin" arrow>
               Create a stablecoin
             </Button>
           </div>

--- a/src/marketing/app/_components/features.tsx
+++ b/src/marketing/app/_components/features.tsx
@@ -272,7 +272,7 @@ export const features: Feature[] = [
     heroActions: [
       {
         label: 'Create a stablecoin',
-        href: '/docs/guide/issuance/create-a-stablecoin',
+        href: '/developers/docs/guide/issuance/create-a-stablecoin',
         primary: true,
       },
       {

--- a/src/marketing/app/features/_components/TokensSections.tsx
+++ b/src/marketing/app/features/_components/TokensSections.tsx
@@ -326,7 +326,7 @@ const STORIES: Story[] = [
     spec: feeTokenSpec,
     ctas: [
       { label: 'Explore TIP-20', href: '/docs/protocol/tip20/overview', primary: true },
-      { label: 'Issue a token', href: '/docs/guide/issuance/create-a-stablecoin' },
+      { label: 'Issue a token', href: '/developers/docs/guide/issuance/create-a-stablecoin' },
     ],
     panelTitle: 'fee-token.ts',
     variants: feeTokenCodeVariants,


### PR DESCRIPTION
## Summary
- Update marketing CTAs for the Create a stablecoin guide to the rendered developers docs path.
- Leave docs-internal Vocs links unchanged.

## Test
- pnpm check

Prompted by: vijith