### PR TITLE
Update docs landing links

### DIFF
--- a/src/marketing/app/_components/Footer.tsx
+++ b/src/marketing/app/_components/Footer.tsx
@@ -20,6 +20,7 @@ const footerLinkClassName =
 const CONTACT_URL = 'https://tempo.xyz/contact'
 const GITHUB_URL = 'https://github.com/tempoxyz'
 const X_URL = 'https://twitter.com/tempo'
+const TEMPO_DOCS_URL = 'https://docs.tempo.xyz/docs'
 
 function FooterLinkItem({ link }: { link: FooterLink }) {
   return link.href.startsWith('/') ? (
@@ -44,7 +45,7 @@ const columns: FooterColumn[] = [
   {
     header: 'Documentation',
     links: [
-      { label: 'Docs', href: '/docs' },
+      { label: 'Docs', href: TEMPO_DOCS_URL },
       { label: 'Payments guide', href: '/docs/guide/payments' },
       { label: 'Token issuance', href: '/docs/guide/issuance' },
     ],

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -25,6 +25,8 @@ import {
 import SearchDialog from './SearchDialog'
 import TempoLogo from './TempoLogo'
 
+const TEMPO_DOCS_URL = 'https://docs.tempo.xyz/docs'
+
 const protocolMenu: MegaMenuData = {
   variant: 'vertical',
   columns: [
@@ -61,7 +63,7 @@ const developersMenu: MegaMenuData = {
         {
           label: 'Docs',
           desc: 'Guides, references & quickstart',
-          href: '/docs',
+          href: TEMPO_DOCS_URL,
           icon: <DocsIcon />,
         },
       ],
@@ -171,7 +173,7 @@ const menu: MenuItem[] = [
   { label: 'Resources', href: '/docs', mega: developersMenu },
   { label: 'Performance', href: '/performance' },
   { label: 'Blog', href: '/blog' },
-  { label: 'Docs', href: '/docs' },
+  { label: 'Docs', href: TEMPO_DOCS_URL },
 ]
 
 // Flatten a mega menu into its leaf links for the mobile accordion.


### PR DESCRIPTION
## Summary
- Update the docs landing page Resources menu Docs link to `https://docs.tempo.xyz/docs`.
- Update the docs landing page navbar and footer Docs links to `https://docs.tempo.xyz/docs`.

## Verification
- `pnpm exec biome check src/marketing/app/_components/Header.tsx src/marketing/app/_components/Footer.tsx`
- `pnpm check:types`
- `pnpm test -- src/lib/feedback.test.ts src/lib/faucet-api.test.ts src/components/lib/wallets.test.ts` could not start because `vite-plugin-mkcert` timed out fetching from GitHub.
- `pnpm build` could not complete because Vocs OpenAPI/LLMS generation timed out on an external fetch; marketing-only build depends on full build output.

Prompted by: @juandolealt