### PR TITLE
Fix developers docs RSC route rewrites

### DIFF
--- a/src/lib/vercel-routing.test.ts
+++ b/src/lib/vercel-routing.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+type VercelConfig = {
+  rewrites?: Array<{ source: string; destination: string }>
+}
+
+describe('Vercel routing', () => {
+  it('normalizes doubled /developers RSC routes at the edge', () => {
+    const config = JSON.parse(fs.readFileSync('vercel.json', 'utf8')) as VercelConfig
+    const rewrites = config.rewrites ?? []
+
+    expect(rewrites.slice(0, 4)).toEqual([
+      {
+        source: '/developers/RSC/R/developers.txt',
+        destination: '/developers/RSC/R/_root.txt',
+      },
+      {
+        source: '/developers/RSC/R/developers/:path(.*)',
+        destination: '/developers/RSC/R/:path',
+      },
+      {
+        source: '/RSC/R/developers.txt',
+        destination: '/RSC/R/_root.txt',
+      },
+      {
+        source: '/RSC/R/developers/:path(.*)',
+        destination: '/RSC/R/:path',
+      },
+    ])
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -207,6 +207,22 @@
   ],
   "rewrites": [
     {
+      "source": "/developers/RSC/R/developers.txt",
+      "destination": "/developers/RSC/R/_root.txt"
+    },
+    {
+      "source": "/developers/RSC/R/developers/:path(.*)",
+      "destination": "/developers/RSC/R/:path"
+    },
+    {
+      "source": "/RSC/R/developers.txt",
+      "destination": "/RSC/R/_root.txt"
+    },
+    {
+      "source": "/RSC/R/developers/:path(.*)",
+      "destination": "/RSC/R/:path"
+    },
+    {
       "source": "/ingest/static/:path(.*)",
       "destination": "https://us-assets.i.posthog.com/static/:path"
     },


### PR DESCRIPTION
## Summary
- add Vercel rewrites for doubled `/developers` RSC artifact URLs before they reach the app
- cover both proxied `/developers/RSC/R/...` and direct `/RSC/R/...` shapes
- add a regression test that keeps those rewrites first

Prompted by: @alexrisch

## Testing
- `node -e "const fs=require('fs'); const c=JSON.parse(fs.readFileSync('vercel.json','utf8')); console.log(c.rewrites.slice(0,4));"`
- `pnpm exec biome check vercel.json src/lib/vercel-routing.test.ts`

## Notes
- `pnpm test -- src/lib/vercel-routing.test.ts` is blocked in this sandbox because Vocs fetches the remote OpenAPI spec at Vitest startup and `https://api.tempo.xyz/openapi.json` times out here. `CI=true` avoids mkcert, but still hits the Vocs OpenAPI fetch.