### PR TITLE
Use canonical developers docs URL

### DIFF
--- a/src/marketing/app/_components/Footer.tsx
+++ b/src/marketing/app/_components/Footer.tsx
@@ -20,7 +20,7 @@ const footerLinkClassName =
 const CONTACT_URL = 'https://tempo.xyz/contact'
 const GITHUB_URL = 'https://github.com/tempoxyz'
 const X_URL = 'https://twitter.com/tempo'
-const TEMPO_DOCS_URL = 'https://docs.tempo.xyz/docs'
+const TEMPO_DOCS_URL = 'https://tempo.xyz/developers/docs/'
 
 function FooterLinkItem({ link }: { link: FooterLink }) {
   return link.href.startsWith('/') ? (

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -25,7 +25,7 @@ import {
 import SearchDialog from './SearchDialog'
 import TempoLogo from './TempoLogo'
 
-const TEMPO_DOCS_URL = 'https://docs.tempo.xyz/docs'
+const TEMPO_DOCS_URL = 'https://tempo.xyz/developers/docs/'
 
 const protocolMenu: MegaMenuData = {
   variant: 'vertical',


### PR DESCRIPTION
## Summary
- replace hard-coded `https://docs.tempo.xyz/docs` marketing nav links with `https://tempo.xyz/developers/docs/`
- leave the `docs.tempo.xyz/docs` test fixture alone because it models origin-route normalization

Prompted by: @alexrisch

## Testing
- `pnpm exec biome check src/marketing/app/_components/Header.tsx src/marketing/app/_components/Footer.tsx`
- `pnpm check:types`