### PR TITLE
Redirect docs domain to developers

### DIFF
--- a/src/lib/docs-routing.test.ts
+++ b/src/lib/docs-routing.test.ts
@@ -14,12 +14,40 @@ const vercelConfig = JSON.parse(
 ) as { redirects: Redirect[] }
 
 const redirects = vercelConfig.redirects.filter((redirect) => !redirect.has)
+const hostRedirects = vercelConfig.redirects.filter((redirect) =>
+  Array.isArray(redirect.has)
+    ? redirect.has.some(
+        (condition) =>
+          typeof condition === 'object' &&
+          condition !== null &&
+          'type' in condition &&
+          'value' in condition &&
+          condition.type === 'host' &&
+          condition.value === 'docs.tempo.xyz',
+      )
+    : false,
+)
 
 function findRedirect(source: string) {
   return redirects.find((redirect) => redirect.source === source)
 }
 
 describe('docs routing redirects', () => {
+  it.each([
+    ['/', 'https://tempo.xyz/developers'],
+    ['/developers', 'https://tempo.xyz/developers'],
+    ['/developers/:path*', 'https://tempo.xyz/developers/:path*'],
+    ['/:path*', 'https://tempo.xyz/developers/:path*'],
+  ])('redirects docs.tempo.xyz%s to %s', (source, destination) => {
+    expect(hostRedirects).toContainEqual(
+      expect.objectContaining({
+        source,
+        destination,
+        permanent: true,
+      }),
+    )
+  })
+
   it.each([
     ['/tools', '/docs/tools'],
     ['/tools/:path*', '/docs/tools/:path*'],

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,50 @@
       "has": [
         {
           "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers",
+      "permanent": true
+    },
+    {
+      "source": "/developers",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers",
+      "permanent": true
+    },
+    {
+      "source": "/developers/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
           "value": "faucet.tempo.xyz"
         }
       ],


### PR DESCRIPTION
## Summary
- add host-scoped redirects for `docs.tempo.xyz` to canonical `https://tempo.xyz/developers` URLs
- preserve already-prefixed `/developers/...` paths without double-prefixing
- add regression coverage for the host-specific redirects

Prompted by: @alexrisch

## Testing
- `pnpm exec biome check vercel.json src/lib/docs-routing.test.ts`
- `pnpm check:types`

## Not run
- `CI=true pnpm test -- src/lib/docs-routing.test.ts` still fails during Vocs startup because `vocs:openapi` fetches the remote OpenAPI spec and the fetch fails in this sandbox.

## Deploy order
Merge/deploy the `tempo-web` proxy-origin PR first and set `DOCS_PROXY_ORIGIN` to a non-redirecting docs deployment origin, then deploy this docs-domain redirect.