### PR TITLE
Redirect docs.tempo.xyz to developers

### DIFF
--- a/src/lib/docs-routing.test.ts
+++ b/src/lib/docs-routing.test.ts
@@ -14,12 +14,43 @@ const vercelConfig = JSON.parse(
 ) as { redirects: Redirect[] }
 
 const redirects = vercelConfig.redirects.filter((redirect) => !redirect.has)
+const hostRedirects = vercelConfig.redirects.filter((redirect) => redirect.has)
 
 function findRedirect(source: string) {
   return redirects.find((redirect) => redirect.source === source)
 }
 
+function findHostRedirect(source: string, host: string) {
+  return hostRedirects.find(
+    (redirect) =>
+      redirect.source === source &&
+      Array.isArray(redirect.has) &&
+      redirect.has.some(
+        (condition) =>
+          typeof condition === 'object' &&
+          condition !== null &&
+          'type' in condition &&
+          'value' in condition &&
+          condition.type === 'host' &&
+          condition.value === host,
+      ),
+  )
+}
+
 describe('docs routing redirects', () => {
+  it.each([
+    ['/', 'https://tempo.xyz/developers'],
+    ['/developers', 'https://tempo.xyz/developers'],
+    ['/developers/:path*', 'https://tempo.xyz/developers/:path*'],
+    ['/:path*', 'https://tempo.xyz/developers/:path*'],
+  ])('redirects docs.tempo.xyz%s to %s', (source, destination) => {
+    expect(findHostRedirect(source, 'docs.tempo.xyz')).toMatchObject({
+      source,
+      destination,
+      permanent: true,
+    })
+  })
+
   it.each([
     ['/tools', '/docs/tools'],
     ['/tools/:path*', '/docs/tools/:path*'],

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,50 @@
       "has": [
         {
           "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers",
+      "permanent": true
+    },
+    {
+      "source": "/developers",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers",
+      "permanent": true
+    },
+    {
+      "source": "/developers/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
           "value": "faucet.tempo.xyz"
         }
       ],


### PR DESCRIPTION
## Summary
- add host-scoped `docs.tempo.xyz` redirects to canonical `https://tempo.xyz/developers` URLs
- preserve already-prefixed `/developers/...` paths without adding `/developers` twice
- cover the host-scoped redirect table in the routing test

Prompted by: @alexrisch

## Testing
- `pnpm exec biome check vercel.json src/lib/docs-routing.test.ts`
- `pnpm check:types`

## Not run
- `pnpm exec vitest run src/lib/docs-routing.test.ts` fails before test execution because `vite-plugin-mkcert` times out fetching GitHub during Vite startup in this sandbox.