### PR TITLE
Fix docs faucet CORS origin

### DIFF
--- a/src/lib/faucet-api.test.ts
+++ b/src/lib/faucet-api.test.ts
@@ -70,10 +70,12 @@ describe('faucet API', () => {
   })
 
   it('allows docs and Vercel origins for CORS', async () => {
-    const docsResponse = await OPTIONS(requestWithOrigin('https://tempo.xyz'))
+    const tempoResponse = await OPTIONS(requestWithOrigin('https://tempo.xyz'))
+    const docsResponse = await OPTIONS(requestWithOrigin('https://docs.tempo.xyz'))
     const vercelResponse = await OPTIONS(requestWithOrigin('https://docs-git-branch.vercel.app'))
 
-    expect(docsResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://tempo.xyz')
+    expect(tempoResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://tempo.xyz')
+    expect(docsResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://docs.tempo.xyz')
     expect(vercelResponse.headers.get('Access-Control-Allow-Origin')).toBe(
       'https://docs-git-branch.vercel.app',
     )
@@ -81,8 +83,10 @@ describe('faucet API', () => {
 
   it('does not allow arbitrary CORS origins', async () => {
     const response = await OPTIONS(requestWithOrigin('https://example.com'))
+    const prefixResponse = await OPTIONS(requestWithOrigin('https://tempo.xyz.example.com'))
 
     expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    expect(prefixResponse.headers.get('Access-Control-Allow-Origin')).toBeNull()
   })
 })
 

--- a/src/pages/_api/api/faucet.ts
+++ b/src/pages/_api/api/faucet.ts
@@ -54,7 +54,7 @@ async function fund(address: `0x${string}`, headers: Record<string, string>): Pr
 }
 
 function cors(origin: string | null): Record<string, string> {
-  const allowedOrigins = ['https://tempo.xyz']
+  const allowedOrigins = ['https://tempo.xyz', 'https://docs.tempo.xyz']
 
   if (origin?.includes('vercel.app')) allowedOrigins.push(origin)
   if (process.env.NODE_ENV === 'development') allowedOrigins.push('http://localhost:5173')
@@ -64,7 +64,7 @@ function cors(origin: string | null): Record<string, string> {
     'Access-Control-Allow-Headers': 'Content-Type, x-api-token',
   }
 
-  if (origin && allowedOrigins.some((allowed) => origin.startsWith(allowed)))
+  if (origin && allowedOrigins.includes(origin))
     headers['Access-Control-Allow-Origin'] = origin
 
   return headers


### PR DESCRIPTION
## Summary
- allow `https://docs.tempo.xyz` to call the faucet API
- switch CORS allow-list matching to exact origin checks
- add coverage for docs origin and prefix lookalike rejection

## Test
- `pnpm exec vitest run src/lib/faucet-api.test.ts --config vitest.unit.config.ts`

Note: `pnpm test src/lib/faucet-api.test.ts` could not start in this sandbox because the shared Vite config fetches mkcert/OpenAPI resources during startup; the focused unit test was run with a temporary minimal Vitest config.

Prompted by: @max-digi