### PR TITLE
docs: update T7 release to v1.10.1

### DIFF
--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.10.0 (planned) | Planned: Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. Release notes and binaries will be linked once published. | <Badge variant="red">Required</Badge> |
+| [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.9.0](https://github.com/tempoxyz/tempo/releases/tag/v1.9.0) | Jun 15, 2026 | Testnet + Mainnet | Required for T6; adds account-level receive policies for safer TIP-20 deposits and admin access keys for smoother passkey, device, and delegated-key management. Operators were required to run this release before the T6 activation timestamp on each network. | <Badge variant="red">Required</Badge> |
 | [v1.8.2](https://github.com/tempoxyz/tempo/releases/tag/v1.8.2) | Jun 8, 2026 | Testnet + Mainnet | High-priority patch release that fixes a `--minimal` node issue when requesting historical blocks through the commonware marshal interface. | <Badge variant="yellow">Recommended</Badge> |
@@ -42,12 +42,12 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | **Scope** | Storage credits for DEX order storage and TIP-20 channel storage; lower the base fee when gas is below the target threshold; deprecate new TIP-20 rewards |
 | **TIPs** | [TIP-1060: Storage Credits](https://tips.sh/1060), [TIP-1064: StablecoinDEX Order Storage Credits](https://tips.sh/1064), [TIP-1066: TIP-20 Channel Storage Credits](https://tips.sh/1066), [TIP-1067: Dynamic Base Fee](https://tips.sh/1067-1), [TIP-1075: Deprecate TIP-20 Rewards](https://github.com/tempoxyz/tempo/pull/5380) |
 | **Details** | [T7 network upgrade](/docs/protocol/upgrades/t7) |
-| **Release** | v1.10.0 (planned for June 29, 2026) |
+| **Release** | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) |
 | **Testnet** | Planned: July 2, 2026 |
 | **Mainnet** | Planned: July 9, 2026 |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
-T7 is planned for v1.10.0, with release publication planned for June 29, 2026. Release notes, binaries, and detailed node operator guidance will be linked when v1.10.0 is available.
+T7 is supported by [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1), published on June 29, 2026. Node operators should upgrade before the activation timestamp on each network.
 
 ---
 

--- a/src/pages/docs/protocol/upgrades/t7.mdx
+++ b/src/pages/docs/protocol/upgrades/t7.mdx
@@ -8,18 +8,17 @@ description: Partner-focused overview and rollout dates for the T7 network upgra
 T7 gives partners a clearer fee model for high-volume payment and exchange flows. It adds storage credits for reusable DEX order and TIP-20 channel state, makes the base fee move down when network usage is below the target threshold, and deprecates new TIP-20 rewards.
 
 :::info[T7 status]
-T7 is planned for v1.10.0. Release publication is planned for June 29, 2026, testnet rollout is planned for July 2, 2026, and mainnet rollout is planned for July 9, 2026.
+Release [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) is required for T7. See the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
 :::
 
 ## Timeline
 
 | Milestone | Date |
 |-----------|------|
-| Release publication | June 29, 2026 |
 | Testnet rollout | July 2, 2026 |
 | Mainnet rollout | July 9, 2026 |
 
-Node operator upgrade guidance will be linked when v1.10.0 is available. Operators should be ready to run the T7-compatible release before the activation timestamp on each network.
+Node operators should upgrade to [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) before the activation timestamp on each network.
 
 ## Overview
 
@@ -61,13 +60,13 @@ T7 deprecates new TIP-20 reward opt-ins and reward distributions so partners do 
 
 ## Compatible releases
 
-The following release is planned to support the T7 feature set:
+The following release supports the T7 feature set:
 
 | Ecosystem | T7-compatible releases |
 |-----------|------------------------|
-| Node operators | `v1.10.0` (planned for June 29, 2026) |
+| Node operators | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) |
 
-Release notes, binaries, and package versions will be linked when v1.10.0 is available.
+Release notes and binaries are available in the [v1.10.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1).
 
 ## What operators and integrators should know
 


### PR DESCRIPTION
Updates the T7 network-upgrade docs to link the published v1.10.1 release and remove planned-release wording now that release notes and binaries are available.