### PR TITLE
Fix docs links in marketing nav

### DIFF
--- a/src/marketing/app/_components/Footer.tsx
+++ b/src/marketing/app/_components/Footer.tsx
@@ -21,7 +21,6 @@ const footerLinkClassName =
 const CONTACT_URL = 'https://tempo.xyz/contact'
 const GITHUB_URL = 'https://github.com/tempoxyz'
 const X_URL = 'https://twitter.com/tempo'
-const TEMPO_DOCS_URL = 'https://docs.tempo.xyz/docs'
 
 function FooterLinkItem({ link }: { link: FooterLink }) {
   return link.href.startsWith('/') ? (
@@ -46,7 +45,7 @@ const columns: FooterColumn[] = [
   {
     header: 'Documentation',
     links: [
-      { label: 'Docs', href: TEMPO_DOCS_URL },
+      { label: 'Docs', href: '/docs' },
       { label: 'Payments guide', href: '/docs/guide/payments' },
       { label: 'Token issuance', href: '/docs/guide/issuance' },
     ],

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -26,7 +26,7 @@ import {
 import SearchDialog from './SearchDialog'
 import TempoLogo from './TempoLogo'
 
-const TEMPO_DOCS_URL = 'https://docs.tempo.xyz/docs'
+const TEMPO_DOCS_URL = '/docs'
 
 const protocolMenu: MegaMenuData = {
   variant: 'vertical',


### PR DESCRIPTION
## Summary
- restore the marketing header Docs links to the app-internal /docs path
- restore the marketing footer Docs link to the app-internal /docs path
- keeps both links same-origin so they no longer open as external docs.tempo.xyz links in a new tab

## Test plan
- Not run (link-only changes)