### PR TITLE
feat: track agent docs page requests

### DIFF
--- a/e2e/docs-request-classifier.test.ts
+++ b/e2e/docs-request-classifier.test.ts
@@ -86,6 +86,53 @@ const cases: ClassificationCase[] = [
     },
   },
   {
+    name: 'Axios docs page request',
+    input: { path: '/docs/api/authentication', userAgent: 'axios/1.7.9' },
+    expected: {
+      agent_family: 'http_client',
+      agent_kind: 'developer_tool',
+      match_source: 'managed_list',
+      shouldTrack: true,
+      surface: 'docs',
+    },
+  },
+  {
+    name: 'Got markdown request',
+    input: {
+      path: '/docs/api/authentication.md',
+      userAgent: 'got (https://github.com/sindresorhus/got)',
+    },
+    expected: {
+      agent_family: 'http_client',
+      agent_kind: 'developer_tool',
+      match_source: 'managed_list',
+      shouldTrack: true,
+      surface: 'markdown',
+    },
+  },
+  {
+    name: 'Python Requests docs page request',
+    input: { path: '/docs/guide/payments/send-a-payment', userAgent: 'python-requests/2.32.3' },
+    expected: {
+      agent_family: 'http_client',
+      agent_kind: 'developer_tool',
+      match_source: 'managed_list',
+      shouldTrack: true,
+      surface: 'docs',
+    },
+  },
+  {
+    name: 'Go HTTP client llms request',
+    input: { path: '/llms.txt', userAgent: 'Go-http-client/2.0' },
+    expected: {
+      agent_family: 'http_client',
+      agent_kind: 'developer_tool',
+      match_source: 'managed_list',
+      shouldTrack: true,
+      surface: 'llms',
+    },
+  },
+  {
     name: 'AI referrer',
     input: { path: '/guide/payments', referer: 'https://chatgpt.com/c/abc' },
     expected: {
@@ -105,17 +152,45 @@ const cases: ClassificationCase[] = [
     },
   },
   {
-    name: 'skill surface with unknown user agent',
+    name: 'skill surface with curl client',
     input: { path: '/SKILL.md', userAgent: 'curl/8.0' },
     expected: {
-      match_source: 'agent_surface',
+      agent_family: 'http_client',
+      agent_kind: 'developer_tool',
+      match_source: 'managed_list',
       shouldTrack: true,
       surface: 'skill',
     },
   },
   {
+    name: 'unknown non-browser docs page request',
+    input: { path: '/docs/api/authentication', userAgent: 'CustomFetcher/0.1' },
+    expected: {
+      agent_family: 'unknown_client',
+      agent_kind: 'unknown_ai',
+      match_source: 'unknown_ua',
+      shouldTrack: true,
+      surface: 'docs',
+    },
+  },
+  {
+    name: 'missing user agent docs page request',
+    input: { path: '/docs/api/authentication' },
+    expected: {
+      agent_family: 'unknown_client',
+      agent_kind: 'unknown_ai',
+      match_source: 'unknown_ua',
+      shouldTrack: true,
+      surface: 'docs',
+    },
+  },
+  {
     name: 'normal human docs page',
-    input: { path: '/guide/payments', userAgent: 'Mozilla/5.0' },
+    input: {
+      path: '/guide/payments',
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0 Safari/537.36',
+    },
     expected: {
       agent_kind: 'human',
       match_source: 'none',

--- a/src/lib/docs-request-classifier.ts
+++ b/src/lib/docs-request-classifier.ts
@@ -37,6 +37,8 @@ export type DocsRequestMatchSource =
   | 'ai_referrer'
   /** Unknown client requested a machine-readable agent surface. */
   | 'agent_surface'
+  /** Unknown user agent without a known attribution rule. */
+  | 'unknown_ua'
   /** No server-side agent signal matched. */
   | 'none'
 
@@ -92,6 +94,22 @@ const MANAGED_CLIENT_USER_AGENT_RULES: readonly UserAgentRule[] = [
   { token: 'codex-mcp-client/', agent_family: 'openai', agent_kind: 'developer_tool' },
   /** Common Codex MCP workaround UA set manually via http_headers. */
   { token: 'codex-mcp/', agent_family: 'openai', agent_kind: 'developer_tool' },
+  /** Common JavaScript HTTP client used by local agents and scripts. */
+  { token: 'axios/', agent_family: 'http_client', agent_kind: 'developer_tool' },
+  /** Node.js fetch-like HTTP client used by local agents and scripts. */
+  { token: 'node-fetch/', agent_family: 'http_client', agent_kind: 'developer_tool' },
+  /** Node.js HTTP client used by local agents and scripts. */
+  { token: 'got/', agent_family: 'http_client', agent_kind: 'developer_tool' },
+  /** Node.js HTTP client used by local agents and scripts. */
+  { token: 'got ', agent_family: 'http_client', agent_kind: 'developer_tool' },
+  /** CLI HTTP client often used by agents and docs-ingestion scripts. */
+  { token: 'curl/', agent_family: 'http_client', agent_kind: 'developer_tool' },
+  /** Python HTTP client often used by agents and docs-ingestion scripts. */
+  { token: 'python-requests/', agent_family: 'http_client', agent_kind: 'developer_tool' },
+  /** Python HTTP client often used by async agents and docs-ingestion scripts. */
+  { token: 'aiohttp/', agent_family: 'http_client', agent_kind: 'developer_tool' },
+  /** Go default HTTP client used by command-line tooling and agents. */
+  { token: 'Go-http-client/', agent_family: 'http_client', agent_kind: 'developer_tool' },
 ]
 
 /** AI product hosts that can refer humans into the docs after an answer/citation. */
@@ -149,6 +167,17 @@ export function classifyDocsRequest(input: {
     }
   }
 
+  if (surface === 'docs' && isUnknownUserAgent(input.userAgent)) {
+    return {
+      agent_family: 'unknown_client',
+      agent_kind: 'unknown_ai',
+      match_source: 'unknown_ua',
+      referer_host: refererHost,
+      surface,
+      shouldTrack: true,
+    }
+  }
+
   return {
     agent_kind: 'human',
     match_source: 'none',
@@ -188,6 +217,10 @@ function matchUserAgent(userAgent = '') {
   )
 
   if (managedRule) return formatUserAgentMatch(managedRule, 'managed_list')
+}
+
+function isUnknownUserAgent(userAgent = '') {
+  return !userAgent.toLowerCase().includes('mozilla/5.0')
 }
 
 function formatUserAgentMatch(rule: UserAgentRule, matchSource: 'official_ua' | 'managed_list') {


### PR DESCRIPTION
## Summary

- Track common HTTP client user agents as developer-tool docs traffic.
- Add an unknown UA fallback bucket for unattributed docs page requests.
- Cover known clients, unknown clients, and browser traffic in classifier tests.

## Motivation

Agent and script reads do not run browser analytics, so docs page views from clients like axios, curl, and custom fetchers need server-side attribution.

## Key design considerations

- Keep official crawler and managed-client attribution ahead of fallback matching.
- Use `unknown_ua` as a burn-down bucket that can be grouped by raw user agent in analytics.
- Exclude browser-like UAs from server-side fallback tracking to avoid double-counting client analytics.