### PR TITLE
Add API topnav link to /docs/api

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1104,6 +1104,10 @@ export default defineConfig({
       text: 'Docs',
       link: '/docs',
     },
+    {
+      text: 'API',
+      link: '/docs/api',
+    },
 
     { text: 'Ecosystem', link: 'https://tempo.xyz/ecosystem' },
     { text: 'Wallet', link: 'https://wallet.tempo.xyz' },


### PR DESCRIPTION
Adds an "API" link to the top navigation pointing to `/docs/api`.