### PR TITLE
Add search benchmark harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "unplugin-auto-import": "^21.0.0",
     "unplugin-icons": "^23.0.1",
     "viem": "^2.53.1",
-    "vocs": "2.1.9",
+    "vocs": "2.2.1",
     "wagmi": "3.6.14",
     "waku": "^1.0.0-beta.0",
     "webauthx": "~0.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check": "biome check --write --unsafe .",
     "check:types": "tsgo --project tsconfig.json --noEmit",
     "preview": "node dist/preview.js",
+    "search:benchmark": "bun search-benchmark/run.ts",
     "test": "vitest run --dir src",
     "test:e2e": "playwright test",
     "bundle:analyze": "node --experimental-strip-types scripts/bundle-diff.ts --skip-build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^2.53.1
         version: 2.53.1(typescript@5.9.3)(zod@4.3.6)
       vocs:
-        specifier: 2.1.9
-        version: 2.1.9(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.6)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(waku@1.0.0-beta.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.6)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        specifier: 2.2.1
+        version: 2.2.1(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.6)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(waku@1.0.0-beta.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.6)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       wagmi:
         specifier: 3.6.14
         version: 3.6.14(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.6))(@types/react@19.2.14)(accounts@0.10.7)(react@19.2.6)(typescript@5.9.3)(viem@2.53.1(typescript@5.9.3)(zod@4.3.6))
@@ -4717,8 +4717,8 @@ packages:
       jsdom:
         optional: true
 
-  vocs@2.1.9:
-    resolution: {integrity: sha512-mB2RncVKrg13s/0ciYUTddgJJ/fvbXCb0Tb6HRymz0aEOSyhyjDkYa3C2Z1OUz/VhrvH9CHkNM6cMkWWu9xijQ==}
+  vocs@2.2.1:
+    resolution: {integrity: sha512-naPotNSOk6l9UHqE75Yn5cMN/BmAmwDl5QnE4TVZ46XdhGd+oSEDw7SmiMdHV/sI5qmH1PlAtPLVAwtVUKNSXQ==}
     hasBin: true
     peerDependencies:
       '@vocs/twoslash-rust': ^0.1.0
@@ -9981,7 +9981,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@2.1.9(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.6)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(waku@1.0.0-beta.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.6)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vocs@2.2.1(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.6)(rollup@4.60.1)(typescript@5.9.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(waku@1.0.0-beta.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.6)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/search-benchmark/README.md
+++ b/search-benchmark/README.md
@@ -1,0 +1,20 @@
+# Search Benchmark
+
+Accuracy-only harness for tuning docs search before changing production ranking.
+
+Run it with:
+
+```sh
+bun run search:benchmark
+```
+
+## Files
+
+- `queries.ts` is the editable ground truth. Add real user queries, label them, and list the page paths that should count as relevant.
+- `config.ts` defines MiniSearch variants. `production-baseline` should mirror `vocs.config.ts`; the other variants are experiments.
+- `corpus.ts` builds the benchmark corpus from `src/pages` using Vocs' own search extractor.
+- `run.ts` prints top-1/top-3/top-5, MRR, zero-result rate, per-label accuracy, and top-3 misses.
+
+## Notes
+
+The scorer compares page paths, so section anchors are stripped before matching. Negative queries use an empty `relevant` list and are excluded from recall metrics.

--- a/search-benchmark/config.ts
+++ b/search-benchmark/config.ts
@@ -15,6 +15,7 @@ export type SearchVariant = {
 }
 
 const productionBoost = { title: 4, subtitle: 3, text: 2, category: 1, titles: 1 }
+const tunedProductionBoost = { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 3 }
 const excerptPathTextBoost = { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 2, text: 2 }
 const pathHeavyBoost = { title: 7, subtitle: 3, titles: 2, path: 6, excerpt: 1, text: 1 }
 const balancedPathTextBoost = { title: 5, subtitle: 3, titles: 2, path: 3, text: 2 }
@@ -60,7 +61,7 @@ export const variants: SearchVariant[] = [
   {
     name: 'production-baseline',
     description: 'Current Vocs 2.2.1 path/excerpt production settings.',
-    fields: ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text'],
+    fields: ['title', 'titles', 'subtitle', 'path', 'excerpt'],
     storeFields: [
       'category',
       'href',
@@ -72,12 +73,12 @@ export const variants: SearchVariant[] = [
       'type',
     ],
     derivedFields: ['path', 'excerpt'],
-    excerptWords: 80,
+    excerptWords: 24,
     searchOptions: {
       combineWith: 'OR',
-      fuzzy: 0.2,
-      prefix: true,
-      boost: excerptPathTextBoost,
+      fuzzy: 0.1,
+      prefix: false,
+      boost: tunedProductionBoost,
       boostDocument,
     },
   },

--- a/search-benchmark/config.ts
+++ b/search-benchmark/config.ts
@@ -36,8 +36,8 @@ export function boostDocument(
 
 export const variants: SearchVariant[] = [
   {
-    name: 'production-baseline',
-    description: 'Current unpatched Vocs production settings.',
+    name: 'legacy-vocs-baseline',
+    description: 'Previous unconfigured Vocs production settings.',
     fields: ['category', 'subtitle', 'text', 'title', 'titles'],
     storeFields: [
       'category',
@@ -58,9 +58,32 @@ export const variants: SearchVariant[] = [
     },
   },
   {
+    name: 'production-baseline',
+    description: 'Current Vocs 2.2.1 path/excerpt production settings.',
+    fields: ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text'],
+    storeFields: [
+      'category',
+      'href',
+      'searchPriority',
+      'subtitle',
+      'text',
+      'title',
+      'titles',
+      'type',
+    ],
+    derivedFields: ['path', 'excerpt'],
+    excerptWords: 80,
+    searchOptions: {
+      combineWith: 'OR',
+      fuzzy: 0.2,
+      prefix: true,
+      boost: excerptPathTextBoost,
+      boostDocument,
+    },
+  },
+  {
     name: 'path-excerpt-text-or-fallback',
-    description:
-      'Candidate upstream Vocs config: exact path/excerpt/text search with OR fuzzy fallback.',
+    description: 'Candidate future config: exact path/excerpt/text search with OR fuzzy fallback.',
     fields: ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text'],
     storeFields: [
       'category',

--- a/search-benchmark/config.ts
+++ b/search-benchmark/config.ts
@@ -1,0 +1,138 @@
+import type { SearchOptions } from 'minisearch'
+
+export type DerivedField = 'path' | 'excerpt'
+
+export type SearchVariant = {
+  name: string
+  description: string
+  fields: string[]
+  storeFields: string[]
+  derivedFields?: DerivedField[]
+  excerptWords?: number
+  searchOptions: SearchOptions
+  fallbackOptions?: SearchOptions
+  minResultsBeforeFallback?: number
+}
+
+const productionBoost = { title: 4, subtitle: 3, text: 2, category: 1, titles: 1 }
+const excerptPathTextBoost = { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 2, text: 2 }
+const pathHeavyBoost = { title: 7, subtitle: 3, titles: 2, path: 6, excerpt: 1, text: 1 }
+const balancedPathTextBoost = { title: 5, subtitle: 3, titles: 2, path: 3, text: 2 }
+
+export function boostDocument(
+  _documentId: unknown,
+  _term: string,
+  storedFields?: Record<string, unknown>,
+): number {
+  const priority = (storedFields?.searchPriority as number | undefined) ?? 1
+  const href = storedFields?.href as string | undefined
+  const isDocsPath = href?.startsWith('/docs/') ?? false
+  const segments = href ? href.split('/').filter(Boolean).length : 1
+  const depth = isDocsPath ? Math.max(segments - 1, 1) : segments
+  const depthBoost = 1 / Math.max(depth, 1)
+  const docsBoost = isDocsPath ? 1.5 : 1
+  return priority * depthBoost * docsBoost
+}
+
+export const variants: SearchVariant[] = [
+  {
+    name: 'production-baseline',
+    description: 'Current unpatched Vocs production settings.',
+    fields: ['category', 'subtitle', 'text', 'title', 'titles'],
+    storeFields: [
+      'category',
+      'href',
+      'searchPriority',
+      'subtitle',
+      'text',
+      'title',
+      'titles',
+      'type',
+    ],
+    searchOptions: {
+      combineWith: 'AND',
+      fuzzy: 0.2,
+      prefix: true,
+      boost: productionBoost,
+      boostDocument,
+    },
+  },
+  {
+    name: 'path-excerpt-text-or-fallback',
+    description:
+      'Candidate upstream Vocs config: exact path/excerpt/text search with OR fuzzy fallback.',
+    fields: ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text'],
+    storeFields: [
+      'category',
+      'href',
+      'searchPriority',
+      'subtitle',
+      'text',
+      'title',
+      'titles',
+      'type',
+    ],
+    derivedFields: ['path', 'excerpt'],
+    excerptWords: 80,
+    searchOptions: {
+      combineWith: 'AND',
+      fuzzy: false,
+      prefix: true,
+      boost: excerptPathTextBoost,
+      boostDocument,
+    },
+    fallbackOptions: {
+      combineWith: 'OR',
+      fuzzy: 0.2,
+      prefix: true,
+      boost: excerptPathTextBoost,
+      boostDocument,
+    },
+    minResultsBeforeFallback: 3,
+  },
+  {
+    name: 'path-heavy-or-fallback',
+    description: 'Exact title/path/excerpt/text search with path-heavy OR fuzzy fallback.',
+    fields: ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text'],
+    storeFields: ['href', 'searchPriority', 'title'],
+    derivedFields: ['path', 'excerpt'],
+    excerptWords: 80,
+    searchOptions: {
+      combineWith: 'AND',
+      fuzzy: false,
+      prefix: true,
+      boost: pathHeavyBoost,
+      boostDocument,
+    },
+    fallbackOptions: {
+      combineWith: 'OR',
+      fuzzy: 0.2,
+      prefix: true,
+      boost: pathHeavyBoost,
+      boostDocument,
+    },
+    minResultsBeforeFallback: 3,
+  },
+  {
+    name: 'path-text-or-fallback',
+    description: 'Exact title/path/full-text search with balanced OR fuzzy fallback.',
+    fields: ['title', 'titles', 'subtitle', 'path', 'text'],
+    storeFields: ['href', 'searchPriority', 'title'],
+    derivedFields: ['path'],
+    searchOptions: {
+      combineWith: 'AND',
+      fuzzy: false,
+      prefix: true,
+      boost: balancedPathTextBoost,
+      boostDocument,
+    },
+    fallbackOptions: {
+      combineWith: 'OR',
+      fuzzy: 0.2,
+      prefix: true,
+      boost: balancedPathTextBoost,
+      boostDocument,
+    },
+    minResultsBeforeFallback: 3,
+  },
+]

--- a/search-benchmark/corpus.ts
+++ b/search-benchmark/corpus.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const vocsSearchPath = path.resolve(process.cwd(), 'node_modules/vocs/dist/internal/search.js')
+const { extract } = (await import(pathToFileURL(vocsSearchPath).href)) as {
+  extract: (
+    source: string,
+    config: unknown,
+  ) => {
+    searchPriority: number | undefined
+    sections: Array<{
+      anchor: string
+      isPage: boolean
+      subtitle: string
+      text: string
+      title: string
+      titles: string[]
+    }>
+  }
+}
+
+export type Doc = {
+  id: string
+  href: string
+  title: string
+  titles: string[]
+  subtitle: string
+  text: string
+  category: string
+  searchPriority: number | undefined
+  type: 'page' | 'section'
+}
+
+const PAGES_DIR = path.resolve(process.cwd(), 'src/pages')
+
+export function hrefFromPage(page: string): string {
+  return (
+    `/${page}`
+      .replace(/\.(md|mdx)$/, '')
+      .replace(/\/index$/, '')
+      .replace(/^$/, '/') || '/'
+  )
+}
+
+/**
+ * Build the benchmark corpus from every MDX/MD page using Vocs' own section
+ * extractor, so benchmark input matches production docs search content.
+ */
+export async function buildCorpus(): Promise<Doc[]> {
+  const entries = await fs.readdir(PAGES_DIR, { recursive: true })
+  const pages = entries.filter((p) => p.endsWith('.md') || p.endsWith('.mdx'))
+
+  const docs: Doc[] = []
+  for (const page of pages) {
+    const filePath = path.join(PAGES_DIR, page)
+    const content = await fs.readFile(filePath, 'utf-8')
+    const { searchPriority, sections } = extract(content, {})
+    if (sections.length === 0) continue
+    const href = hrefFromPage(page)
+    for (const section of sections) {
+      docs.push({
+        id: `${filePath}#${section.anchor}`,
+        href: section.anchor ? `${href}#${section.anchor}` : href,
+        title: section.title,
+        titles: section.titles,
+        subtitle: section.subtitle,
+        text: section.text,
+        category: '',
+        searchPriority,
+        type: section.isPage ? 'page' : 'section',
+      })
+    }
+  }
+  return docs
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  const docs = await buildCorpus()
+  const pages = new Set(docs.map((d) => d.href.split('#')[0]))
+  console.error(`corpus: ${docs.length} sections across ${pages.size} pages`)
+  // Print page-level docs (title + href) to author fixtures.
+  for (const d of docs) {
+    if (d.type === 'page') console.log(`${d.href}\t${d.title}`)
+  }
+}

--- a/search-benchmark/queries.ts
+++ b/search-benchmark/queries.ts
@@ -1,0 +1,98 @@
+export type SearchQueryLabel =
+  // Literal page title, API name, or exact term users are expected to type.
+  | 'exact'
+  // Topic-oriented query where the right page may not contain the exact words.
+  | 'concept'
+  // Natural-language question phrased like a user asking for help.
+  | 'nl'
+  // Misspelled query that should still recover the intended page.
+  | 'typo'
+  // Out-of-domain query that should not count toward recall metrics.
+  | 'negative'
+
+export type SearchQueryFixture = {
+  q: string
+  label: SearchQueryLabel
+  relevant: string[]
+  notes?: string
+}
+
+export const queries: SearchQueryFixture[] = [
+  {
+    q: 'json rpc',
+    label: 'exact',
+    relevant: ['/docs/api/json-rpc', '/docs/protocol/rpc'],
+  },
+  {
+    q: 'rate limits',
+    label: 'exact',
+    relevant: ['/docs/api/rate-limits'],
+  },
+  {
+    q: 'pagination',
+    label: 'exact',
+    relevant: ['/docs/api/pagination'],
+  },
+  {
+    q: 'transfer',
+    label: 'exact',
+    relevant: ['/docs/guide/payments/send-a-payment'],
+  },
+  {
+    q: 'accept payments',
+    label: 'exact',
+    relevant: ['/docs/guide/payments/transfer-memos'],
+  },
+  {
+    q: 'sponsor fees',
+    label: 'exact',
+    relevant: ['/docs/guide/payments/sponsor-user-fees'],
+  },
+  {
+    q: 'faucet',
+    label: 'exact',
+    relevant: ['/docs/quickstart/faucet'],
+  },
+  {
+    q: 'sponsor fees',
+    label: 'concept',
+    relevant: ['/docs/guide/payments/sponsor-user-fees'],
+  },
+  {
+    q: 'token list',
+    label: 'concept',
+    relevant: ['/docs/quickstart/tokenlist'],
+  },
+  {
+    q: 'discover services',
+    label: 'concept',
+    relevant: ['/docs/guide/machine-payments/discover-services'],
+  },
+  {
+    q: 'how do I get test tokens',
+    label: 'nl',
+    relevant: ['/docs/quickstart/faucet'],
+    notes:
+      'Starter natural-language fixture; tune if a funding guide becomes the canonical answer.',
+  },
+  {
+    q: 'where is the rpc url',
+    label: 'nl',
+    relevant: ['/docs/quickstart/connection-details', '/docs/api/json-rpc', '/docs/protocol/rpc'],
+  },
+  {
+    q: 'virtaul adresses',
+    label: 'typo',
+    relevant: ['/docs/guide/payments/virtual-addresses', '/docs/protocol/tip20/virtual-addresses'],
+  },
+  {
+    q: 'sponser fees',
+    label: 'typo',
+    relevant: ['/docs/guide/payments/sponsor-user-fees'],
+  },
+  {
+    q: 'favorite pizza topping',
+    label: 'negative',
+    relevant: [],
+  },
+]

--- a/search-benchmark/run.ts
+++ b/search-benchmark/run.ts
@@ -1,0 +1,111 @@
+import { variants } from './config.ts'
+import { buildCorpus } from './corpus.ts'
+import { queries } from './queries.ts'
+import { buildSearch, pagePath } from './search.ts'
+
+type QueryResult = {
+  query: (typeof queries)[number]
+  results: string[]
+  rank: number
+}
+
+function fmtPct(x: number): string {
+  return `${(x * 100).toFixed(1)}%`
+}
+
+function rankResult(results: string[], relevant: string[]): number {
+  const relevantPages = new Set(relevant.map(pagePath))
+  return results.findIndex((result) => relevantPages.has(pagePath(result)))
+}
+
+function hitAt(result: QueryResult, k: number): boolean {
+  return result.rank >= 0 && result.rank < k
+}
+
+function printPerLabel(resultsByVariant: Map<string, QueryResult[]>): void {
+  console.log()
+  console.log('per-label top-3 accuracy:')
+  const labels = [
+    ...new Set(queries.filter((query) => query.relevant.length).map((query) => query.label)),
+  ]
+
+  console.table(
+    labels.map((label) => {
+      const row: Record<string, string> = { label }
+      for (const [variantName, results] of resultsByVariant) {
+        const labelResults = results.filter(
+          ({ query }) => query.label === label && query.relevant.length,
+        )
+        row[variantName] =
+          `${labelResults.filter((result) => hitAt(result, 3)).length}/${labelResults.length}`
+      }
+      return row
+    }),
+  )
+}
+
+function printMisses(resultsByVariant: Map<string, QueryResult[]>): void {
+  for (const [variantName, results] of resultsByVariant) {
+    console.log()
+    console.log(`${variantName} misses (not in top-3):`)
+    const misses = results.filter(
+      ({ query, rank }) => query.relevant.length && (rank < 0 || rank >= 3),
+    )
+    if (misses.length === 0) {
+      console.log('  (none)')
+      continue
+    }
+
+    for (const { query, results: queryResults } of misses) {
+      console.log(`  [${query.label}] "${query.q}"`)
+      console.log(`    expected: ${query.relevant.map(pagePath).join(', ')}`)
+      console.log(`    actual:   ${queryResults.slice(0, 3).join(', ') || '(none)'}`)
+    }
+  }
+}
+
+function evaluate(search: (query: string) => string[]): QueryResult[] {
+  return queries.map((query) => {
+    const results = search(query.q)
+    return { query, results, rank: rankResult(results, query.relevant) }
+  })
+}
+
+function metrics(variantName: string, results: QueryResult[]): Record<string, string> {
+  const scored = results.filter(({ query }) => query.relevant.length)
+  const count = scored.length || 1
+  return {
+    variant: variantName,
+    top1: fmtPct(scored.filter((result) => hitAt(result, 1)).length / count),
+    top3: fmtPct(scored.filter((result) => hitAt(result, 3)).length / count),
+    top5: fmtPct(scored.filter((result) => hitAt(result, 5)).length / count),
+    MRR: (
+      scored.reduce((sum, result) => sum + (result.rank >= 0 ? 1 / (result.rank + 1) : 0), 0) /
+      count
+    ).toFixed(3),
+    zero: fmtPct(scored.filter(({ results }) => results.length === 0).length / count),
+  }
+}
+
+async function main(): Promise<void> {
+  const docs = await buildCorpus()
+  const pages = new Set(docs.map((d) => pagePath(d.href)))
+  console.log(`corpus: ${docs.length} sections, ${pages.size} pages`)
+  console.log(
+    `queries: ${queries.length} (${queries.filter((q) => q.relevant.length > 0).length} scored)`,
+  )
+  console.log()
+
+  const resultsByVariant = new Map<string, QueryResult[]>()
+  for (const variant of variants) {
+    resultsByVariant.set(variant.name, evaluate(buildSearch(variant, docs)))
+  }
+
+  console.table(
+    [...resultsByVariant].map(([variantName, results]) => metrics(variantName, results)),
+  )
+  printPerLabel(resultsByVariant)
+  printMisses(resultsByVariant)
+}
+
+main()

--- a/search-benchmark/search.ts
+++ b/search-benchmark/search.ts
@@ -1,0 +1,82 @@
+import MiniSearch from 'minisearch'
+import type { DerivedField, SearchVariant } from './config.ts'
+import type { Doc } from './corpus.ts'
+
+type SearchDoc = Doc & Partial<Record<DerivedField, string>>
+type SearchHit = { id: unknown; href: string }
+
+export function tokenize(text: string): string[] {
+  const tokens: string[] = []
+  for (const word of text.split(/[\s\-._/:@]+/)) {
+    if (!word) continue
+    tokens.push(word.toLowerCase())
+    const split = word
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+      .split(/\s+/)
+      .map((w) => w.toLowerCase())
+      .filter((w) => w.length > 0)
+    if (split.length > 1) tokens.push(...split)
+  }
+  return tokens.filter((w) => w.length > 0)
+}
+
+export function pagePath(href: string): string {
+  return href.split('#')[0] ?? href
+}
+
+function prepareDoc(doc: Doc, variant: SearchVariant): SearchDoc {
+  const indexed: SearchDoc = { ...doc }
+  for (const field of variant.derivedFields ?? []) {
+    if (field === 'path') {
+      indexed.path = pagePath(doc.href)
+        .replace(/^\/docs\//, '/')
+        .replaceAll('/', ' ')
+    } else {
+      indexed.excerpt = doc.text
+        .trim()
+        .split(/\s+/)
+        .slice(0, variant.excerptWords ?? 40)
+        .join(' ')
+    }
+  }
+  return indexed
+}
+
+function pagesFromHits(hits: SearchHit[]): string[] {
+  const seen = new Set<string>()
+  const pages: string[] = []
+  for (const hit of hits) {
+    const page = pagePath(hit.href)
+    if (seen.has(page)) continue
+    seen.add(page)
+    pages.push(page)
+  }
+  return pages
+}
+
+export function buildSearch(variant: SearchVariant, docs: Doc[]): (query: string) => string[] {
+  const index = new MiniSearch<SearchDoc>({
+    fields: variant.fields,
+    storeFields: variant.storeFields,
+    tokenize,
+  })
+  index.addAll(docs.map((doc) => prepareDoc(doc, variant)))
+
+  return (query) => {
+    const hits = index.search(query, {
+      ...variant.searchOptions,
+      tokenize,
+    }) as unknown as SearchHit[]
+    if (!variant.fallbackOptions || hits.length >= (variant.minResultsBeforeFallback ?? 1)) {
+      return pagesFromHits(hits)
+    }
+
+    const seen = new Set(hits.map((hit) => hit.id))
+    const fallbackHits = index
+      .search(query, { ...variant.fallbackOptions, tokenize })
+      .map((hit) => hit as unknown as SearchHit)
+      .filter((hit) => !seen.has(hit.id))
+    return pagesFromHits([...hits, ...fallbackHits])
+  }
+}

--- a/src/marketing/search.ts
+++ b/src/marketing/search.ts
@@ -1,14 +1,14 @@
 import { getSearchIndex } from 'virtual:marketing/search-index'
 import MiniSearch, { type Options, type SearchOptions } from 'minisearch'
 
-// The fields, store fields and tokenizer below mirror Vocs' internal search
-// config (vocs/dist/internal/search.client.js) so the index that Vocs builds is
-// queried here exactly as it is inside the docs app. Vocs doesn't export these,
-// so they're duplicated and must be kept in sync.
-const searchFields = ['category', 'subtitle', 'text', 'title', 'titles']
+// Mirrors the search config in vocs.config.ts so the marketing search loads the
+// same serialized index that the docs search dialog uses.
+const searchFields = ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text']
 const storeFields = [
   'category',
+  'excerpt',
   'href',
+  'path',
   'searchPriority',
   'subtitle',
   'text',
@@ -24,6 +24,8 @@ export type SearchResult = {
   titles: string[]
   text: string
   category?: string
+  excerpt?: string
+  path?: string
   type: 'page' | 'section' | 'nav'
   searchPriority?: number
   terms?: string[]
@@ -52,18 +54,15 @@ function tokenize(text: string): string[] {
   return tokens.filter((w) => w.length > 0)
 }
 
-// Mirrors Vocs' resolved default `search` options (vocs/dist/internal/config.js)
-// so ranking matches the docs search dialog.
 const searchOptions: SearchOptions = {
-  combineWith: 'AND',
+  combineWith: 'OR',
   fuzzy: 0.2,
   prefix: true,
-  boost: { title: 4, subtitle: 3, text: 2, category: 1, titles: 1 },
+  boost: { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 2, text: 2 },
   boostDocument: (_id, _term, storedFields) => {
     const priority = (storedFields?.searchPriority as number | undefined) ?? 1
     const href = storedFields?.href as string | undefined
     const isDocsPath = href?.startsWith('/docs/') ?? false
-    // Treat /docs/ as root for depth calculation (subtract 1).
     const segments = href ? href.split('/').filter(Boolean).length : 1
     const depth = isDocsPath ? Math.max(segments - 1, 1) : segments
     const depthBoost = 1 / Math.max(depth, 1)

--- a/src/marketing/search.ts
+++ b/src/marketing/search.ts
@@ -3,7 +3,7 @@ import MiniSearch, { type Options, type SearchOptions } from 'minisearch'
 
 // Mirrors the search config in vocs.config.ts so the marketing search loads the
 // same serialized index that the docs search dialog uses.
-const searchFields = ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text']
+const searchFields = ['title', 'titles', 'subtitle', 'path', 'excerpt']
 const storeFields = [
   'category',
   'excerpt',
@@ -56,9 +56,9 @@ function tokenize(text: string): string[] {
 
 const searchOptions: SearchOptions = {
   combineWith: 'OR',
-  fuzzy: 0.2,
-  prefix: true,
-  boost: { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 2, text: 2 },
+  fuzzy: 0.1,
+  prefix: false,
+  boost: { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 3 },
   boostDocument: (_id, _term, storedFields) => {
     const priority = (storedFields?.searchPriority as number | undefined) ?? 1
     const href = storedFields?.href as string | undefined

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -12,8 +12,8 @@ const baseUrl = (() => {
   return ''
 })()
 
-const searchIndexFields = ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text']
-const searchBoost = { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 2, text: 2 }
+const searchIndexFields = ['title', 'titles', 'subtitle', 'path', 'excerpt']
+const searchBoost = { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 3 }
 
 function extractSearchField(document: Record<string, unknown>, fieldName: string) {
   if (fieldName === 'path') {
@@ -26,7 +26,7 @@ function extractSearchField(document: Record<string, unknown>, fieldName: string
     return String(document.text ?? '')
       .trim()
       .split(/\s+/)
-      .slice(0, 80)
+      .slice(0, 24)
       .join(' ')
   }
   return document[fieldName]
@@ -72,8 +72,8 @@ export default defineConfig({
     },
     query: {
       combineWith: 'OR',
-      fuzzy: 0.2,
-      prefix: true,
+      fuzzy: 0.1,
+      prefix: false,
       boost: searchBoost,
       boostDocument: boostSearchDocument,
     },

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -31,6 +31,44 @@ export default defineConfig({
   description: 'Documentation for the Tempo network and protocol specifications',
   renderStrategy: 'partial-static',
   feedback: createFeedbackAdapter(),
+  search: {
+    index: {
+      fields: ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text'],
+      storeFields: ['path', 'excerpt'],
+      extractField(document: Record<string, unknown>, fieldName: string) {
+        if (fieldName === 'path') {
+          return String(document.href ?? '')
+            .split('#')[0]
+            .replace(/^\/docs\//, '/')
+            .replaceAll('/', ' ')
+        }
+        if (fieldName === 'excerpt') {
+          return String(document.text ?? '')
+            .trim()
+            .split(/\s+/)
+            .slice(0, 80)
+            .join(' ')
+        }
+        return document[fieldName]
+      },
+    },
+    query: {
+      combineWith: 'OR',
+      fuzzy: 0.2,
+      prefix: true,
+      boost: { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 2, text: 2 },
+      boostDocument(_documentId, _term, storedFields) {
+        const priority = (storedFields?.searchPriority as number | undefined) ?? 1
+        const href = storedFields?.href as string | undefined
+        const isDocsPath = href?.startsWith('/docs/') ?? false
+        const segments = href ? href.split('/').filter(Boolean).length : 1
+        const depth = isDocsPath ? Math.max(segments - 1, 1) : segments
+        const depthBoost = 1 / Math.max(depth, 1)
+        const docsBoost = isDocsPath ? 1.5 : 1
+        return priority * depthBoost * docsBoost
+      },
+    },
+  },
   mcp: {
     enabled: true,
     sources: [

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -12,6 +12,39 @@ const baseUrl = (() => {
   return ''
 })()
 
+const searchIndexFields = ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text']
+const searchBoost = { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 2, text: 2 }
+
+function extractSearchField(document: Record<string, unknown>, fieldName: string) {
+  if (fieldName === 'path') {
+    return String(document.href ?? '')
+      .split('#')[0]
+      .replace(/^\/docs\//, '/')
+      .replaceAll('/', ' ')
+  }
+  if (fieldName === 'excerpt') {
+    return String(document.text ?? '')
+      .trim()
+      .split(/\s+/)
+      .slice(0, 80)
+      .join(' ')
+  }
+  return document[fieldName]
+}
+
+function boostSearchDocument(
+  _documentId: unknown,
+  _term: string,
+  storedFields?: Record<string, unknown>,
+) {
+  const priority = (storedFields?.searchPriority as number | undefined) ?? 1
+  const href = storedFields?.href as string | undefined
+  const segments = href ? href.split('/').filter(Boolean).length : 1
+  const depth = href?.startsWith('/docs/') ? Math.max(segments - 1, 1) : segments
+  const docsBoost = href?.startsWith('/docs/') ? 1.5 : 1
+  return priority * (1 / Math.max(depth, 1)) * docsBoost
+}
+
 export default defineConfig({
   // banner: {
   //   dismissable: false,
@@ -33,40 +66,16 @@ export default defineConfig({
   feedback: createFeedbackAdapter(),
   search: {
     index: {
-      fields: ['title', 'titles', 'subtitle', 'path', 'excerpt', 'text'],
+      fields: searchIndexFields,
       storeFields: ['path', 'excerpt'],
-      extractField(document: Record<string, unknown>, fieldName: string) {
-        if (fieldName === 'path') {
-          return String(document.href ?? '')
-            .split('#')[0]
-            .replace(/^\/docs\//, '/')
-            .replaceAll('/', ' ')
-        }
-        if (fieldName === 'excerpt') {
-          return String(document.text ?? '')
-            .trim()
-            .split(/\s+/)
-            .slice(0, 80)
-            .join(' ')
-        }
-        return document[fieldName]
-      },
+      extractField: extractSearchField,
     },
     query: {
       combineWith: 'OR',
       fuzzy: 0.2,
       prefix: true,
-      boost: { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 2, text: 2 },
-      boostDocument(_documentId, _term, storedFields) {
-        const priority = (storedFields?.searchPriority as number | undefined) ?? 1
-        const href = storedFields?.href as string | undefined
-        const isDocsPath = href?.startsWith('/docs/') ?? false
-        const segments = href ? href.split('/').filter(Boolean).length : 1
-        const depth = isDocsPath ? Math.max(segments - 1, 1) : segments
-        const depthBoost = 1 / Math.max(depth, 1)
-        const docsBoost = isDocsPath ? 1.5 : 1
-        return priority * depthBoost * docsBoost
-      },
+      boost: searchBoost,
+      boostDocument: boostSearchDocument,
     },
   },
   mcp: {


### PR DESCRIPTION
## Summary

- Add a TypeScript-configured MiniSearch benchmark under `search-benchmark/`
- Add Vocs-backed corpus extraction and seeded query fixtures
- Add a `search:benchmark` script for accuracy tables and miss lists

## Motivation

Provide an editable docs search benchmark for comparing relevance configs before applying search changes upstream.

## Key design considerations

- Leaves production search and Vocs configuration unchanged
- Keeps fixtures in TypeScript for comments and tuning notes
- Includes the unpatched production baseline plus candidate path/excerpt fallback variants