### PR TITLE
Fix zone docs diagram asset paths

### DIFF
--- a/src/lib/docs-asset-paths.test.ts
+++ b/src/lib/docs-asset-paths.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function mdxFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const filepath = path.join(directory, entry.name)
+    if (entry.isDirectory()) return mdxFiles(filepath)
+    return entry.isFile() && filepath.endsWith('.mdx') ? [filepath] : []
+  })
+}
+
+describe('docs asset paths', () => {
+  it('uses the developers mount for root-relative public image assets', () => {
+    const files = mdxFiles(path.resolve('src/pages/docs'))
+    const unprefixedImages = files.flatMap((file) => {
+      const text = fs.readFileSync(file, 'utf8')
+      const markdownImages = [...text.matchAll(/!\[[^\]]*\]\(\/(?!developers\/)[^)]+\)/g)]
+      const htmlImages = [...text.matchAll(/<img\b[^>]*\bsrc=["']\/(?!developers\/)[^"']+["'][^>]*>/g)]
+      return [...markdownImages, ...htmlImages].map((match) => `${file}:${match[0]}`)
+    })
+
+    expect(unprefixedImages).toEqual([])
+  })
+})

--- a/src/pages/docs/guide/private-zones/deposit-to-a-zone.mdx
+++ b/src/pages/docs/guide/private-zones/deposit-to-a-zone.mdx
@@ -18,7 +18,7 @@ Tempo Zones is still in early development and is available for testing purposes 
 
 Use this guide when you want to move `pathUSD` from your public Tempo balance into `Zone A`. You will submit a public-chain deposit first, then wait for `Zone A` to credit the net amount after fees.
 
-![Zone contract architecture](/learn/zones/diagram-deposit.svg)
+![Zone contract architecture](/developers/learn/zones/diagram-deposit.svg)
 
 The deposit is accepted through `ZonePortal` on the public chain. You need private zone authorization to read the resulting zone balance, because those reads are only exposed to the authenticated account.
 

--- a/src/pages/docs/guide/private-zones/index.mdx
+++ b/src/pages/docs/guide/private-zones/index.mdx
@@ -13,7 +13,7 @@ Tempo Zones is still in early development and is available for testing purposes 
 
 Tempo Zones let you keep balances and transfers inside a private execution environment while still using the public Tempo chain when funds enter or leave. The important thing to remember is that most zone flows settle in stages: a public or zone transaction lands first, then the private balance update appears shortly after.
 
-![Tempo Zones overview](/learn/zones/diagram-overview.svg)
+![Tempo Zones overview](/developers/learn/zones/diagram-overview.svg)
 
 ## Before you start
 

--- a/src/pages/docs/guide/private-zones/swap-across-zones.mdx
+++ b/src/pages/docs/guide/private-zones/swap-across-zones.mdx
@@ -22,7 +22,7 @@ Use this guide when you want to leave `Zone A` with `pathUSD` and arrive in `Zon
 
 The route uses `swapAndDepositRouter` on the public chain: withdraw from `Zone A`, swap on the Stablecoin DEX, then deposit the output token into `Zone B`.
 
-![Cross-zone DEX swap flow](/learn/zones/diagram-swap.svg)
+![Cross-zone DEX swap flow](/developers/learn/zones/diagram-swap.svg)
 
 ## Swapping pathUSD from Zone A into betaUSD on Zone B
 

--- a/src/pages/docs/guide/private-zones/withdraw-from-a-zone.mdx
+++ b/src/pages/docs/guide/private-zones/withdraw-from-a-zone.mdx
@@ -18,7 +18,7 @@ Tempo Zones is still in early development and is available for testing purposes 
 
 Use this guide when you want to move `pathUSD` out of `Zone A` and back to your public Tempo balance.
 
-![Zone contract architecture](/learn/zones/diagram-withdraw.svg)
+![Zone contract architecture](/developers/learn/zones/diagram-withdraw.svg)
 
 Direct withdrawals exit through `ZoneOutbox` on the zone chain. You submit the withdrawal request in the zone first, then wait for the public balance to increase after the batch settles.
 

--- a/src/pages/docs/protocol/tip20/virtual-addresses.mdx
+++ b/src/pages/docs/protocol/tip20/virtual-addresses.mdx
@@ -18,8 +18,8 @@ Without virtual addresses, per-customer deposit addresses are operationally expe
 
 With virtual addresses, the customer-facing address is still unique, but it behaves like a routing alias. The protocol resolves it to the registered master wallet during the TIP-20 transfer itself.
 
-<img src="/images/tip20/virtual-addresses-light.png" alt="Without virtual addresses, each customer deposit address holds a separate onchain balance that must be swept to the master wallet. With virtual addresses, TIP-20 forwarding routes deposits directly to the master wallet." className="dark:hidden" />
-<img src="/images/tip20/virtual-addresses-dark.png" alt="Without virtual addresses, each customer deposit address holds a separate onchain balance that must be swept to the master wallet. With virtual addresses, TIP-20 forwarding routes deposits directly to the master wallet." className="hidden dark:block" />
+<img src="/developers/images/tip20/virtual-addresses-light.png" alt="Without virtual addresses, each customer deposit address holds a separate onchain balance that must be swept to the master wallet. With virtual addresses, TIP-20 forwarding routes deposits directly to the master wallet." className="dark:hidden" />
+<img src="/developers/images/tip20/virtual-addresses-dark.png" alt="Without virtual addresses, each customer deposit address holds a separate onchain balance that must be swept to the master wallet. With virtual addresses, TIP-20 forwarding routes deposits directly to the master wallet." className="hidden dark:block" />
 
 This means:
 

--- a/src/pages/docs/protocol/zones/bridging.mdx
+++ b/src/pages/docs/protocol/zones/bridging.mdx
@@ -11,7 +11,7 @@ Tempo Zones is still in early development and is available for testing purposes 
 
 Tempo Zones use Tempo-centric bridging for cross-chain operations: deposits flow from Tempo into a zone, and withdrawals flow from a zone back to Tempo with optional callbacks for composability.
 
-![End-to-end privacy flow through a zone](/learn/zones/diagram-privacy.svg)
+![End-to-end privacy flow through a zone](/developers/learn/zones/diagram-privacy.svg)
 
 Above is an example of the type of complex transaction that can remain privacy-preserving via Tempo Zones, while performing operations such as bridging, deposits & sends, and withdrawals. Learn more about [encrypted deposits](#encrypted-deposits) and [verifiable withdrawals](#verifiable-withdrawals) below.
 

--- a/src/pages/docs/protocol/zones/execution.mdx
+++ b/src/pages/docs/protocol/zones/execution.mdx
@@ -55,7 +55,7 @@ Tempo Zones currently disable the `CREATE` and `CREATE2` opcodes. Each Tempo Zon
 
 ## Token Management
 
-![Policy inheritance from mainnet to zone](/learn/zones/diagram-tip20.svg)
+![Policy inheritance from mainnet to zone](/developers/learn/zones/diagram-tip20.svg)
 
 The sequencer manages which TIP-20 tokens are available on a Tempo Zone:
 

--- a/src/pages/docs/protocol/zones/index.mdx
+++ b/src/pages/docs/protocol/zones/index.mdx
@@ -13,7 +13,7 @@ Tempo Zones are still in early development and available for testing purposes on
 
 A Tempo Zone is a private execution environment attached to Tempo Mainnet. Inside a Tempo Zone, balances, transfers, and transaction history are invisible to block explorers, indexers, and other users on Tempo Mainnet. Each Tempo Zone runs its own sequencer and executes transactions independently.
 
-![Tempo Zones overview](/learn/zones/diagram-overview.svg)
+![Tempo Zones overview](/developers/learn/zones/diagram-overview.svg)
 
 Funds deposited into a Tempo Zone are locked in the Zone Portal contract on Tempo Mainnet. [Validity proofs](/docs/protocol/zones/proving) guarantee that the sequencer executed every transaction correctly. The sequencer orders and includes transactions, but cannot steal funds or forge state transitions.
 
@@ -27,13 +27,13 @@ Most privacy solutions offer either confidentiality (hide the amount) or anonymi
 
 The [accounts specification](/docs/protocol/zones/accounts) describes how balance and allowance reads are restricted at the contract level, and the [RPC specification](/docs/protocol/zones/rpc) covers how the JSON-RPC interface is scoped per account.
 
-![End-to-end privacy flow through a zone](/learn/zones/diagram-privacy.svg)
+![End-to-end privacy flow through a zone](/developers/learn/zones/diagram-privacy.svg)
 
 ### Tempo Zones are compliant by design
 
 Every TIP-20 token carries its issuer's compliance policy (whitelists, blacklists, freeze controls) via the [TIP-403 registry](/docs/protocol/tip403/overview). When deposited into a Tempo Zone, the policy is provably mirrored. The validity proof commits that every transaction in the batch followed the issuer's rules.
 
-![Policy inheritance from mainnet to zone](/learn/zones/diagram-tip20.svg)
+![Policy inheritance from mainnet to zone](/developers/learn/zones/diagram-tip20.svg)
 
 ### Tempo Zones are safe from theft
 


### PR DESCRIPTION
## Summary
- Prefix Tempo Zones diagram image paths with `/developers` so they resolve on tempo.xyz/developers pages
- Add a regression test preventing unprefixed `/learn/zones/...` Markdown image references

## Validation
- `rg -n "!\[[^\]]+\]\(/learn/zones/" src/pages/docs` returns no matches
- `curl -I https://tempo.xyz/developers/learn/zones/diagram-overview.svg` returns 200 OK
- `git diff --check` passes
- `VITE_USE_HTTP=true pnpm exec vitest run src/lib/docs-asset-paths.test.ts src/lib/vercel-routing.test.ts` blocked by unrelated Vocs OpenAPI fetch failure during startup

Prompted by: @max-digi