### PR TITLE
[codex] Improve docs headings and navigation

### DIFF
--- a/src/pages/docs/api.mdx
+++ b/src/pages/docs/api.mdx
@@ -13,7 +13,7 @@ Use the Tempo API for indexed chain data, readable account activity, token metad
 The Tempo API is under active development. Endpoints are not yet stable and may change without notice.
 :::
 
-## Getting Started
+## Start with the Tempo API
 
 Every endpoint is served over HTTPS from `https://api.tempo.xyz` under the `/v1` prefix. Most read endpoints are public, so you can make your first request without any credentials:
 
@@ -23,7 +23,7 @@ curl 'https://api.tempo.xyz/v1/blocks'
 
 The same base URL and credentials give you access to three surfaces:
 
-- [**REST API**](#api-endpoints): typed endpoints for indexed chain data such as blocks, transactions, tokens, balances, transfers, and receipts.
+- [**REST API**](#tempo-rest-api-endpoints): typed endpoints for indexed chain data such as blocks, transactions, tokens, balances, transfers, and receipts.
 
   ```bash
   curl 'https://api.tempo.xyz/v1/addresses/0x.../balances'
@@ -58,17 +58,17 @@ Public access lets you try the API and serve low-volume reads, and [MPP](/docs/a
 API keys are only available on request. [Contact us](https://tempo.xyz/contact/) to learn more.
 :::
 
-## Example
+## Try a Tempo API request
 
 Check out an endpoint below and click "Try" to run it directly against the API. For example, fetch the token balances for an address:
 
 <OpenApi.Playground operationId="getAddressBalances" hideQueryParams />
 
-## API Endpoints
+## Tempo REST API endpoints
 
 <OpenApi.Endpoints path="/docs/api" />
 
-## Next Steps
+## Next API integration steps
 
 <Cards>
   <Card

--- a/src/pages/docs/api/authentication.mdx
+++ b/src/pages/docs/api/authentication.mdx
@@ -3,7 +3,7 @@ title: Authentication
 description: Authenticate Tempo API requests with production or sandbox API keys, or pay per request with MPP.
 ---
 
-# Authentication
+# API Authentication
 
 The Tempo API supports three ways to authenticate a request, so you can start without credentials and add authentication as your needs grow:
 
@@ -26,7 +26,7 @@ Every key belongs to one of two environments, **production** or **sandbox**, tha
 - Production: `tempo:sk:...`
 - Sandbox: `tempo_sandbox:sk:...`
 
-### Production vs. Sandbox
+### Production and sandbox API keys
 
 | Property | Production | Sandbox |
 | --- | --- | --- |
@@ -37,7 +37,7 @@ Every key belongs to one of two environments, **production** or **sandbox**, tha
 
 Both environments grant the same scopes and quotas. The only difference is the set of chains a key may read.
 
-### Authenticating
+### Authenticate API requests
 
 Send the token in either header:
 
@@ -56,7 +56,7 @@ curl 'https://api.tempo.xyz/v1/blocks?chainId=testnet' \
   --header 'Authorization: Bearer tempo_sandbox:sk:...'
 ```
 
-### Behaviors
+### API authentication behaviors
 
 - **Production keys** work on any chain. A request that omits `chainId` targets mainnet.
 - **Sandbox keys** are restricted to non-mainnet chains.

--- a/src/pages/docs/api/conventions.mdx
+++ b/src/pages/docs/api/conventions.mdx
@@ -3,13 +3,13 @@ title: Conventions
 description: Formatting standards and shared patterns used across the Tempo API — base URL, chains, identifiers, amounts, timestamps, request IDs, errors, and rate limits.
 ---
 
-# Conventions
+# API Conventions
 
 The Tempo API follows consistent formatting rules for identifiers, amounts, timestamps, and shared query parameters. This page is a quick reference for the patterns you'll encounter on every endpoint.
 
 For authentication and pagination, see the dedicated [Authentication](/docs/api/authentication) and [Pagination](/docs/api/pagination) pages.
 
-## Base URL
+## Tempo API base URL
 
 The Tempo API is served from a single base URL, with endpoints versioned under the `/v1` prefix:
 
@@ -19,7 +19,7 @@ https://api.tempo.xyz/v1
 
 For example: `https://api.tempo.xyz/v1/tokens`. See the [Versioning Policy](/docs/api/versioning-policy) for how versions, breaking changes, and deprecations work.
 
-## Chains
+## Chain identifiers
 
 Tempo runs multiple chains. Select one per request with the `chainId` query parameter, which accepts a chain alias or a numeric chain id:
 
@@ -35,7 +35,7 @@ curl 'https://api.tempo.xyz/v1/blocks?chainId=testnet' \
 
 `chainId` defaults to `mainnet` when omitted. A sandbox API key steers an omitted `chainId` to `testnet` — see [Authentication](/docs/api/authentication) for how key environments interact with chain selection.
 
-## Identifiers
+## Resource identifiers
 
 On-chain identifiers are `0x`-prefixed lowercase hex strings. They are returned in lowercase, and are accepted case-insensitively on input.
 
@@ -49,7 +49,7 @@ On-chain identifiers are `0x`-prefixed lowercase hex strings. They are returned 
 Treat identifiers as opaque strings. Always compare them in lowercase, since the API normalizes them to lowercase on output.
 :::
 
-## Amounts
+## Token amount formats
 
 Token amounts are returned as **decimal strings in the token's smallest unit**, never as numbers. This preserves full precision for large values that exceed the range of a JSON number.
 
@@ -67,7 +67,7 @@ Never parse amounts into floating-point numbers. JSON floats lose precision for 
 
 Raw EVM quantities (such as gas values) use a `0x`-prefixed hexadecimal integer instead, for example `0x1a` (which is `26`).
 
-## Timestamps
+## API timestamp formats
 
 All datetime fields are returned in UTC, formatted as ISO 8601 with a `Z` suffix:
 
@@ -77,14 +77,14 @@ YYYY-MM-DDTHH:MM:SSZ
 
 For example: `2024-01-01T00:00:00Z`. Date-range query parameters accept the same ISO 8601 format.
 
-## Query Parameters
+## API query parameters
 
 A few conventions are shared by query parameters across endpoints:
 
 - **Booleans** are the literal strings `true` or `false` (for example, `?verified=true`).
 - **Opt-in fields** are requested with a comma-separated `include` parameter (for example, `?include=token,totalCount`). Expensive fields are computed only when you ask for them. The available values differ per endpoint and are documented on each operation.
 
-## Request IDs
+## API request IDs
 
 Every response carries a `tempo-request-id` header that uniquely identifies the request. Error responses also echo it as `requestId` in the body. Include this value when contacting support so a request can be traced.
 
@@ -92,10 +92,10 @@ Every response carries a `tempo-request-id` header that uniquely identifies the 
 tempo-request-id: 0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9
 ```
 
-## Errors
+## API error conventions
 
 Errors use a single, consistent envelope with a conventional HTTP status code and a stable, machine-readable `error.code` you branch on. See [Errors](/docs/api/errors) for the envelope and the full code catalog.
 
-## Rate Limits
+## API rate-limit conventions
 
 Every response carries standard `RateLimit-*` headers, and requests that exceed quota receive `429 Too Many Requests` with a `Retry-After` header. See [Rate Limits](/docs/api/rate-limits) for the full model and best practices.

--- a/src/pages/docs/api/errors.mdx
+++ b/src/pages/docs/api/errors.mdx
@@ -3,7 +3,7 @@ title: Errors
 description: How the Tempo API signals errors, including HTTP status codes, the error envelope, and the full catalog of machine-readable error codes.
 ---
 
-# Errors
+# API Errors
 
 The Tempo API uses conventional HTTP status codes to indicate the result of a request:
 
@@ -11,7 +11,7 @@ The Tempo API uses conventional HTTP status codes to indicate the result of a re
 - **`4xx`**: the request failed given the information provided (for example, a missing parameter or an unknown resource).
 - **`5xx`**: something went wrong on Tempo's side.
 
-## Error Response
+## API error response format
 
 Every error returns the same JSON envelope:
 
@@ -112,9 +112,9 @@ You exceeded the rate limit. The response carries a `Retry-After` header. See [R
 | `rate_limit_exceeded` | The request exceeded the quota for its window. |
 | `payment_required` | The request was over quota on an endpoint where payment is accepted but none was supplied. |
 
-## 5xx: Server Errors
+## 5xx: Tempo server errors
 
-Something went wrong on Tempo's side. These are transient. Retry with [exponential backoff](/docs/api/rate-limits#retry-with-backoff).
+Something went wrong on Tempo's side. These are transient. Retry with [exponential backoff](/docs/api/rate-limits#retry-rate-limited-requests-with-backoff).
 
 | Status | Code | Meaning |
 | --- | --- | --- |

--- a/src/pages/docs/api/indexer-api.mdx
+++ b/src/pages/docs/api/indexer-api.mdx
@@ -11,7 +11,7 @@ The Tempo API exposes an **Indexer entrypoint** for read-only SQL over chain dat
 This page explains what the indexer is and how it's organized. For the request/response contract of the API endpoint, see the [indexer query reference](/docs/api/indexer). For the full table schema, an interactive query console, and self-hosting, see the [Indexer guide](/docs/developer-tools/indexer).
 :::
 
-## Architecture
+## Indexer API architecture
 
 `tidx` writes the same chain data into two stores and routes each query to the right one:
 
@@ -40,7 +40,7 @@ The sync engine runs two jobs concurrently: a **realtime** loop that follows the
                   GET /v1/indexer/query
 ```
 
-## What it indexes
+## Tempo data the indexer API covers
 
 Every Tempo block is decoded into a set of **base tables**, available in both stores:
 
@@ -51,7 +51,7 @@ Every Tempo block is decoded into a set of **base tables**, available in both st
 | `logs` | EVM logs: block, log index, transaction hash, emitting contract, topics, data. |
 | `receipts` | Receipts: status, gas used, effective gas price, contract address, fee payer. |
 
-## Analytics tables
+## Indexer API analytics tables
 
 With `engine=clickhouse`, the indexer additionally exposes pre-computed tables maintained from the base data. These exist so common reads are sort-key seeks instead of full scans:
 
@@ -64,17 +64,17 @@ With `engine=clickhouse`, the indexer additionally exposes pre-computed tables m
 The typed REST endpoints (tokens, balances, activity, exchanges) are the stable, supported interface for these common reads. Query the analytics tables directly when you need custom SQL the REST endpoints don't cover.
 :::
 
-## Decoded events
+## Indexer API decoded events
 
 There are two ways to read decoded event data:
 
 - **Pre-decoded tables** — common events are decoded at insert time into ClickHouse tables such as `token_transfers` (`Transfer`), `token_approvals` (`Approval`), and the DEX tables. Prefer these when available.
 - **Query-time decoding** — pass a `signature` parameter and the indexer exposes the matching `logs` as a virtual table named after the event, so you can select its arguments directly. This works on either engine. See the [indexer query reference](/docs/api/indexer).
 
-## Querying
+## Querying the Indexer API
 
 Run read-only `SELECT` queries through [`GET /v1/indexer/query`](/docs/api/indexer), optionally streaming live as new blocks arrive over Server-Sent Events. Requests share the same [authentication](/docs/api/authentication), [rate limits](/docs/api/rate-limits), and `RateLimit-*` headers as the rest of the API. See the [indexer query reference](/docs/api/indexer) for parameters, response shape, live streaming, and errors.
 
-## Self-hosting
+## Self-hosting the indexer API
 
 `tidx` is open source and can run from Docker or source against your own PostgreSQL (and optional ClickHouse). See the [repository](https://github.com/tempoxyz/tidx) and the [Indexer guide](/docs/developer-tools/indexer) for configuration and deployment.

--- a/src/pages/docs/api/json-rpc.mdx
+++ b/src/pages/docs/api/json-rpc.mdx
@@ -16,7 +16,7 @@ Point any Ethereum-compatible client at the hosted entrypoint, or [run your own 
 | Mainnet | `https://api.tempo.xyz/rpc` |
 | Testnet | `https://api.tempo.xyz/rpc/testnet` |
 
-## Connecting via Tools
+## Connect to Tempo JSON-RPC with tools
 
 Use the Tempo JSON-RPC API with command-line tools, TypeScript clients, React hooks, or Rust providers.
 
@@ -102,6 +102,6 @@ Use the Tempo JSON-RPC API with command-line tools, TypeScript clients, React ho
   </Tab>
 </Tabs>
 
-## Endpoints
+## Tempo JSON-RPC endpoints
 
 <OpenApi.Endpoints path="/docs/api" resource="rpc" />

--- a/src/pages/docs/api/pagination.mdx
+++ b/src/pages/docs/api/pagination.mdx
@@ -3,11 +3,11 @@ title: Pagination
 description: Page through Tempo API list endpoints with cursors, page numbers, and optional total counts.
 ---
 
-# Pagination
+# API Pagination
 
 Tempo list endpoints share one pagination contract. Use **cursor** pagination for stable traversal and deep reads. Use **page** pagination only when an endpoint supports it and you need a shallow, page-numbered UI.
 
-## Modes
+## Tempo API pagination modes
 
 | Mode | Parameters | Use for | Notes |
 | --- | --- | --- | --- |
@@ -22,7 +22,7 @@ Page pagination is positional. If new rows arrive at the head of a feed, items c
 Do not send `cursor` and `page` together. The request fails with a `422` validation error.
 :::
 
-## Request Parameters
+## Pagination request parameters
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -31,7 +31,7 @@ Do not send `cursor` and `page` together. The request fails with a `422` validat
 | `page` | integer | none | 1-indexed positional page number. `page=1` is the head page. Mutually exclusive with `cursor`. `page × limit` must be at most `10,000`. |
 | `include` | string | none | Comma-separated include flags. Send `include=totalCount` to add `meta.totalCount` and `meta.totalCountCapped` to the response. |
 
-## Response Envelope
+## Pagination response envelope
 
 List endpoints return a common envelope:
 
@@ -57,7 +57,7 @@ List endpoints return a common envelope:
 `nextCursor === null` is the only end-of-list signal. Do not stop because `data` is shorter than `limit`, because `data` is empty, or because of `totalCount`.
 :::
 
-## Cursor Pagination
+## Cursor pagination for Tempo API lists
 
 Fetch the first page without a cursor:
 
@@ -101,7 +101,7 @@ Cursors are opaque. Store and pass them back exactly as received; do not decode,
 If a cursor is malformed or forged, the request starts again from the head instead of returning an error.
 :::
 
-## Page Pagination
+## Page pagination for shallow Tempo API lists
 
 Use `page` only for shallow, page-numbered interfaces:
 
@@ -118,7 +118,7 @@ curl 'https://api.tempo.xyz/v1/tokens?limit=25&page=2' \
 
 For anything deeper than `10,000` rows, use cursor pagination. Some endpoints support cursor pagination only — this is common when each returned item is derived from a variable number of underlying rows, which makes positional page boundaries unstable.
 
-## Counting Results
+## Count results in paginated responses
 
 Counts are optional. Request them with `include=totalCount`:
 
@@ -144,7 +144,7 @@ The count is computed by a capped subquery up to `10,000` matched rows:
 - When `meta.totalCountCapped` is `true`, `meta.totalCount` is a lower bound: there are at least that many matches.
 - Counts are independent of pagination. Use `nextCursor`, not `totalCount`, to decide whether to request another page.
 
-## Best Practices
+## Pagination best practices for Tempo API clients
 
 - Prefer cursor pagination for integrations, sync jobs, exports, and live feeds.
 - Use the largest `limit` your workload can handle, up to `200`, to reduce round trips.

--- a/src/pages/docs/api/rate-limits.mdx
+++ b/src/pages/docs/api/rate-limits.mdx
@@ -3,11 +3,11 @@ title: Rate Limits
 description: How the Tempo API rate limits requests, the headers it returns, and best practices for staying within quota.
 ---
 
-# Rate Limits
+# API Rate Limits
 
 The Tempo API enforces rate limits to ensure fair usage and system stability. Limits are counted in **fixed one-minute windows**, and every response reports your current quota in `RateLimit-*` headers.
 
-## Quota Structure
+## Tempo API quota structure
 
 Each request consumes from one quota bucket, chosen by how the request is authenticated:
 
@@ -23,7 +23,7 @@ Each request consumes from one quota bucket, chosen by how the request is authen
 Default limits are a starting point and may be raised for a given key. The authoritative limit for any request is always the value in its `RateLimit-Limit` response header — read the headers rather than hardcoding a number.
 :::
 
-## Response Headers
+## Rate-limit response headers
 
 Every rate-limited response carries your current quota:
 
@@ -41,7 +41,7 @@ RateLimit-Scope: data:read
 | `RateLimit-Reset` | Unix timestamp (seconds) when the window resets and the count returns to the full limit. |
 | `RateLimit-Scope` | The scope bucket the request was counted against. Present on API-key requests. |
 
-## Exceeding the Limit
+## Exceeding Tempo API rate limits
 
 When you exceed the limit, the API responds with `429 Too Many Requests` and a `Retry-After` header giving the number of seconds to wait before retrying:
 
@@ -64,13 +64,13 @@ Retry-After: 12
 On endpoints that allow anonymous access, an over-quota request can instead be answered with `402 Payment Required`, letting you pay per request with MPP rather than wait. See [Authentication](/docs/api/authentication) for details.
 :::
 
-## Best Practices
+## Rate-limit best practices for Tempo API clients
 
-### Respect the headers
+### Respect rate-limit headers
 
 Read `RateLimit-Remaining` and `RateLimit-Reset` to pace your requests, and pause until `RateLimit-Reset` when `RateLimit-Remaining` reaches `0` rather than retrying blindly.
 
-### Retry with backoff
+### Retry rate-limited requests with backoff
 
 When you receive a `429`, wait for the duration in `Retry-After`, then retry with exponential backoff and jitter for repeated failures:
 
@@ -89,12 +89,12 @@ async function withRetry<T>(fn: () => Promise<Response>): Promise<Response> {
 }
 ```
 
-### Cache and paginate
+### Cache and paginate API reads
 
 - Cache responses for read-heavy data that does not need to be real-time.
 - Use [pagination](/docs/api/pagination) with a large `limit` to fetch more per request instead of issuing many small calls.
 - Request only the fields you need with `include`, so expensive computations run only when required.
 
-### Authenticate
+### Authenticate for higher API quotas
 
 Anonymous traffic is held to the lower IP-based limit. Send an [API key](/docs/api/authentication) to get a per-key, per-scope quota, and request a higher limit if your workload needs it.

--- a/src/pages/docs/api/transactions-and-transfers.mdx
+++ b/src/pages/docs/api/transactions-and-transfers.mdx
@@ -11,7 +11,7 @@ Transactions and transfers are the two most common resources in the Tempo API, a
 **Transactions vs. transfers** — a transaction is what a user *submits*; transfers are what *happens* when it executes. One transaction can produce zero, one, or many token transfers. Use [`/v1/transactions`](/docs/api/transactions) to inspect submitted transactions and their outcomes, and [`/v1/transfers`](/docs/api/transfers) to list the token movements that resulted.
 :::
 
-## The model
+## Tempo transaction and transfer model
 
 - A **transaction** is what a user submits to Tempo: a signed envelope that moves value or calls a contract. It may produce zero, one, or many token transfers. Query [`/v1/transfers`](/docs/api/transfers) to list the token movements it caused.
 - A **transfer** is an effect of transaction execution: a TIP-20 token moved from one account to another. Multiple transfers can come from a single transaction, and some transactions produce no transfers at all.
@@ -29,7 +29,7 @@ A transaction that calls a contract might emit several transfers (for example, a
                                                   resolves back to its transaction
 ```
 
-## When to use which
+## When to use transactions or transfers
 
 | | Transaction | Transfer |
 | --- | --- | --- |

--- a/src/pages/docs/build.mdx
+++ b/src/pages/docs/build.mdx
@@ -7,11 +7,11 @@ import { Cards, Card } from 'vocs'
 
 # Build on Tempo
 
-Use this section when you are designing payment experiences or payment infrastructure on Tempo. The guides here focus on what your product should do: move stablecoins, issue assets, exchange liquidity, isolate activity in private zones, or let agents pay for services.
+Use this section when you are designing payment experiences or payment infrastructure on Tempo. The guides here focus on what your product needs to do: move stablecoins, issue assets, exchange liquidity, isolate activity in private zones, or let agents pay for services.
 
 Start with **Make Payments** if you are not sure where to begin. It covers the core transfer flow and introduces the payment primitives used throughout the rest of the docs.
 
-## Payment Workflows
+## Core Build Paths
 
 <Cards>
   <Card
@@ -33,20 +33,20 @@ Start with **Make Payments** if you are not sure where to begin. It covers the c
     icon="lucide:arrow-left-right"
   />
   <Card
-    title="Private Zones"
-    description="Connect to zones, deposit funds, send tokens privately, bridge, swap, and withdraw."
-    to="/docs/guide/private-zones"
-    icon="lucide:lock-keyhole"
-  />
-  <Card
     title="Agentic Payments"
     description="Accept one-time, pay-as-you-go, and streamed payments through the Machine Payments Protocol."
     to="/docs/guide/machine-payments"
     icon="lucide:bot"
   />
+  <Card
+    title="Private Zones"
+    description="Connect to zones, deposit funds, send tokens privately, bridge, swap, and withdraw."
+    to="/docs/guide/private-zones"
+    icon="lucide:lock-keyhole"
+  />
 </Cards>
 
-## Before You Ship
+## Production Essentials
 
 <Cards>
   <Card
@@ -62,15 +62,21 @@ Start with **Make Payments** if you are not sure where to begin. It covers the c
     icon="lucide:layers"
   />
   <Card
-    title="Configure Receive Policies"
-    description="Control which tokens and senders an account can receive for TIP-20 transfers."
-    to="/docs/guide/payments/configure-receive-policies"
-    icon="lucide:shield-check"
-  />
-  <Card
     title="Pay Fees in Any Stablecoin"
     description="Use Tempo's fee system to pay transaction fees with supported stablecoins."
     to="/docs/guide/payments/pay-fees-in-any-stablecoin"
     icon="lucide:badge-dollar-sign"
+  />
+  <Card
+    title="Sponsor User Fees"
+    description="Let your app or service pay transaction fees on behalf of users."
+    to="/docs/guide/payments/sponsor-user-fees"
+    icon="lucide:heart-handshake"
+  />
+  <Card
+    title="Configure Receive Policies"
+    description="Control which tokens and senders an account can receive for TIP-20 transfers."
+    to="/docs/guide/payments/configure-receive-policies"
+    icon="lucide:shield-check"
   />
 </Cards>

--- a/src/pages/docs/cli/download.mdx
+++ b/src/pages/docs/cli/download.mdx
@@ -9,13 +9,13 @@ Download chain snapshots for faster initial sync. Fetches MDBX state and static 
 
 Running `tempo download` without a snapshot profile opens an interactive component selector. Passing a profile flag such as `--minimal` or `--archive` skips the selector. Validators should use `--minimal`. RPC providers, indexers, and other workloads that need complete historical data should use `--archive`.
 
-## Usage
+## `tempo download` usage
 
 ```bash
 tempo download [flags]
 ```
 
-## Flags
+## `tempo download` flags
 
 | Flag | Description |
 | --- | --- |
@@ -70,7 +70,7 @@ tempo download --chain moderato --minimal --force
 If you are unsure which pruning configuration your validator is running, reach out to the Tempo team before replacing snapshot data.
 :::
 
-## Examples
+## `tempo download` examples
 
 Open the interactive selector for mainnet:
 

--- a/src/pages/docs/cli/index.mdx
+++ b/src/pages/docs/cli/index.mdx
@@ -13,7 +13,7 @@ The `tempo` binary covers three core workflows:
 - **`tempo request`** — make paid HTTP requests with automatic [MPP](https://mpp.dev/overview) payment negotiation
 - **`tempo node`** / **`tempo download`** — run and sync a Tempo node
 
-## Install
+## Install the Tempo CLI
 
 :::code-group
 ```bash [Terminal]
@@ -41,7 +41,7 @@ codex exec "Read https://tempo.xyz/SKILL.md and set up tempo"
 
 All commands support `--help` for documentation and `--describe` for JSON command schemas. For scripts and agents, pass `-t` (`--toon-output`) to get compact, machine-readable output, and use `--dry-run` or `--max-spend` before paid calls.
 
-## Commands
+## Tempo CLI commands
 
 Dive into each command:
 

--- a/src/pages/docs/cli/node.mdx
+++ b/src/pages/docs/cli/node.mdx
@@ -49,7 +49,7 @@ Flags grouped by function:
 | `--telemetry-metrics-interval <dur>` | Metrics push interval (default: `10s`) |
 | `--metrics <port>` | Enable Prometheus metrics on this port |
 
-## Examples
+## `tempo node` examples
 
 Download a snapshot and start an RPC node:
 
@@ -70,7 +70,7 @@ tempo node --datadir /data/tempo \
   --consensus.fee-recipient 0x...
 ```
 
-## Learn more
+## Learn more about Tempo node operations
 
 <Cards>
   <Card

--- a/src/pages/docs/cli/request.mdx
+++ b/src/pages/docs/cli/request.mdx
@@ -11,7 +11,7 @@ A curl-compatible HTTP client that handles [Machine Payments Protocol](https://m
 
 Requires [`tempo wallet login`](/docs/cli/wallet) first. Use [`tempo wallet services`](/docs/cli/wallet#discover-services) before calling paid endpoints so agents and scripts use registered URLs, methods, pricing, and request schemas instead of guessing.
 
-## Usage
+## `tempo request` usage
 
 | Command | Description |
 | --- | --- |
@@ -21,7 +21,7 @@ Requires [`tempo wallet login`](/docs/cli/wallet) first. Use [`tempo wallet serv
 | `tempo request -X POST <url> --json '{...}'` | Send a JSON body |
 | `tempo request <url> -H 'Header: Value'` | Add a custom header |
 
-## Flags
+## `tempo request` flags
 
 | Flag | Description |
 | --- | --- |
@@ -33,7 +33,7 @@ Requires [`tempo wallet login`](/docs/cli/wallet) first. Use [`tempo wallet serv
 | `-D <file>` / `--dump-header <file>` | Write response headers, useful for inspecting MPP challenges |
 | `-t` / `--toon-output` | Compact machine-readable output for scripts and agents |
 
-## Examples
+## `tempo request` examples
 
 Preview cost before paying:
 
@@ -62,7 +62,7 @@ tempo request -t --dry-run -D "$headers" -X POST \
 
 Discover the right URL and request schema first with [`tempo wallet services`](/docs/cli/wallet#discover-services).
 
-## Learn more
+## Learn more about paid Tempo requests
 
 <Cards>
   <Card

--- a/src/pages/docs/cli/wallet.mdx
+++ b/src/pages/docs/cli/wallet.mdx
@@ -13,13 +13,13 @@ Tempo Wallet CLI is the command-line way to use [Tempo Wallet](https://wallet.te
   <Card
     title="Download"
     description="Install the Tempo launcher and wallet extensions"
-    to="#download"
+    to="#download-the-tempo-wallet-cli"
     icon="lucide:download"
   />
   <Card
     title="Authenticate"
     description="Connect to your Tempo Wallet"
-    to="#authenticate"
+    to="#authenticate-with-tempo-wallet-cli"
     icon="lucide:log-in"
   />
   <Card
@@ -37,7 +37,7 @@ Tempo Wallet CLI is the command-line way to use [Tempo Wallet](https://wallet.te
   <Card
     title="Add Funds"
     description="Fund your wallet or transfer tokens"
-    to="#add-funds"
+    to="#add-wallet-funds"
     icon="lucide:plus-circle"
   />
   <Card
@@ -54,7 +54,7 @@ Tempo Wallet CLI is the command-line way to use [Tempo Wallet](https://wallet.te
   />
 </Cards>
 
-## Download
+## Download the Tempo Wallet CLI
 
 ```bash
 curl -fsSL https://tempo.xyz/install | bash
@@ -62,7 +62,7 @@ curl -fsSL https://tempo.xyz/install | bash
 
 The launcher manages `tempo wallet` and `tempo request` extensions. To update later, run `tempoup`. Verify with `tempo --version`.
 
-## Authenticate
+## Authenticate with Tempo Wallet CLI
 
 ```bash
 tempo wallet login
@@ -115,7 +115,7 @@ tempo wallet revoke <ACCESS_KEY_ADDRESS>
 
 Each wallet can have multiple access keys with independent spending limits. Use scoped keys to constrain what an agent or script can spend, and revoke keys that are stale or no longer needed.
 
-## Add funds
+## Add wallet funds
 
 ```bash
 tempo wallet fund
@@ -197,9 +197,9 @@ tempo wallet -t transfer --credits --dry-run --mpp-challenge-file "$headers"
 tempo wallet -t transfer --credits --mpp-challenge-file "$headers"
 ```
 
-## Command reference
+## Tempo Wallet CLI command reference
 
-### Authentication
+### Wallet authentication commands
 
 | Command | Description |
 | --- | --- |
@@ -210,7 +210,7 @@ tempo wallet -t transfer --credits --mpp-challenge-file "$headers"
 | `tempo wallet whoami` | Print readiness, address, balances, and key state |
 | `tempo wallet whoami --credits` | Print MPP Credits balance |
 
-### Keys
+### Wallet key commands
 
 | Command | Description |
 | --- | --- |
@@ -218,7 +218,7 @@ tempo wallet -t transfer --credits --mpp-challenge-file "$headers"
 | `tempo wallet revoke <access-key> --dry-run` | Preview access-key revocation |
 | `tempo wallet revoke <access-key>` | Revoke an access key |
 
-### Funds
+### Wallet funding commands
 
 | Command | Description |
 | --- | --- |
@@ -228,7 +228,7 @@ tempo wallet -t transfer --credits --mpp-challenge-file "$headers"
 | `tempo wallet transfer <amount> <token> <to>` | Transfer tokens to another address |
 | `tempo wallet transfer --credits --mpp-challenge-file <file>` | Pay an MPP challenge with credits |
 
-### Services
+### Wallet service discovery commands
 
 | Command | Description |
 | --- | --- |
@@ -236,7 +236,7 @@ tempo wallet -t transfer --credits --mpp-challenge-file "$headers"
 | `tempo wallet services --search <query>` | Filter services by keyword |
 | `tempo wallet services <id>` | Show endpoints, methods, and request schemas |
 
-### Sessions
+### Wallet session commands
 
 | Command | Description |
 | --- | --- |
@@ -246,14 +246,14 @@ tempo wallet -t transfer --credits --mpp-challenge-file "$headers"
 | `tempo wallet sessions close --orphaned` | Close sessions whose counterparty is unreachable |
 | `tempo wallet sessions close --finalize` | Finalize channels pending close |
 
-### Advanced
+### Advanced wallet commands
 
 | Command | Description |
 | --- | --- |
 | `tempo wallet debug` | Collect debug info for support |
 | `tempo wallet completions <shell>` | Generate shell completions |
 
-## Learn more
+## Learn more about Tempo Wallet CLI
 
 <Cards>
   <Card

--- a/src/pages/docs/developer-tools/fee-payer.mdx
+++ b/src/pages/docs/developer-tools/fee-payer.mdx
@@ -9,7 +9,7 @@ import { Cards, Card } from 'vocs'
 
 Tempo Labs provides hosted fee payer endpoints for applications that want to sponsor Tempo transaction fees without running fee payer infrastructure.
 
-## Hosted endpoints
+## Hosted fee payer endpoints
 
 The hosted endpoints are JSON-RPC relays that fill, sponsor, and broadcast Tempo Transactions. They are CORS-enabled and return standard JSON-RPC responses.
 
@@ -18,13 +18,13 @@ The hosted endpoints are JSON-RPC relays that fill, sponsor, and broadcast Tempo
 | Mainnet | `https://sponsor.tempo.xyz/tp_<api_key>` | `4217` | Approved integrations with an API key |
 | Testnet | `https://sponsor.moderato.tempo.xyz` | `42431` | Public development and testing |
 
-### Rate limits and policy
+### Hosted fee payer rate limits and policy
 
 Hosted fee payer endpoints are rate-limited and may reject requests that fall outside the configured sponsorship policy.
 
 Clients should avoid retry loops, back off after errors, and treat sponsorship as conditional. If sponsorship is rejected, the client should either let the user pay their own fee or retry through an application-owned fee payer.
 
-### Pricing and access
+### Hosted fee payer pricing and access
 
 The public testnet fee payer is free for development and testing.
 
@@ -38,7 +38,7 @@ const feePayerUrl = `https://sponsor.tempo.xyz/${feePayerToken}`
 
 Do not send the fee payer token as a bearer token or another request header. The hosted fee payer authenticates the key from the path segment.
 
-## Using in production
+## Use a fee payer in production
 
 Run your own fee payer when you need:
 
@@ -49,9 +49,9 @@ Run your own fee payer when you need:
 
 See [Sponsor User Fees](/docs/guide/payments/sponsor-user-fees) to deploy your own fee payer service.
 
-## Configure clients
+## Configure clients for hosted fee sponsorship
 
-### Tempo Wallet
+### Tempo Wallet fee sponsorship
 
 ```ts twoslash [wagmi.config.ts]
 import { tempo } from 'viem/chains'
@@ -71,7 +71,7 @@ export const config = createConfig({
 })
 ```
 
-### WebAuthn or custom transports
+### WebAuthn or custom fee payer transports
 
 Use [`withRelay`](https://viem.sh/tempo/transports/withRelay) to route transaction fill and sponsorship requests through the hosted fee payer.
 
@@ -95,9 +95,9 @@ export const config = createConfig({
 
 For testnet development, use `https://sponsor.moderato.tempo.xyz` without an API key.
 
-## Query the fee payer
+## Query the hosted fee payer
 
-### Chain ID
+### Query the fee payer chain ID
 
 ```bash
 curl -X POST "https://sponsor.tempo.xyz/tp_<api_key>" \
@@ -105,7 +105,7 @@ curl -X POST "https://sponsor.tempo.xyz/tp_<api_key>" \
   -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
 ```
 
-### Fill a sponsored transaction
+### Fill a sponsored Tempo transaction
 
 `eth_fillTransaction` returns a filled Tempo transaction plus metadata describing whether the request is sponsored.
 
@@ -128,7 +128,7 @@ curl -X POST "https://sponsor.tempo.xyz/tp_<api_key>" \
 
 A sponsored response includes `capabilities.sponsored: true` and sponsor metadata.
 
-## API reference
+## Hosted fee payer API reference
 
 | Method | Description |
 | --- | --- |
@@ -142,13 +142,13 @@ A sponsored response includes `capabilities.sponsored: true` and sponsor metadat
 Fee sponsorship requires a Tempo Transaction. The sender signs with sponsorship enabled, then the fee payer counter-signs with `feePayerSignature`.
 :::
 
-## How it works
+## How hosted fee sponsorship works
 
 Tempo Transactions support native fee sponsorship through a separate fee payer signature. The user signs the transaction first, leaving fee token selection to the fee payer. The hosted fee payer validates the request, chooses the fee token, signs the fee payer payload, and either returns the completed transaction or broadcasts it depending on the JSON-RPC method.
 
 No paymaster contract, bundler, or EntryPoint contract is required.
 
-## Next steps
+## Next steps for fee sponsorship
 
 <Cards>
   <Card icon="lucide:wallet" title="Sponsor User Fees" description="Build gasless payment flows and deploy your own fee payer service." to="/docs/guide/payments/sponsor-user-fees" />

--- a/src/pages/docs/developer-tools/indexer.mdx
+++ b/src/pages/docs/developer-tools/indexer.mdx
@@ -13,7 +13,7 @@ For developers building on Tempo, Tempo Labs provides a free indexing service bu
 
 Use it when you need block, transaction, log, token, holder, or decoded event data without running your own indexing pipeline.
 
-## Hosted endpoints
+## Hosted `tidx` endpoints
 
 The public hosted endpoints are unauthenticated, read-only, and CORS-enabled.
 
@@ -22,21 +22,21 @@ The public hosted endpoints are unauthenticated, read-only, and CORS-enabled.
 | Mainnet | `https://indexer.tempo.xyz` | `4217` |
 | Testnet | `https://indexer.testnet.tempo.xyz` | `42431` |
 
-### Rate limits
+### Hosted `tidx` rate limits
 
 The public hosted endpoints are rate-limited. Responses include `X-Ratelimit-Limit`, `X-Ratelimit-Remaining`, and `X-Ratelimit-Reset` headers.
 
 Clients should keep queries bounded, include explicit `LIMIT` clauses, avoid polling expensive aggregates, and back off when remaining quota is low.
 
-### Pricing
+### Hosted `tidx` pricing
 
 Requests within the public rate limit are free. When a client exceeds the free quota, the hosted indexer returns an MPP challenge for paid overflow access at `$0.001` per request.
 
 Use an MPP-capable client, such as `tempo request`, for paid overflow traffic. Plain `curl` and browser requests can use the free quota, but they will not automatically pay a `402 Payment Required` challenge.
 
-## Query `tidx`
+## Query Tempo data with `tidx`
 
-### Latest blocks
+### Latest Tempo blocks
 
 ```bash
 curl -G "https://indexer.tempo.xyz/query" \
@@ -45,7 +45,7 @@ curl -G "https://indexer.tempo.xyz/query" \
   --data-urlencode "sql=SELECT num, hash, timestamp FROM blocks ORDER BY num DESC LIMIT 5"
 ```
 
-### Decoded events
+### Decoded Tempo events
 
 ```bash
 curl -G "https://indexer.tempo.xyz/query" \
@@ -55,19 +55,19 @@ curl -G "https://indexer.tempo.xyz/query" \
   --data-urlencode 'sql=SELECT arg0 AS from_address, arg1 AS to_address, arg2 AS value, block_num, tx_hash FROM Transfer ORDER BY block_num DESC LIMIT 5'
 ```
 
-### Health check
+### `tidx` health check
 
 ```bash
 curl "https://indexer.tempo.xyz/health"
 ```
 
-## Interactive example
+## Interactive `tidx` SQL example
 
 Run live SQL against the hosted indexer.
 
 <TidxQuery />
 
-## API reference
+## `tidx` API reference
 
 | Endpoint | Description |
 | --- | --- |
@@ -90,7 +90,7 @@ Run live SQL against the hosted indexer.
 Creating or deleting materialized views is only available from trusted infrastructure. Use the hosted endpoints for read-only queries, or run your own `tidx` instance when you need custom view management.
 :::
 
-## Run your own indexer
+## Run your own Tempo indexer
 
 The [`tidx` repository](https://github.com/tempoxyz/tidx) includes Docker, source build, configuration, CLI, schema, and materialized view docs.
 
@@ -102,7 +102,7 @@ docker run -v $(pwd)/config.toml:/config.toml ghcr.io/tempoxyz/tidx up
 
 See the [`tidx` README](https://github.com/tempoxyz/tidx) for the full setup guide and CLI reference.
 
-## How it works
+## How `tidx` indexes Tempo data
 
 `tidx` writes chain data into two stores:
 
@@ -113,7 +113,7 @@ The `/query` endpoint accepts SQL and can expose decoded events on demand throug
 
 `tidx` also maintains ClickHouse materialized tables for expensive common reads, such as token balances, token holders, supply, approvals, and address activity.
 
-## Next steps
+## Next steps for Tempo indexing
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/issuance/create-a-stablecoin.mdx
+++ b/src/pages/docs/guide/issuance/create-a-stablecoin.mdx
@@ -1,4 +1,5 @@
 ---
+title: Create a Stablecoin
 description: Create your own stablecoin on Tempo using TIP-20 tokens. Deploy tokens with built-in compliance features and role-based permissions.
 interactive: true
 ---
@@ -15,7 +16,7 @@ Create your own stablecoin on Tempo using [TIP-20 Tokens](/docs/protocol/tip20/o
 TIP-20 tokens are designed specifically for payments with built-in compliance features, role-based permissions,
 and integration with Tempo's payment infrastructure.
 
-## Demo
+## Stablecoin creation demo
 
 By the end of this guide, you will be able to create a stablecoin on Tempo.
 
@@ -25,11 +26,11 @@ By the end of this guide, you will be able to create a stablecoin on Tempo.
   <CreateToken stepNumber={3} last />
 </Demo.Container>
 
-## Steps
+## Stablecoin creation steps
 
 ::::steps
 
-### Set up Wagmi
+### Set up Wagmi for stablecoin creation
 
 Ensure that you have set up your project with Wagmi, a Tempo chain config, and a wallet connector:
 
@@ -37,7 +38,7 @@ Ensure that you have set up your project with Wagmi, a Tempo chain config, and a
 - [TypeScript SDK](/docs/sdk/typescript)
 - [Wallet integration](/docs/quickstart/wallet-developers)
 
-### Add testnet funds¹
+### Add testnet funds for deployment¹
 
 Before we send off a transaction to deploy our stablecoin to the Tempo testnet, we need to make sure our account is funded with a stablecoin to cover the transaction fee. 
 
@@ -91,7 +92,7 @@ export const config = createConfig({
 started quickly. For production, you will need to onramp & fund your account manually.
 :::
 
-### Add form fields
+### Add stablecoin form fields
 
 Now that we have some funds to cover the transaction fee in our account, we can create a stablecoin.
 
@@ -145,7 +146,7 @@ export const config = createConfig({
 
 :::
 
-### Add submission logic
+### Add stablecoin deployment logic
 
 Now that we have some input fields, we need to add some logic to handle the submission of the form to create the stablecoin.
 
@@ -213,7 +214,7 @@ export const config = createConfig({
 
 :::
 
-### Add success state
+### Add stablecoin creation success state
 
 Now that users can submit the form and create a stablecoin, let's add a basic success state to display 
 the name of the stablecoin and a link to the transaction receipt.
@@ -279,18 +280,18 @@ export const config = createConfig({
 
 :::
 
-### Next steps
+### Next steps after creating a stablecoin
 
 Now that you have created your first stablecoin, you can now:
 - [Add your token to the Token List](/docs/quickstart/tokenlist#adding-a-new-token) so it appears in wallets, explorers, and other apps on Tempo
-- learn the [Best Practices](#best-practices) below
+- learn the [Best Practices](#stablecoin-creation-best-practices) below
 - follow a guide on how to [mint](/docs/guide/issuance/mint-stablecoins) and [more](/docs/guide/issuance/manage-stablecoin) with your stablecoin.
 
 ::::
 
-## Best Practices
+## Stablecoin creation best practices
 
-### Loading State
+### Stablecoin creation loading state
 
 When the user is creating a stablecoin, we should show loading state to indicate that the process is happening.
 
@@ -305,7 +306,7 @@ We can use the `isPending` property from the `useCreateSync` hook to show pendin
 </button>
 ```
 
-### Error Handling
+### Stablecoin creation error handling
 
 If an error unexpectedly occurs, we should display an error message to the user.
 
@@ -323,7 +324,7 @@ export function CreateStablecoin() {
 }
 ```
 
-## Learning Resources
+## Stablecoin creation learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/issuance/distribute-rewards.mdx
+++ b/src/pages/docs/guide/issuance/distribute-rewards.mdx
@@ -1,4 +1,5 @@
 ---
+title: Distribute Rewards
 description: Distribute rewards to token holders using TIP-20's built-in reward mechanism. Allocate tokens proportionally based on holder balances.
 interactive: true
 ---
@@ -20,7 +21,7 @@ Distribute rewards to token holders using TIP-20's built-in reward distribution 
 
 Rewards can be distributed by anyone on any TIP-20 token, and claimed by any holder who has opted in. This guide covers both the reward distributor and token holder use cases. While the demo below uses a token you create, the same principles apply to any token.
 
-## Demo
+## Rewards distribution demo
 
 Try out the complete rewards flow: create a token, opt in to receive rewards on it, create a reward for yourself, and claim it.
 
@@ -35,15 +36,15 @@ Try out the complete rewards flow: create a token, opt in to receive rewards on 
   <ClaimReward stepNumber={8} flowDependencies={['rewardId']} last />
 </Demo.Container>
 
-## Steps
+## Rewards distribution steps
 
 ::::steps
 
-### [Optional] Create a Stablecoin
+### [Optional] Create a reward token
 
 If you would like to distribute rewards on a token you have created, follow the [Create a Stablecoin](/docs/guide/issuance/create-a-stablecoin) guide to deploy your token.
 
-### Tell Your Users to Opt In to Rewards
+### Tell users to opt in to rewards
 
 Token holders must opt in to receive rewards by setting their reward recipient address. This is typically set to their own address.
 
@@ -98,7 +99,7 @@ export const config = createConfig({
 
 :::
 
-### Make a Reward Distribution
+### Make a stablecoin reward distribution
 
 Anyone can make a reward distribution that allocates tokens to all opted-in holders proportionally based on their balance.
 
@@ -156,7 +157,7 @@ export const config = createConfig({
 
 :::
 
-### Your Users Can Claim Rewards
+### Let users claim stablecoin rewards
 
 Once a reward is distributed, opted-in holders can claim their share.
 
@@ -209,7 +210,7 @@ export const config = createConfig({
 
 ::::
 
-## Recipes
+## Rewards distribution recipes
 
 ### Watch for new reward distributions
 
@@ -257,7 +258,7 @@ function WatchOptIns() {
 }
 ```
 
-## Learning Resources
+## Rewards distribution learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/issuance/index.mdx
+++ b/src/pages/docs/guide/issuance/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: Stablecoin Issuance
 description: Create and manage your own stablecoin on Tempo. Issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
 ---
 
@@ -6,32 +7,45 @@ import { Cards, Card } from 'vocs'
 
 # Stablecoin Issuance
 
-Create and manage your own stablecoin on Tempo. Learn how to issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
+Create and manage your own stablecoin on Tempo. Launch the token first, then configure fees, rewards, roles, supply controls, and transfer policies.
+
+## Launch a Stablecoin
 
 <Cards>
   <Card
-    description="Create your own stablecoin using TIP-20 tokens with built-in compliance features"
+    description="Create your own stablecoin using TIP-20 tokens with built-in compliance features."
     to="/docs/guide/issuance/create-a-stablecoin"
     icon="lucide:coins"
     title="Create a Stablecoin"
   />
 
   <Card
-    description="Mint new tokens to increase supply and distribute your stablecoin"
+    description="Mint new tokens to increase supply and distribute your stablecoin."
     to="/docs/guide/issuance/mint-stablecoins"
     icon="lucide:plus"
     title="Mint Stablecoins"
   />
 
   <Card
-    description="Enable users to pay transaction fees using your stablecoin"
+    description="Enable users to pay transaction fees using your stablecoin."
     to="/docs/guide/issuance/use-for-fees"
     icon="lucide:circle-dollar-sign"
     title="Use Your Stablecoin for Fees"
   />
+</Cards>
+
+## Operate a Stablecoin
+
+<Cards>
+  <Card
+    description="Distribute Tempo Token Rewards to users or liquidity providers for eligible activity."
+    to="/docs/guide/issuance/distribute-rewards"
+    icon="lucide:gift"
+    title="Distribute Rewards"
+  />
 
   <Card
-    description="Manage roles, permissions, supply caps, and transfer policies for your stablecoin"
+    description="Manage roles, permissions, supply caps, and transfer policies for your stablecoin."
     to="/docs/guide/issuance/manage-stablecoin"
     icon="lucide:settings"
     title="Manage Your Stablecoin"

--- a/src/pages/docs/guide/issuance/manage-stablecoin.mdx
+++ b/src/pages/docs/guide/issuance/manage-stablecoin.mdx
@@ -1,4 +1,5 @@
 ---
+title: Manage Your Stablecoin
 description: Configure stablecoin permissions, supply limits, and compliance policies. Grant roles, set transfer policies, and control pause/unpause functionality.
 interactive: true
 ---
@@ -23,19 +24,19 @@ Configure your stablecoin's permissions, supply limits, and compliance policies 
 
 TIP-20 tokens use a role-based access control system that allows you to delegate different administrative functions to different addresses. For detailed information about the role system, see the [TIP-20 specification](/docs/protocol/tip20/spec#role-based-access-control).
 
-## Steps
+## Stablecoin management steps
 
 In this guide, we'll walk through how to assign and check the **`issuer`** role, but the process is identical for other roles like `pause`, `unpause`, `burnBlocked`, and `defaultAdmin`.
 
 ::::steps
 
-### Setup
+### Set up stablecoin management
 
 Before you can manage roles on your stablecoin, you need to create one. Follow the [Create a Stablecoin](/docs/guide/issuance/create-a-stablecoin) guide to deploy your token.
 
 Once you've created your token, you can proceed to grant roles to specific addresses.
 
-### Grant Roles to an Address
+### Grant stablecoin roles to an address
 
 Assign roles to specific addresses to delegate token management capabilities.
 
@@ -98,7 +99,7 @@ export const config = createConfig({
 
 :::
 
-### Check if an Address Has a Role
+### Check stablecoin roles for an address
 
 Use `hasRole` to verify whether an address has been granted a specific role.
 
@@ -175,7 +176,7 @@ export const config = createConfig({
 
 :::
 
-### Revoke the Issuer Role
+### Revoke the stablecoin issuer role
 
 Revoke roles from addresses when you need to remove their permissions.
 
@@ -288,13 +289,13 @@ export const config = createConfig({
 
 ::::
 
-## Recipes
+## Stablecoin management recipes
 
-### Set the Token Logo
+### Set the stablecoin logo
 
 Set or update the token's on-chain `logoURI` so wallets and explorers can read the icon directly from the token contract via `logoURI()`. This requires the **`DEFAULT_ADMIN_ROLE`** and is done by calling `setLogoURI(string newLogoURI)` on the token ([TIP-1026](https://tips.sh/1026)). For the recommended format, use a square, rasterized PNG or WebP (max 256 bytes; `https`, `http`, `ipfs`, or `data` scheme).
 
-### Set Supply Cap
+### Set the stablecoin supply cap
 
 Limit the maximum total supply of your token. Setting supply caps requires the **`DEFAULT_ADMIN_ROLE`**. The new cap cannot be less than the current total supply.
 
@@ -359,7 +360,7 @@ export const config = createConfig({
 
 :::
 
-### Configure Transfer Policies
+### Configure stablecoin transfer policies
 
 Control who can send and receive your stablecoin for compliance and regulatory requirements. Setting transfer policies requires the **`DEFAULT_ADMIN_ROLE`**.
 
@@ -466,7 +467,7 @@ export const config = createConfig({
 
 :::
 
-### Pause and Unpause Token Transfers
+### Pause and unpause stablecoin transfers
 
 Temporarily halt all token transfers during emergency situations or maintenance windows. Pausing transfers requires the **`PAUSE_ROLE`**. Unpausing transfers requires the **`UNPAUSE_ROLE`**.
 
@@ -544,7 +545,7 @@ export const config = createConfig({
 
 :::
 
-### Using the Burn Blocked Role
+### Use the stablecoin burn-blocked role
 
 The Burn Blocked role allows your team to burn tokens from blocked or frozen addresses. This is useful for regulatory compliance when you need to remove tokens from addresses that violate terms of service or legal requirements.
 
@@ -616,21 +617,21 @@ export const config = createConfig({
 
 :::
 
-## Best Practices
+## Stablecoin management best practices
 
-### Role Separation
+### Stablecoin role separation
 
 Use different addresses for different roles to enhance security. For example, assign the issuer role to your treasury address for minting, and the pause role to your security team for emergency controls.
 
-### Event Monitoring
+### Stablecoin event monitoring
 
 Monitor onchain events for role changes, mints, burns, and administrative actions to maintain visibility into token operations and detect unauthorized activities.
 
-### Emergency Procedures
+### Stablecoin emergency procedures
 
 Ensure pause and unpause roles are assigned to trusted addresses and that your team has documented procedures for responding to security incidents requiring token transfers to be halted.
 
-## Learning Resources
+## Stablecoin management learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/issuance/manage-stablecoin.mdx
+++ b/src/pages/docs/guide/issuance/manage-stablecoin.mdx
@@ -360,6 +360,8 @@ export const config = createConfig({
 
 :::
 
+<span id="configure-transfer-policies" />
+
 ### Configure stablecoin transfer policies
 
 Control who can send and receive your stablecoin for compliance and regulatory requirements. Setting transfer policies requires the **`DEFAULT_ADMIN_ROLE`**.

--- a/src/pages/docs/guide/issuance/mint-stablecoins.mdx
+++ b/src/pages/docs/guide/issuance/mint-stablecoins.mdx
@@ -1,4 +1,5 @@
 ---
+title: Mint Stablecoins
 description: Mint new tokens to increase your stablecoin's total supply. Grant the issuer role and create tokens with optional memos for tracking.
 interactive: true
 ---
@@ -16,17 +17,17 @@ import { Cards, Card } from 'vocs'
 
 Create new tokens by minting them to a specified address. Minting increases the total supply of your stablecoin.
 
-## Steps
+## Stablecoin minting steps
 
 ::::steps
 
-### Create a Stablecoin
+### Create the stablecoin to mint
 
 Before you can mint tokens, you need to create a stablecoin. Follow the [Create a Stablecoin](/docs/guide/issuance/create-a-stablecoin) guide to deploy your token.
 
 Once you've created your token, you can proceed to grant the issuer role and mint tokens.
 
-### Grant the Issuer Role
+### Grant the stablecoin issuer role
 
 Assign the issuer role to the address that will mint tokens. Minting requires the **`ISSUER_ROLE`**.
 
@@ -96,7 +97,7 @@ export const config = createConfig({
 
 :::
 
-### Mint Tokens to a Recipient
+### Mint stablecoins to a recipient
 
 Now that the issuer role is granted, you can mint tokens to any address.
 
@@ -260,9 +261,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ::::
 
-## Recipes
+## Stablecoin minting recipes
 
-### Burning Stablecoins
+### Burn stablecoins
 
 To decrease supply, you can burn tokens from your own balance. Burning requires the **`ISSUER_ROLE`** and sufficient balance in the caller's account.
 
@@ -407,9 +408,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 :::
 
-## Best Practices
+## Stablecoin minting best practices
 
-### Monitor Supply Caps
+### Monitor stablecoin supply caps
 
 If your token has a supply cap set, any `mint()` or `mintWithMemo()` call that would exceed the cap will revert with `SupplyCapExceeded()`. You must either:
 - Burn tokens to reduce total supply below the cap
@@ -418,11 +419,11 @@ If your token has a supply cap set, any `mint()` or `mintWithMemo()` call that w
 
 Use [`getMetadata`](https://viem.sh/tempo/actions/token.getMetadata) to check your token's total supply before minting.
 
-### Role Separation
+### Separate stablecoin roles
 
 Assign the issuer role to dedicated treasury or minting addresses separate from your admin address. This enhances security by limiting the privileges of any single address.
 
-## Learning Resources
+## Stablecoin minting learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/issuance/use-for-fees.mdx
+++ b/src/pages/docs/guide/issuance/use-for-fees.mdx
@@ -1,4 +1,5 @@
 ---
+title: Use Your Stablecoin for Fees
 description: Enable users to pay transaction fees using your stablecoin. Add fee pool liquidity and integrate with Tempo's flexible fee payment system.
 interactive: true
 ---
@@ -17,7 +18,7 @@ import { PayWithIssuedToken } from '../../../../components/guides/steps/payments
 
 Enable users to pay transaction fees using your stablecoin. Tempo supports flexible fee payment options, allowing users to pay fees in any stablecoin they hold.
 
-## Demo
+## Fee-token stablecoin demo
 
 <Demo.Container name="Use Your Stablecoin for Fees" footerVariant="source" src="tempoxyz/examples/tree/main/examples/issuance">
   <Connect stepNumber={1} />
@@ -29,15 +30,15 @@ Enable users to pay transaction fees using your stablecoin. Tempo supports flexi
   <PayWithIssuedToken stepNumber={7} last />
 </Demo.Container>
 
-## Steps
+## Fee-token stablecoin setup steps
 
 ::::steps
 
-### Create your stablecoin
+### Create your fee-token stablecoin
 
 First, create and mint your stablecoin by following the [Create a Stablecoin](/docs/guide/issuance/create-a-stablecoin) guide.
 
-### Add fee pool liquidity
+### Add Fee AMM liquidity
 
 Before users can pay fees with your token, you need to provide liquidity in the Fee AMM between your token and a liquid quote token, or directly against validator payout tokens where you want explicit direct-route coverage.
 
@@ -117,7 +118,7 @@ require(reserveValidator > 0, "No liquidity available for fee conversion");
 
 If the pool has no liquidity (`reserveValidatorToken == 0`), you'll need to add liquidity to the fee pool before users can pay fees with your token. See the [Create a Stablecoin](/docs/guide/issuance/create-a-stablecoin) guide for instructions on minting fee AMM liquidity.
 
-### Send payment with your token as fee
+### Send a payment using your stablecoin as the fee token
 
 Your users can send payments using your issued stablecoin as the fee token:
 
@@ -283,7 +284,7 @@ Users can set your stablecoin as their default fee token at the account level, o
 
 ::::
 
-## How It Works
+## How stablecoin fee payments work
 
 When users pay transaction fees with your stablecoin, Tempo's fee system automatically handles the conversion if validators prefer a different token. The [Fee AMM](/docs/protocol/fees/spec-fee-amm) ensures seamless fee payments across all supported stablecoins.
 
@@ -294,13 +295,13 @@ Users can select your stablecoin as their fee token through:
 
 Learn more about [how users pay fees in different stablecoins](/docs/guide/payments/pay-fees-in-any-stablecoin) and the complete [fee token preference hierarchy](/docs/protocol/fees/spec-fee#fee-token-preferences).
 
-## Benefits
+## Benefits of stablecoin fee tokens
 
 - **User convenience**: Users can pay fees with the same token they're using
 - **Liquidity**: Encourages users to hold your stablecoin
 - **Flexibility**: Works seamlessly with Tempo's fee system
 
-## Best Practices
+## Stablecoin fee-token best practices
 
 ### Monitor pool liquidity
 
@@ -320,7 +321,7 @@ Before promoting fee payments with your token, thoroughly test the flow on testn
 3. Execute test transactions with various gas costs
 4. Monitor that fee conversions work correctly
 
-## Next Steps
+## Next steps for stablecoin fee tokens
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/agent.mdx
+++ b/src/pages/docs/guide/machine-payments/agent.mdx
@@ -11,13 +11,13 @@ The `tempo` CLI handles `402 Payment Required` responses the same way the client
 
 ::::steps
 
-### Install the CLI
+### Install the Tempo CLI
 
 ```bash
 curl -fsSL https://tempo.xyz/install | bash
 ```
 
-### Log in
+### Log in to Tempo Wallet
 
 ```bash
 tempo wallet login
@@ -30,7 +30,7 @@ tempo wallet whoami
 If your balance is zero, run `tempo wallet fund` before making requests.
 :::
 
-### Discover services
+### Discover MPP services
 
 ```bash
 tempo wallet services --search ai
@@ -41,7 +41,7 @@ The service directory shows endpoint URLs, HTTP methods, pricing, and request sc
 
 For MCP-capable agents, see [Discover MPP services](/docs/guide/machine-payments/discover-services) to connect the read-only services MCP server at `https://mpp.dev/mcp/services`.
 
-### Preview cost
+### Preview the MPP request cost
 
 ```bash
 tempo request --dry-run -X POST \
@@ -51,7 +51,7 @@ tempo request --dry-run -X POST \
 
 `--dry-run` validates the request and shows the payment cost without spending.
 
-### Make a paid request
+### Make an MPP paid request
 
 ```bash
 tempo request -X POST \
@@ -81,7 +81,7 @@ Read https://tempo.xyz/SKILL.md and set up tempo
 
 Once installed, the agent can discover services, preview costs, and make paid requests within scoped spending limits.
 
-## Next steps
+## Next steps for agentic payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/client.mdx
+++ b/src/pages/docs/guide/machine-payments/client.mdx
@@ -11,7 +11,7 @@ Polyfill `fetch` to handle `402` responses. Your existing code works unchanged â
 
 ::::steps
 
-### Install dependencies
+### Install MPP client dependencies
 
 :::code-group
 ```bash [npm]
@@ -25,7 +25,7 @@ bun add mppx viem
 ```
 :::
 
-### Define an account
+### Define the MPP payer account
 
 ```ts
 import { privateKeyToAccount } from 'viem/accounts'
@@ -37,7 +37,7 @@ const account = privateKeyToAccount('0xabcâ€¦123')
 With Tempo, you can also use passkey or WebCrypto signing.
 :::
 
-### Create payment handler
+### Create the MPP payment handler
 
 Call `Mppx.create` at startup. This polyfills `fetch` to automatically handle `402` payment challenges.
 
@@ -65,7 +65,7 @@ const response = await mppx.fetch('https://api.example.com/resource')
 ```
 :::
 
-### Request protected resources
+### Request MPP-protected resources
 
 Use `fetch`. Payment happens when a server returns `402`.
 
@@ -75,9 +75,9 @@ const response = await fetch('https://api.example.com/resource')
 
 ::::
 
-## Learn more
+## Advanced MPP client patterns
 
-### Wagmi
+### Use MPP with Wagmi
 
 You can inject a [Wagmi](https://wagmi.sh) connector into Mppx by passing the `getConnectorClient` function.
 
@@ -111,7 +111,7 @@ export const config = createConfig({
 
 :::
 
-### Per-request accounts
+### Use per-request payer accounts
 
 Pass accounts on individual requests instead of at setup:
 
@@ -131,7 +131,7 @@ const response = await mppx.fetch('https://api.example.com/resource', {
 })
 ```
 
-### Manual payment handling
+### Handle MPP payments manually
 
 Use `Mppx.create` for full control over the payment flow:
 
@@ -161,7 +161,7 @@ if (response.status === 402) {
 }
 ```
 
-### Payment receipts
+### Read MPP payment receipts
 
 On success, the server returns a `Payment-Receipt` header:
 
@@ -178,7 +178,7 @@ console.log(receipt.reference)
 // 0xtx789abc...
 ```
 
-## Next steps
+## Next steps for MPP clients
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/discover-services.mdx
+++ b/src/pages/docs/guide/machine-payments/discover-services.mdx
@@ -194,7 +194,7 @@ The MCP server only helps with discovery and planning. The target service's runt
 
 ::::
 
-## Example recipes
+## MPP service discovery example recipes
 
 | Agent task | Start with | Then call |
 | --- | --- | --- |
@@ -204,7 +204,7 @@ The MCP server only helps with discovery and planning. The target service's runt
 | Map a `402` recipient back to services | `get_services_by_recipient` | `get_offers` and `get_service` for the matching provider |
 | Build custom catalog analytics | `get_facets` and `get_catalog_status` | Fetch [`https://mpp.dev/api/services`](https://mpp.dev/api/services) directly |
 
-## Agent prompts
+## Agent prompts for MPP discovery
 
 Give your agent a task and tell it to use the services MCP server first:
 
@@ -227,7 +227,7 @@ services, why each matched, whether pricing is fixed or dynamic, and the next MC
 tool call you would make before constructing the HTTP request.
 ```
 
-## MCP tools
+## MCP tools for MPP service discovery
 
 | Tool | Purpose |
 | --- | --- |
@@ -249,7 +249,7 @@ Use the web directory when a human is exploring the catalog. Use the public API 
 
 For execution, call services directly with [`tempo request`](/docs/cli/request), the [MPP client quickstart](/docs/guide/machine-payments/client), or another MPP-capable client. Discovery narrows the choice; the service's runtime `402` challenge confirms the exact payment terms.
 
-## Next steps
+## Next steps for MPP service discovery
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/index.mdx
+++ b/src/pages/docs/guide/machine-payments/index.mdx
@@ -11,7 +11,7 @@ import { TerminalDemo } from '../../../../components/TerminalDemo'
 
 Make agentic payments using the [Machine Payments Protocol](https://mpp.dev) (MPP). MPP adds inline payments to any HTTP endpoint — agents, apps, or humans pay as part of their request, and the server verifies payment before returning the response.
 
-## Try it out
+## Try an agentic payment
 
 See the full payment flow in action. The terminal creates an ephemeral wallet, funds it with testnet USDG, and makes a paid request to fetch a photo.
 
@@ -19,7 +19,7 @@ See the full payment flow in action. The terminal creates an ephemeral wallet, f
   <TerminalDemo />
 </div>
 
-## Payment flow
+## MPP payment flow
 
 A client requests a paid resource, the server responds with `402` and a `Challenge` describing the price. The client pays, retries with a `Credential` transaction, and the server returns the resource with a `Receipt`.
 
@@ -40,7 +40,7 @@ A client requests a paid resource, the server responds with `402` and a `Challen
 4. **Retry** — Client re-sends with `Authorization: Payment` header containing the Credential
 5. **Deliver** — Server verifies, returns `200` with `Payment-Receipt` header
 
-## Why Tempo
+## Why Tempo for agentic payments
 
 Tempo's transaction model is designed for agentic payments using MPP:
 
@@ -50,7 +50,7 @@ Tempo's transaction model is designed for agentic payments using MPP:
 - **2D and expiring nonces** — Parallel nonce lanes prevent payment transactions from blocking other account activity
 - **High throughput** — Supports the on-chain settlement volume that payment channels generate at scale
 
-## Payment intents
+## MPP payment intents on Tempo
 
 Two [intents](https://mpp.dev/protocol#payment-intents) are available on Tempo:
 
@@ -61,13 +61,13 @@ Two [intents](https://mpp.dev/protocol#payment-intents) are available on Tempo:
 | **Best for** | Single API calls, content access, one-off purchases | LLM APIs, metered services, usage-based billing |
 | **On-chain cost** | Per request | Amortized across many requests |
 
-## Use cases
+## Agentic payment use cases
 
 - **Paid APIs** — Charge per request without API keys, billing accounts, or signup flows.
 - **MCP tools** — Monetize tool calls served through the Model Context Protocol. Agents pay per call without OAuth or account setup.
 - **Digital content** — Charge per access for articles, data feeds, or media without subscription paywalls.
 
-## Get started
+## Get started with MPP on Tempo
 
 <Cards>
   <Card
@@ -108,7 +108,7 @@ Two [intents](https://mpp.dev/protocol#payment-intents) are available on Tempo:
   />
 </Cards>
 
-## SDKs and tools
+## MPP SDKs and tools
 
 | Tool | Package | Install |
 |-----|---------|---------|
@@ -119,7 +119,7 @@ Two [intents](https://mpp.dev/protocol#payment-intents) are available on Tempo:
 
 See the [full SDK documentation](https://mpp.dev/sdk) for API reference and advanced usage.
 
-## Learn more
+## Learn more about MPP
 
 - [MPP documentation](https://mpp.dev) — Full protocol docs, SDK reference, and guides
 - [IETF specs](https://paymentauth.org/) — Normative protocol specification

--- a/src/pages/docs/guide/machine-payments/one-time-payments.mdx
+++ b/src/pages/docs/guide/machine-payments/one-time-payments.mdx
@@ -9,11 +9,11 @@ import { Card, Cards } from 'vocs'
 
 Build a payment-gated API that charges $0.01 per request using `mppx`. The server returns a random photo from [Picsum](https://picsum.photos) behind a paywall.
 
-## Server setup
+## One-time payment server setup
 
 ::::steps
 
-### Install dependencies
+### Install one-time payment dependencies
 
 :::code-group
 ```bash [npm]
@@ -27,7 +27,7 @@ bun add mppx viem
 ```
 :::
 
-### Set up `Mppx` instance
+### Set up an `Mppx` charge instance
 
 Set up an `Mppx` instance with the `tempo` method.
 
@@ -45,7 +45,7 @@ const mppx = Mppx.create({
 })
 ```
 
-### Add a payment-gated route
+### Add a one-time payment route
 
 Add payment verification using `mppx.charge` as route middleware. The handler only runs after payment is verified.
 
@@ -142,7 +142,7 @@ Bun.serve({
 
 :::
 
-### Test the endpoint
+### Test the one-time payment endpoint
 
 ```bash
 # Create account funded with testnet tokens
@@ -154,7 +154,7 @@ $ npx mppx http://localhost:3000/api/photo
 
 ::::
 
-## Next steps
+## Next steps for one-time payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/pay-as-you-go.mdx
+++ b/src/pages/docs/guide/machine-payments/pay-as-you-go.mdx
@@ -14,7 +14,7 @@ Build a payment-gated photo gallery API that charges $0.01 per photo using `mppx
 Unlike [one-time payments](/docs/guide/machine-payments/one-time-payments), sessions open a payment channel once and use off-chain vouchers for each subsequent request — vouchers are processed in pure CPU-bound signature checks, not bottlenecked by blockchain throughput.
 :::
 
-## How sessions work
+## How pay-as-you-go sessions work
 
 <MermaidDiagram chart={`sequenceDiagram
     participant Client
@@ -42,11 +42,11 @@ Unlike [one-time payments](/docs/guide/machine-payments/one-time-payments), sess
 3. **Top up** — If the channel runs low, the client deposits additional tokens without closing the channel
 4. **Close** — Either party closes the channel, settling the final balance on-chain and refunding unused deposit
 
-## Server setup
+## Pay-as-you-go server setup
 
 ::::steps
 
-### Install dependencies
+### Install pay-as-you-go dependencies
 
 :::code-group
 ```bash [npm]
@@ -60,7 +60,7 @@ bun add mppx viem
 ```
 :::
 
-### Set up `Mppx` instance
+### Set up an `Mppx` session instance
 
 Set up an `Mppx` instance with the `tempo` method.
 
@@ -78,7 +78,7 @@ const mppx = Mppx.create({
 })
 ```
 
-### Add a session-gated route
+### Add a pay-as-you-go route
 
 Add payment verification using `mppx.session` as route middleware. The handler only runs after payment is verified.
 
@@ -175,7 +175,7 @@ Bun.serve({
 
 :::
 
-### Test the endpoint
+### Test the pay-as-you-go endpoint
 
 ```bash
 # Create account funded with testnet tokens
@@ -187,7 +187,7 @@ $ npx mppx http://localhost:3000/api/sessions/photo
 
 ::::
 
-## Client setup
+## Pay-as-you-go client setup
 
 When using sessions from a client, set `maxDeposit` to enable automatic channel management. This is the maximum amount of tokens the client locks into the payment channel's reserve contract. Any unspent deposit is refunded when the channel closes.
 
@@ -212,7 +212,7 @@ const res = await fetch('http://localhost:3000/api/sessions/photo')
 - The client handles the full session lifecycle automatically: channel open, voucher signing, and retry after `402` responses.
 - If the server sets `suggestedDeposit`, the client uses `min(suggestedDeposit, maxDeposit)`.
 
-## Next steps
+## Next steps for pay-as-you-go payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/server.mdx
+++ b/src/pages/docs/guide/machine-payments/server.mdx
@@ -9,7 +9,7 @@ import { Card, Cards } from 'vocs'
 
 Plug MPP into any server framework to accept payments for protected resources. Use `mppx` middleware for your framework, or call `mppx/server` directly with the Fetch API.
 
-## Framework middleware
+## MPP server framework middleware
 
 Use the framework-specific middleware from `mppx` to integrate payment into your server. Each middleware handles the `402` challenge/credential flow and attaches receipts automatically.
 
@@ -83,7 +83,7 @@ mppx.charge({
 ```
 :::
 
-## Manual mode
+## Manual MPP server mode
 
 If you prefer full control over the payment flow, use `mppx/server` directly with the Fetch API.
 
@@ -112,7 +112,7 @@ export async function handler(request: Request) {
 `currency` is the TIP-20 token contract address — [`0x20c0…`](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000000?live=false) is PathUSD on Tempo. `recipient` is the address that receives payment. See the [Tempo payment method](https://mpp.dev/payment-methods/tempo) for supported tokens.
 :::
 
-## Realm
+## MPP payment realm
 
 The `realm` identifies your server in payment challenges and on-chain attribution. By default, mppx auto-detects it from environment variables (`HOSTNAME`, `VERCEL_URL`, etc.), but this can produce incorrect values in containerized environments where `HOSTNAME` is set to an internal identifier (e.g. a Kubernetes pod name).
 
@@ -130,7 +130,7 @@ const mppx = Mppx.create({
 
 You can also set the `MPP_REALM` environment variable instead of passing it in code.
 
-## Push & pull modes
+## MPP push and pull modes
 
 Tempo charges support two transaction submission modes, determined by the client:
 
@@ -139,7 +139,7 @@ Tempo charges support two transaction submission modes, determined by the client
 
 Your server handles both modes automatically — no configuration required. The server inspects the credential payload type (`transaction` for pull, `hash` for push) and verifies accordingly.
 
-### Fee sponsorship
+### MPP fee sponsorship
 
 To sponsor gas fees for pull-mode clients, pass a `feePayer` account to `tempo()`:
 
@@ -158,7 +158,7 @@ const mppx = Mppx.create({
 
 When a pull-mode client submits a signed transaction, the server co-signs with the fee payer account before broadcasting. Push-mode clients pay their own gas, so `feePayer` is ignored for those requests.
 
-## Testing your server
+## Test your MPP server
 
 After your server is running, test it with the `mppx` CLI:
 
@@ -174,7 +174,7 @@ $ npx mppx <your-server>/resource
 Use `npx mppx --inspect` to debug your server's Challenge response without making any payments.
 :::
 
-## Next steps
+## Next steps for MPP servers
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/streamed-payments.mdx
+++ b/src/pages/docs/guide/machine-payments/streamed-payments.mdx
@@ -14,7 +14,7 @@ Build a payment-gated API that streams content word-by-word and charges $0.001 p
 Streamed payments extend [pay-as-you-go sessions](/docs/guide/machine-payments/pay-as-you-go) with SSE. The server charges per token as content streams — if the channel balance runs out mid-stream, the client automatically sends a new voucher and the stream resumes.
 :::
 
-## How sessions work
+## How streamed payment sessions work
 
 <MermaidDiagram chart={`sequenceDiagram
     participant Client
@@ -46,11 +46,11 @@ Streamed payments extend [pay-as-you-go sessions](/docs/guide/machine-payments/p
 3. **Top up** — If the channel runs low mid-stream, the server emits a `payment-need-voucher` event and the client automatically signs a new voucher
 4. **Close** — Either party closes the channel, settling the final balance on-chain and refunding unused deposit
 
-## Server setup
+## Streamed payment server setup
 
 ::::steps
 
-### Install dependencies
+### Install streamed payment dependencies
 
 :::code-group
 ```bash [npm]
@@ -64,7 +64,7 @@ bun add mppx viem
 ```
 :::
 
-### Set up `Mppx` instance with streaming
+### Set up an `Mppx` streaming instance
 
 Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
@@ -80,7 +80,7 @@ const mppx = Mppx.create({
 })
 ```
 
-### Add a streaming route
+### Add a streamed payment route
 
 The handler returns an async generator — each yielded value becomes one SSE event and is charged one tick ($0.001). If the channel balance runs out mid-stream, the server emits `event: payment-need-voucher` and pauses until the client sends a new voucher.
 
@@ -253,7 +253,7 @@ Bun.serve({
 
 :::
 
-### Test the endpoint
+### Test the streamed payment endpoint
 
 ```bash
 # Create account funded with testnet tokens
@@ -265,7 +265,7 @@ $ npx mppx http://localhost:3000/api/sessions/poem
 
 ::::
 
-## Client setup
+## Streamed payment client setup
 
 Use `tempo.session()` from `mppx/client` to create a session manager. The `.sse()` method connects to the SSE endpoint and handles voucher renewal automatically — if the server requests a new voucher mid-stream, the client signs and sends one without interrupting the stream.
 
@@ -290,7 +290,7 @@ for await (const word of stream) {
 - **`.sse()`** — Connects to an SSE endpoint. Automatically sends new vouchers when the server emits `payment-need-voucher` events.
 - **`maxDeposit: '1'`** — Locks up to 1 pathUSD. At $0.001/word, this covers ~1,000 words before the channel needs a top-up.
 
-## Next steps
+## Next steps for streamed payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/agent-to-agent.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/agent-to-agent.mdx
@@ -9,22 +9,22 @@ import { Card, Cards } from 'vocs'
 
 Let your agents hire other agents — for coding, design, writing, research, and email — pay per task with stablecoins on Tempo. No platform accounts, no human intermediaries.
 
-## The problem
+## The agent-to-agent payment problem
 
 Agent-to-agent commerce barely exists today. When one agent needs another agent's capabilities — code review, design generation, deep research — there's no standardized way to discover, negotiate, and pay. Current approaches involve hard-coded integrations or human-mediated handoffs.
 
-## How MPP solves it
+## How MPP coordinates agent-to-agent services
 
 MPP provides the payment layer for agent-to-agent commerce. Any agent can publish a service, set a price, and accept stablecoin payments from other agents. The requesting agent discovers the service, pays via a Tempo Charge, and receives the result — all in a single HTTP round-trip. No accounts, no API keys, no human involvement.
 
-## Available services
+## Agent-to-agent services you can pay for
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
 | [Auto.exchange](https://api.auto.exchange) | Discover and hire agents for coding, design, writing | `api.auto.exchange` |
 | [AgentMail](https://mpp.api.agentmail.to) | Email inboxes for AI agents | `mpp.api.agentmail.to` |
 
-## Try it
+## Try agent-to-agent hiring with Tempo
 
 ```bash
 # Install Tempo CLI + wallet
@@ -35,14 +35,14 @@ tempo request api.auto.exchange/v1/tasks \
   -d '{"task": "Review this Python function for bugs", "code": "def add(a, b): return a - b"}'
 ```
 
-## Prompt your agent
+## Prompt your agent to hire another agent
 
 ```
 Use api.auto.exchange to hire another agent via Tempo.
 Pay per task with stablecoins — no account needed.
 ```
 
-## Next steps
+## Next steps for agent-to-agent payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/ai-model-access.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/ai-model-access.mdx
@@ -9,17 +9,17 @@ import { Card, Cards } from 'vocs'
 
 Give your agents access to any LLM — OpenAI, Anthropic, Gemini, DeepSeek, Mistral, and more — without managing API keys, billing accounts, or usage limits. MPP lets agents pay per token with stablecoins on Tempo, and the model provider gets paid instantly.
 
-## The problem
+## The AI model payment problem
 
 Every LLM provider requires a separate API key, billing account, and credit card on file. For a single developer this is manageable. For a fleet of autonomous agents, it's a bottleneck: each agent needs its own credentials, each provider has different billing cycles, and rate limits are tied to account tiers rather than willingness to pay.
 
-## How MPP solves it
+## How MPP enables paid AI model access
 
 With MPP, your agent holds a stablecoin balance on Tempo and pays per request. No signup, no API keys, no invoices. The agent discovers the model's price via the `402` Challenge, pays with a stablecoin transfer or session voucher, and gets the response — all in a single HTTP round-trip.
 
 **Tempo Sessions** are ideal for LLM access. The agent opens a payment channel once, then signs off-chain vouchers for each chunk of tokens received. The model provider verifies vouchers in microseconds — no blockchain calls during inference — and settles in batch later. This makes per-token billing practical without adding latency.
 
-## Available services
+## AI model services you can pay for
 
 | Provider | Models | Service URL |
 |---|---|---|
@@ -32,7 +32,7 @@ With MPP, your agent holds a stablecoin balance on Tempo and pays per request. N
 | Grok | xAI chat, search, code exec | `grok.mpp.tempo.xyz` |
 | [Perplexity](https://perplexity.mpp.paywithlocus.com) | Sonar search + grounding | `perplexity.mpp.paywithlocus.com` |
 
-## Try it
+## Try paid AI model access with Tempo
 
 ```bash
 # Install Tempo CLI + wallet
@@ -43,14 +43,14 @@ tempo request openai.mpp.tempo.xyz/v1/chat/completions \
   -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy AI model access
 
 ```
 Use openai.mpp.tempo.xyz to call GPT-4o via Tempo.
 Pay per request with stablecoins — no API key needed.
 ```
 
-## Next steps
+## Next steps for AI model payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/blockchain-data.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/blockchain-data.mdx
@@ -9,17 +9,17 @@ import { Card, Cards } from 'vocs'
 
 Access on-chain data — token prices, wallet analytics, DEX trades, stablecoin flows, and smart contract events — from any MPP-enabled blockchain data provider. Pay per query with stablecoins on Tempo.
 
-## The problem
+## The blockchain data payment problem
 
 Blockchain data APIs gate access behind API keys, developer accounts, and monthly subscription tiers. Agents that need to query multiple providers — one for wallet balances, another for DEX analytics, a third for historical prices — must manage separate credentials and billing for each. Free tiers run out fast, and upgrading means committing to monthly plans before knowing actual usage.
 
-## How MPP solves it
+## How MPP enables paid blockchain data
 
 With MPP, your agent pays per query. No accounts, no API keys, no tier commitments. The agent calls any blockchain data provider, pays with a stablecoin transfer on Tempo, and gets the data back in the same response.
 
 **Tempo Charge** is a natural fit for data queries: each request has a known cost, settlement takes ~500ms, and the agent only pays for queries it actually makes.
 
-## Available services
+## Blockchain data services you can pay for
 
 | Provider | Data | Service URL |
 |---|---|---|
@@ -29,7 +29,7 @@ With MPP, your agent pays per query. No accounts, no API keys, no tier commitmen
 | [Dune](https://api.dune.com) | Raw transactions, decoded events, stablecoin flows, DeFi | `api.dune.com` |
 | [Codex](https://graph.codex.io) | Token data, prediction markets, charts, wallet analytics | `graph.codex.io` |
 
-## Try it
+## Try Alchemy with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -40,14 +40,14 @@ tempo request mpp.alchemy.com/v2 \
   -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy blockchain data
 
 ```
 Use agents.allium.so to query token prices and wallet balances via Tempo.
 Pay per query with stablecoins — no API key needed.
 ```
 
-## Next steps
+## Next steps for blockchain data payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/browser-automation.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/browser-automation.mdx
@@ -9,15 +9,15 @@ import { Card, Cards } from 'vocs'
 
 Let your agents run headless browser sessions, solve CAPTCHAs, and scrape web pages with geo-targeting — pay per task with stablecoins on Tempo. No API keys, no browser infrastructure to manage.
 
-## The problem
+## The browser automation payment problem
 
 Browser automation at scale requires managing headless browser infrastructure, proxy networks, and CAPTCHA-solving services — each with separate accounts, API keys, and billing. Agents that need to interact with the web face a fragmented stack of tools, each requiring its own integration.
 
-## How MPP solves it
+## How MPP enables paid browser automation
 
 With MPP, your agent pays per browser session, per page scrape, or per CAPTCHA solve using stablecoins on Tempo. The agent sends a request, the service returns its price via a `402` Challenge, the agent pays, and the work is done. No infrastructure setup, no API key management.
 
-## Available services
+## Browser automation services you can pay for
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
@@ -27,7 +27,7 @@ With MPP, your agent pays per browser session, per page scrape, or per CAPTCHA s
 | Firecrawl | Web crawling and structured data extraction | `firecrawl.mpp.tempo.xyz` |
 | [Diffbot](https://diffbot.mpp.paywithlocus.com) | Article, product, and discussion extraction | `diffbot.mpp.paywithlocus.com` |
 
-## Try it
+## Try Oxylabs with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -38,14 +38,14 @@ tempo request oxylabs.mpp.tempo.xyz/v1/queries \
   -d '{"source": "universal", "url": "https://example.com"}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy browser automation
 
 ```
 Use mpp.browserbase.com to run headless browser sessions via Tempo.
 Pay per session with stablecoins — no account needed.
 ```
 
-## Next steps
+## Next steps for browser automation payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/compute-and-code-execution.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/compute-and-code-execution.mdx
@@ -9,17 +9,17 @@ import { Card, Cards } from 'vocs'
 
 Let your agents run code in sandboxed environments, deploy containers, and access GPU compute — pay per use with stablecoins on Tempo. No cloud accounts, no billing dashboards, no credit cards.
 
-## The problem
+## The compute payment problem
 
 Cloud compute requires account creation, billing setup, and credential management before running a single line of code. For agents that need to execute code snippets, deploy temporary services, or run GPU workloads, the overhead of provisioning cloud accounts is disproportionate to the task. Sandbox environments like CodeSandbox or Replit target human developers, not programmatic access.
 
-## How MPP solves it
+## How MPP enables paid code execution
 
 With MPP, your agent pays per execution or per compute-minute with stablecoins on Tempo. Submit code, pay, get results — all in one HTTP request. No accounts, no API keys, no cloud provider onboarding.
 
 **Tempo Charge** works well for discrete tasks like running a code snippet. For longer-running workloads or metered compute, **Tempo Sessions** let the agent pay incrementally as resources are consumed.
 
-## Available services
+## Compute services you can pay for
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
@@ -27,7 +27,7 @@ With MPP, your agent pays per execution or per compute-minute with stablecoins o
 | [Judge0](https://judge0.mpp.paywithlocus.com) | Code execution in 60+ languages, sandboxed | `judge0.mpp.paywithlocus.com` |
 | [Build With Locus](https://mpp.buildwithlocus.com) | Containers, Postgres, Redis, custom domains | `mpp.buildwithlocus.com` |
 
-## Try it
+## Try Judge0 with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -38,14 +38,14 @@ tempo request judge0.mpp.paywithlocus.com/submissions \
   -d '{"source_code": "print(42)", "language_id": 71}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy code execution
 
 ```
 Use judge0.mpp.paywithlocus.com to run Python code via Tempo.
 Pay per execution with stablecoins — no account needed.
 ```
 
-## Next steps
+## Next steps for compute payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/data-enrichment-and-leads.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/data-enrichment-and-leads.mdx
@@ -9,15 +9,15 @@ import { Card, Cards } from 'vocs'
 
 Let your agents enrich contacts, find emails, profile companies, and search LinkedIn — pay per lookup with stablecoins on Tempo. No API keys, no monthly minimums, no seat-based pricing.
 
-## The problem
+## The data enrichment payment problem
 
 Sales and marketing data APIs charge monthly subscriptions with per-seat pricing, even when usage is sporadic. An agent that enriches 50 leads one week and zero the next still pays the same monthly fee. Each provider requires its own account, API key, and billing setup.
 
-## How MPP solves it
+## How MPP enables paid data enrichment
 
 With MPP, your agent pays per enrichment request. Look up a company, enrich a contact, verify an email — each operation is a single paid HTTP request. No contracts, no minimums, no wasted spend during quiet periods.
 
-## Available services
+## Data enrichment services you can pay for
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
@@ -28,7 +28,7 @@ With MPP, your agent pays per enrichment request. Look up a company, enrich a co
 | [Email Reputation](https://abstract-email-reputation.mpp.paywithlocus.com) | Email reputation and risk scoring | `abstract-email-reputation.mpp.paywithlocus.com` |
 | [BuiltWith](https://builtwith.mpp.paywithlocus.com) | Technology profiling for 100M+ websites | `builtwith.mpp.paywithlocus.com` |
 
-## Try it
+## Try Apollo with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -39,14 +39,14 @@ tempo request apollo.mpp.paywithlocus.com/v1/organizations/enrich \
   -d '{"domain": "tempo.xyz"}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy lead enrichment
 
 ```
 Use apollo.mpp.paywithlocus.com to enrich company data via Tempo.
 Pay per lookup with stablecoins — no API key needed.
 ```
 
-## Next steps
+## Next steps for data enrichment payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/financial-data.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/financial-data.mdx
@@ -9,15 +9,15 @@ import { Card, Cards } from 'vocs'
 
 Access real-time stock prices, forex rates, crypto market data, SEC filings, and economic indicators — pay per request with stablecoins on Tempo. No API keys, no subscriptions, no billing accounts.
 
-## The problem
+## The financial data payment problem
 
 Financial data is fragmented across dozens of providers, each with its own API key, pricing tier, and billing cycle. Agents that need multi-source data — stock prices from one provider, SEC filings from another, crypto data from a third — face credential sprawl and unpredictable monthly bills. Free tiers are limited, and most providers require credit cards before returning a single data point.
 
-## How MPP solves it
+## How MPP enables paid financial data
 
 With MPP, your agent pays per data request using stablecoins on Tempo. No signup, no API keys. Point your agent at any MPP-enabled financial data provider, and it handles the rest: price discovery via the `402` Challenge, payment via a TIP-20 transfer, and data delivery in the same response.
 
-## Available services
+## Financial data services you can pay for
 
 | Provider | Data | Service URL |
 |---|---|---|
@@ -27,7 +27,7 @@ With MPP, your agent pays per data request using stablecoins on Tempo. No signup
 | [EDGAR Full-Text](https://edgar-search.mpp.paywithlocus.com) | 10-K, 10-Q, 8-K, proxy statement search | `edgar-search.mpp.paywithlocus.com` |
 | [Exchange Rates](https://abstract-exchange-rates.mpp.paywithlocus.com) | Live and historical FX rates for 150+ currencies | `abstract-exchange-rates.mpp.paywithlocus.com` |
 
-## Try it
+## Try Alpha Vantage with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -38,14 +38,14 @@ tempo request alphavantage.mpp.paywithlocus.com/query \
   -d '{"function": "TIME_SERIES_DAILY", "symbol": "AAPL"}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy financial data
 
 ```
 Use edgar.mpp.paywithlocus.com to search SEC filings via Tempo.
 Pay per query with stablecoins — no API key needed.
 ```
 
-## Next steps
+## Next steps for financial data payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/image-and-media-generation.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/image-and-media-generation.mdx
@@ -9,17 +9,17 @@ import { Card, Cards } from 'vocs'
 
 Let your agents generate images, videos, audio, and speech — pay per generation with stablecoins on Tempo. Access 600+ models through fal.ai, or use OpenAI, Gemini, and Deepgram directly.
 
-## The problem
+## The media generation payment problem
 
 Media generation APIs require separate accounts and API keys per provider. Costs vary wildly by model and resolution, making budgeting unpredictable. Agents that need to generate a product image, a voiceover, and a video clip in a single workflow must juggle three sets of credentials and billing systems.
 
-## How MPP solves it
+## How MPP enables paid media generation
 
 With MPP, your agent pays per generation using stablecoins on Tempo. The price is declared upfront in the `402` Challenge — the agent knows exactly what it will pay before generating anything. One wallet, one balance, any provider.
 
 **Tempo Charge** is ideal for media generation: each request is a discrete unit with a known cost. The agent signs a TIP-20 transfer, the provider verifies it in ~500ms, and returns the generated media.
 
-## Available services
+## Media generation services you can pay for
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
@@ -29,7 +29,7 @@ With MPP, your agent pays per generation using stablecoins on Tempo. The price i
 | [Deepgram](https://deepgram.mpp.paywithlocus.com) | Nova-3 transcription, Aura-2 TTS | `deepgram.mpp.paywithlocus.com` |
 | [Mathpix](https://mathpix.mpp.paywithlocus.com) | OCR for math, science docs, LaTeX | `mathpix.mpp.paywithlocus.com` |
 
-## Try it
+## Try fal.ai with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -40,14 +40,14 @@ tempo request fal.mpp.tempo.xyz/fal-ai/flux/dev \
   -d '{"prompt": "a futuristic city skyline at sunset"}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy media generation
 
 ```
 Use fal.mpp.tempo.xyz to generate images via Tempo.
 Pay per image with stablecoins — no API key needed.
 ```
 
-## Next steps
+## Next steps for media generation payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/location-and-maps.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/location-and-maps.mdx
@@ -9,15 +9,15 @@ import { Card, Cards } from 'vocs'
 
 Let your agents geocode addresses, get directions, check weather, and track flights — pay per request with stablecoins on Tempo. No Google Cloud accounts, no Mapbox tokens, no API keys.
 
-## The problem
+## The location data payment problem
 
 Location APIs require cloud platform accounts with billing verification before returning data. Google Maps requires a Google Cloud project with a credit card. Mapbox requires a developer account with access tokens. Weather and flight APIs have their own signup flows. For agents that need location data as part of a larger workflow, this credential overhead is a barrier.
 
-## How MPP solves it
+## How MPP enables paid location data
 
 With MPP, your agent pays per geocode, per route, or per weather query using stablecoins. No cloud accounts, no access tokens. The agent makes a request, the service returns its price, the agent pays, and the data arrives.
 
-## Available services
+## Location data services you can pay for
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
@@ -28,7 +28,7 @@ With MPP, your agent pays per geocode, per route, or per weather query using sta
 | FlightAPI | Flight prices, tracking, airport schedules | `flightapi.mpp.tempo.xyz` |
 | [IPinfo](https://ipinfo.mpp.paywithlocus.com) | IP geolocation, ASN, privacy detection | `ipinfo.mpp.paywithlocus.com` |
 
-## Try it
+## Try Google Maps with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -39,14 +39,14 @@ tempo request googlemaps.mpp.tempo.xyz/maps/api/geocode/json \
   -d '{"address": "1600 Amphitheatre Parkway, Mountain View, CA"}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy location data
 
 ```
 Use googlemaps.mpp.tempo.xyz to geocode addresses via Tempo.
 Pay per request with stablecoins — no API key needed.
 ```
 
-## Next steps
+## Next steps for location data payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/monetize-your-api.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/monetize-your-api.mdx
@@ -9,11 +9,11 @@ import { Card, Cards } from 'vocs'
 
 Accept stablecoin payments for any HTTP endpoint. No signup flows, no billing accounts, no API key management. Your users — agents, apps, or humans — pay per request with stablecoins on Tempo, and you get paid instantly.
 
-## The problem
+## The API monetization problem
 
 Monetizing an API today means building a billing system: user registration, API key provisioning, usage metering, invoicing, and payment collection. For most developers, the billing infrastructure is harder to build than the API itself. Stripe and similar tools help, but still require account creation and credit card onboarding from every customer.
 
-## How MPP solves it
+## How MPP adds agentic API payments
 
 With MPP, you add a few lines of code to your HTTP endpoint and it becomes payment-gated. The server returns a `402` Challenge with the price, the client pays with a stablecoin transfer, and the server delivers the response with a `Receipt`. Settlement happens in ~500ms on Tempo.
 
@@ -21,11 +21,11 @@ With MPP, you add a few lines of code to your HTTP endpoint and it becomes payme
 - **Tempo Charge** — One-time payment per request. Best for single API calls, content access, or discrete operations.
 - **Tempo Session** — Continuous pay-as-you-go via payment channels. Best for LLM APIs, metered services, or streamed responses.
 
-## Get started in 5 minutes
+## Add API payments in 5 minutes
 
 ::::steps
 
-### Install the SDK
+### Install the MPP SDK
 
 :::code-group
 ```bash [npm]
@@ -39,7 +39,7 @@ bun add mppx viem
 ```
 :::
 
-### Add payment gating
+### Add MPP payment gating
 
 ```ts
 import { Mppx, tempo } from 'mppx/server'
@@ -64,7 +64,7 @@ export async function handler(request: Request) {
 }
 ```
 
-### Test it
+### Test the paid API
 
 ```bash
 npx mppx account create
@@ -81,7 +81,7 @@ npx mppx http://localhost:3000/api/endpoint
 - **Fee sponsorship** — Cover gas fees for your customers so they only need stablecoins
 - **Any stablecoin** — Accept pathUSD, USDC.e, or any TIP-20 token
 
-## Next steps
+## Next steps for API monetization
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/storage.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/storage.mdx
@@ -9,22 +9,22 @@ import { Card, Cards } from 'vocs'
 
 Let your agents store files, upload objects, and create Git repositories — pay per operation with stablecoins on Tempo. No AWS accounts, no access keys, no billing dashboards.
 
-## The problem
+## The storage payment problem
 
 Cloud storage requires account creation, IAM configuration, and billing setup before an agent can store a single byte. Even "simple" object storage like S3 requires access keys, bucket policies, and region selection. For agents that need temporary or task-specific storage, the overhead of cloud account provisioning is disproportionate to the need.
 
-## How MPP solves it
+## How MPP enables paid object storage
 
 With MPP, your agent pays per upload or per repo creation using stablecoins. The storage service publishes its pricing via the `402` Challenge, the agent pays, and the operation completes. No cloud credentials, no IAM roles.
 
-## Available services
+## Storage services you can pay for
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
 | Object Storage | S3/R2-compatible storage, dynamic per-size pricing | `storage.mpp.tempo.xyz` |
 | Code Storage | Paid Git repo creation, authenticated clone URLs | `codestorage.mpp.tempo.xyz` |
 
-## Try it
+## Try object storage with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -35,14 +35,14 @@ tempo request storage.mpp.tempo.xyz/upload \
   -F "file=@document.pdf"
 ```
 
-## Prompt your agent
+## Prompt your agent to buy storage
 
 ```
 Use storage.mpp.tempo.xyz to upload files via Tempo.
 Pay per upload with stablecoins — no cloud account needed.
 ```
 
-## Next steps
+## Next steps for storage payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/translation-and-language.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/translation-and-language.mdx
@@ -9,15 +9,15 @@ import { Card, Cards } from 'vocs'
 
 Let your agents translate text across 30+ languages, transcribe audio, generate speech, and analyze sentiment — pay per request with stablecoins on Tempo.
 
-## The problem
+## The translation payment problem
 
 Language APIs require separate developer accounts for each provider, with usage tied to monthly subscription tiers. An agent that needs to translate a document, transcribe a call, and generate a voiceover must manage three sets of credentials and billing cycles. Most providers don't offer true pay-per-use pricing.
 
-## How MPP solves it
+## How MPP enables paid translation services
 
 With MPP, your agent pays per translation, per transcription, or per TTS request using stablecoins. One Tempo wallet works across all language service providers. The agent pays only for what it uses — no monthly commitments, no unused credits.
 
-## Available services
+## Translation services you can pay for
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
@@ -25,7 +25,7 @@ With MPP, your agent pays per translation, per transcription, or per TTS request
 | [Deepgram](https://deepgram.mpp.paywithlocus.com) | Nova-3 transcription, Aura-2 TTS, sentiment | `deepgram.mpp.paywithlocus.com` |
 | OpenAI | Whisper transcription, TTS | `openai.mpp.tempo.xyz` |
 
-## Try it
+## Try DeepL with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -36,14 +36,14 @@ tempo request deepl.mpp.paywithlocus.com/v2/translate \
   -d '{"text": ["Hello, world!"], "target_lang": "DE"}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy translation
 
 ```
 Use deepl.mpp.paywithlocus.com to translate text via Tempo.
 Pay per request with stablecoins — no API key needed.
 ```
 
-## Next steps
+## Next steps for translation payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/machine-payments/use-cases/web-search-and-research.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/web-search-and-research.mdx
@@ -9,17 +9,17 @@ import { Card, Cards } from 'vocs'
 
 Give your agents access to web search, content extraction, and multi-hop research — pay per query with stablecoins on Tempo. No API keys, no monthly plans, no usage caps.
 
-## The problem
+## The web search payment problem
 
 Agents that research, summarize, or fact-check need reliable web search. But search APIs require developer accounts, billing setups, and API keys for every provider. Rate limits are tied to pricing tiers, and switching between providers means managing multiple integrations.
 
-## How MPP solves it
+## How MPP enables paid web research
 
 With MPP, your agent pays per search query or page extraction in a single HTTP request. The agent discovers the price via the `402` Challenge, pays with a stablecoin transfer, and gets results — no signup required. Switch between search providers by changing the URL.
 
 **Tempo Charge** works well here: each search query is an independent request with a known price. The agent signs a TIP-20 transfer, the provider verifies it in ~500ms, and returns the results.
 
-## Available services
+## Web research services you can pay for
 
 | Provider | Capabilities | Service URL |
 |---|---|---|
@@ -30,7 +30,7 @@ With MPP, your agent pays per search query or page extraction in a single HTTP r
 | [Diffbot](https://diffbot.mpp.paywithlocus.com) | Article, product, and discussion extraction | `diffbot.mpp.paywithlocus.com` |
 | Oxylabs | Web scraping with geo-targeting and JS rendering | `oxylabs.mpp.tempo.xyz` |
 
-## Try it
+## Try Parallel with Tempo payments
 
 ```bash
 # Install Tempo CLI + wallet
@@ -41,14 +41,14 @@ tempo request parallelmpp.dev/search \
   -d '{"query": "machine payments protocol"}'
 ```
 
-## Prompt your agent
+## Prompt your agent to buy web research
 
 ```
 Use parallelmpp.dev to search the web via Tempo.
 Pay per query with stablecoins — no API key needed.
 ```
 
-## Next steps
+## Next steps for web research payments
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/node/installation.mdx
+++ b/src/pages/docs/guide/node/installation.mdx
@@ -1,8 +1,9 @@
 ---
+title: Install a Tempo Node
 description: Install Tempo node using pre-built binaries, build from source with Rust, or run with Docker. Get started in minutes with tempoup.
 ---
 
-# Installation
+# Install a Tempo Node
 
 We provide three different installation paths — installing a pre-built binary, building from source, or using our provided Docker image. For the full CLI command reference, see [`tempo node`](/docs/cli/node).
 

--- a/src/pages/docs/guide/node/rpc.mdx
+++ b/src/pages/docs/guide/node/rpc.mdx
@@ -1,4 +1,5 @@
 ---
+title: Running RPC and Standby Nodes
 description: Set up and run Tempo RPC and standby nodes. Download snapshots, configure systemd services, and monitor node health and sync status.
 ---
 

--- a/src/pages/docs/guide/node/system-requirements.mdx
+++ b/src/pages/docs/guide/node/system-requirements.mdx
@@ -1,4 +1,5 @@
 ---
+title: Tempo Node System Requirements
 description: Minimum and recommended hardware specs for running Tempo RPC and validator nodes. CPU, RAM, storage, network, and port requirements.
 ---
 

--- a/src/pages/docs/guide/node/validator.mdx
+++ b/src/pages/docs/guide/node/validator.mdx
@@ -1,4 +1,5 @@
 ---
+title: Running a Validator Node
 description: Overview of running a Tempo validator node.
 ---
 

--- a/src/pages/docs/guide/payments/accept-a-payment.mdx
+++ b/src/pages/docs/guide/payments/accept-a-payment.mdx
@@ -1,4 +1,5 @@
 ---
+title: Accept a Payment
 description: Accept stablecoin payments in your application. Verify transactions, listen for transfer events, and reconcile payments using memos.
 interactive: true
 ---
@@ -13,7 +14,7 @@ import { Tabs, Tab } from 'vocs'
 
 Accept stablecoin payments in your application. Learn how to receive payments, verify transactions, and reconcile payments using memos.
 
-## Receiving Payments
+## Receive stablecoin payments
 
 Payments are automatically credited to the recipient's address when a transfer is executed. You don't need to do anything special to "accept" a payment, it happens automatically onchain.
 
@@ -24,11 +25,11 @@ In this basic receiving demo you can see the balances update after you add funds
   <AddFunds stepNumber={2} last />
 </Demo.Container>
 
-## Verifying Payments
+## Verify stablecoin payments
 
 Check if a payment has been received by querying the token balance or listening for transfer events:
 
-### Check Balance
+### Check receiver token balance
 
 <Tabs stateKey="library">
   <Tab title="Viem">
@@ -179,7 +180,7 @@ Check if a payment has been received by querying the token balance or listening 
   </Tab>
 </Tabs>
 
-### Listen for Transfer Events
+### Listen for TIP-20 transfer events
 
 <Tabs stateKey="library">
   <Tab title="Viem">
@@ -613,7 +614,7 @@ const { receipt } = await client.dex.sellSync({
 })
 ```
 
-## Next Steps
+## Next steps for accepting payments
 
 - **[Send a payment](/docs/guide/payments/send-a-payment)** to learn how to send payments
 - Learn more about [Exchange](/docs/guide/stablecoin-dex) for cross-stablecoin payments

--- a/src/pages/docs/guide/payments/configure-receive-policies.mdx
+++ b/src/pages/docs/guide/payments/configure-receive-policies.mdx
@@ -26,7 +26,7 @@ For example, receive policies are useful when:
 - a regulated entity that only wants to receive from addresses held by individuals it has KYC'ed
 - an orchestrator or exchange that only wants specific tokens sent to its deposit addresses
 
-## Know the behavior
+## Understand receive policy behavior
 
 If an address has no receive policy, all transfers and mints are allowed by the receive-policy layer.
 
@@ -140,7 +140,7 @@ If `to` is a TIP-1022 virtual address, it is resolved to its master address befo
 
 If resolution fails, the operation reverts as before. If the transfer or mint is blocked, the receipt is recorded for the master address and preserves the original `to` for attribution.
 
-## Learn more
+## Learn more about receive policies
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/payments/index.mdx
+++ b/src/pages/docs/guide/payments/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: Stablecoin Payments
 description: Send and receive stablecoin payments on Tempo. Integrate payments with flexible fee options, sponsorship capabilities, and parallel transactions.
 ---
 
@@ -6,60 +7,66 @@ import { Cards, Card } from 'vocs'
 
 # Stablecoin Payments
 
-Send and receive payments using stablecoins on Tempo. Learn how to integrate payments into your application with flexible fee options and sponsorship capabilities.
+Send and receive payments using stablecoins on Tempo. Start with core payment flows, then add reconciliation, receive controls, fee preferences, sponsorship, and higher-throughput transaction patterns.
+
+## Core Payment Flows
 
 <Cards>
   <Card
-    description="Send stablecoin payments between accounts with optional memos for reconciliation"
+    description="Send stablecoin payments between accounts with optional memos for reconciliation."
     to="/docs/guide/payments/send-a-payment"
     icon="lucide:send"
     title="Send a Payment"
   />
 
   <Card
-    description="Accept payments from users and integrate payment flows into your application"
+    description="Accept payments from users and integrate payment flows into your application."
     to="/docs/guide/payments/accept-a-payment"
     icon="lucide:handshake"
     title="Accept a Payment"
   />
 
   <Card
-    description="Filter inbound TIP-20 transfers and mints by token and sender, then handle blocked receipts"
-    to="/docs/guide/payments/configure-receive-policies"
-    icon="lucide:shield-check"
-    title="Configure Receive Policies"
-  />
-
-  <Card
-    description="Attach 32-byte references to TIP-20 transfers for payment reconciliation"
+    description="Attach 32-byte references to TIP-20 transfers for payment reconciliation."
     to="/docs/guide/payments/transfer-memos"
     icon="lucide:file-text"
     title="Attach a Transfer Memo"
   />
 
   <Card
-    description="Generate one TIP-20 deposit address per customer without sweep transactions"
+    description="Generate one TIP-20 deposit address per customer without sweep transactions."
     to="/docs/guide/payments/virtual-addresses"
     icon="lucide:route"
     title="Use Virtual Addresses"
   />
+</Cards>
+
+## Payment Controls
+
+<Cards>
+  <Card
+    description="Filter inbound TIP-20 transfers and mints by token and sender, then handle blocked receipts."
+    to="/docs/guide/payments/configure-receive-policies"
+    icon="lucide:shield-check"
+    title="Configure Receive Policies"
+  />
 
   <Card
-    description="Configure users to pay transaction fees in any supported stablecoin"
+    description="Configure users to pay transaction fees in any supported stablecoin."
     to="/docs/guide/payments/pay-fees-in-any-stablecoin"
     icon="lucide:circle-dollar-sign"
     title="Pay Fees in Any Stablecoin"
   />
 
   <Card
-    description="Sponsor transaction fees for your users to enable gasless transactions"
+    description="Sponsor transaction fees for your users to enable gasless transactions."
     to="/docs/guide/payments/sponsor-user-fees"
     icon="lucide:heart-handshake"
     title="Sponsor User Fees"
   />
 
   <Card
-    description="Submit multiple transactions in parallel using nonce keys"
+    description="Submit multiple transactions in parallel using nonce keys."
     to="/docs/guide/payments/send-parallel-transactions"
     icon="lucide:git-branch"
     title="Send Parallel Transactions"

--- a/src/pages/docs/guide/payments/pay-fees-in-any-stablecoin.mdx
+++ b/src/pages/docs/guide/payments/pay-fees-in-any-stablecoin.mdx
@@ -26,6 +26,8 @@ By the end of this guide you will be able to pay fees in any stablecoin on Tempo
   <PayWithFeeToken stepNumber={3} feeToken={betaUsd} last />
 </Demo.Container>
 
+<span id="quick-snippet" />
+
 ## Quick fee-token snippet
 
 Using a custom fee token is as simple as passing a `feeToken` attribute to mutable actions like `useTransferSync`, `useSendTransactionSync`, and more.

--- a/src/pages/docs/guide/payments/pay-fees-in-any-stablecoin.mdx
+++ b/src/pages/docs/guide/payments/pay-fees-in-any-stablecoin.mdx
@@ -1,4 +1,5 @@
 ---
+title: Pay Fees in Any Stablecoin
 description: Configure users to pay transaction fees in any supported stablecoin. Eliminate the need for a separate gas token with Tempo's flexible fee system.
 showOutline: 1
 interactive: true
@@ -15,7 +16,7 @@ import { Cards, Card, Tabs, Tab } from 'vocs'
 
 Configure users to pay transaction fees in any supported stablecoin. Tempo's flexible fee system allows users to pay fees with the same token they're using, eliminating the need to hold a separate gas token.
 
-## Demo
+## Fee-token payment demo
 
 By the end of this guide you will be able to pay fees in any stablecoin on Tempo.
 
@@ -25,7 +26,7 @@ By the end of this guide you will be able to pay fees in any stablecoin on Tempo
   <PayWithFeeToken stepNumber={3} feeToken={betaUsd} last />
 </Demo.Container>
 
-## Quick Snippet
+## Quick fee-token snippet
 
 Using a custom fee token is as simple as passing a `feeToken` attribute to mutable actions like `useTransferSync`, `useSendTransactionSync`, and more.
 
@@ -198,19 +199,19 @@ $ cast send \
 <div className="h-6" />
 
 :::info
-The fee token for a given transaction cannot be set from Solidity — it is a transaction-level parameter handled by the signing SDK. However, you can configure a **default** fee token for an account using [`setUserToken`](#set-user-fee-token), which will apply to all future transactions unless explicitly overridden at submission.
+The fee token for a given transaction cannot be set from Solidity — it is a transaction-level parameter handled by the signing SDK. However, you can configure a **default** fee token for an account using [`setUserToken`](#set-a-default-user-fee-token), which will apply to all future transactions unless explicitly overridden at submission.
 :::
 
 </Tab>
 </Tabs>
 
-## Steps
+## Fee-token implementation steps
 
 <Tabs stateKey="library">
   <Tab title="Wagmi">
 ::::steps
 
-### Set up Wagmi
+### Set up Wagmi for fee tokens
 
 Ensure that you have set up your project with Wagmi, a Tempo chain config, and a wallet connector:
 
@@ -218,7 +219,7 @@ Ensure that you have set up your project with Wagmi, a Tempo chain config, and a
 - [TypeScript SDK](/docs/sdk/typescript)
 - [Wallet integration](/docs/quickstart/wallet-developers)
 
-### Add testnet funds¹
+### Add testnet fee-token funds¹
 
 Before you can pay fees in a token of your choice, you need to fund your account. In this guide you will be sending `AlphaUSD` (`0x20c000…0001`) and paying fees in `BetaUSD` (`0x20c000…0002`).
 
@@ -259,7 +260,7 @@ function AddFunds() {
 started quickly. For production, you will need to onramp & fund your account manually.
 :::
 
-### Add pay with fee token logic
+### Add custom fee-token logic
 
 Now that you have `AlphaUSD` to send and `BetaUSD` to pay fees with, you can add a form that allows users to select a fee token and send a payment.
 
@@ -334,7 +335,7 @@ function PayWithFeeToken() {
 ```
 :::
 
-### Display a receipt
+### Display the fee-token receipt
 
 Now that users can send payments with a specified fee token, you can link to the transaction receipt.
 
@@ -375,7 +376,7 @@ function PayWithFeeToken() {
 ```
 :::
 
-### Next steps
+### Next fee-token steps
 
 Now that you have made a payment using a desired fee token, you can:
 - Follow a guide on how to [sponsor user fees](/docs/guide/payments/sponsor-user-fees) to enable gasless transactions
@@ -388,7 +389,7 @@ Now that you have made a payment using a desired fee token, you can:
 
 ::::steps
 
-### Set up Viem Client
+### Set up a Viem client for fee tokens
 
 First, we will set up a Viem client configured with Tempo.
 
@@ -402,7 +403,7 @@ For simplicity of the guide, this example uses a Private Key (Secp256k1) account
 
 :::
 
-### Add testnet funds¹
+### Add testnet fee-token funds¹
 
 Before you can pay fees in a token of your choice, you need to fund your account. In this guide you will be sending `AlphaUSD` (`0x20c000…0001`) and paying fees in `BetaUSD` (`0x20c000…0002`).
 
@@ -430,7 +431,7 @@ await client.faucet.fundSync({
 
 :::
 
-### Add pay with fee token logic
+### Add custom fee-token logic
 
 Now that you have `AlphaUSD` to send and `BetaUSD` to pay fees with, you can now add logic to send a payment with a specified fee token.
 
@@ -467,7 +468,7 @@ const receipt = await client.token.transferSync({
   <Tab title="Rust">
 
 :::info
-For Rust integration, refer to the [Quick Snippet](#quick-snippet) above and the [Set user fee token](#set-user-fee-token) below.
+For Rust integration, refer to the [Quick Snippet](#quick-fee-token-snippet) above and the [Set user fee token](#set-a-default-user-fee-token) below.
 :::
 
   </Tab>
@@ -475,7 +476,7 @@ For Rust integration, refer to the [Quick Snippet](#quick-snippet) above and the
   <Tab title="Python">
 
 :::info
-For Python integration, refer to the [Quick Snippet](#quick-snippet) above and the [Set user fee token](#set-user-fee-token) below.
+For Python integration, refer to the [Quick Snippet](#quick-fee-token-snippet) above and the [Set user fee token](#set-a-default-user-fee-token) below.
 :::
 
   </Tab>
@@ -483,7 +484,7 @@ For Python integration, refer to the [Quick Snippet](#quick-snippet) above and t
   <Tab title="Go">
 
 :::info
-For Go integration, refer to the [Quick Snippet](#quick-snippet) above and the [Set user fee token](#set-user-fee-token) below.
+For Go integration, refer to the [Quick Snippet](#quick-fee-token-snippet) above and the [Set user fee token](#set-a-default-user-fee-token) below.
 :::
 
   </Tab>
@@ -491,7 +492,7 @@ For Go integration, refer to the [Quick Snippet](#quick-snippet) above and the [
   <Tab title="Cast">
 
 :::info
-For Cast integration, refer to the [Quick Snippet](#quick-snippet) above and the [Set user fee token](#set-user-fee-token) below.
+For Cast integration, refer to the [Quick Snippet](#quick-fee-token-snippet) above and the [Set user fee token](#set-a-default-user-fee-token) below.
 :::
 
   </Tab>
@@ -499,13 +500,13 @@ For Cast integration, refer to the [Quick Snippet](#quick-snippet) above and the
   <Tab title="Solidity">
 
 :::info
-For Solidity integration, refer to the [Quick Snippet](#quick-snippet) above and the [Set user fee token](#set-user-fee-token) below.
+For Solidity integration, refer to the [Quick Snippet](#quick-fee-token-snippet) above and the [Set user fee token](#set-a-default-user-fee-token) below.
 :::
 
   </Tab>
 </Tabs>
 
-## Set user fee token
+## Set a default user fee token
 
 You can also set a persistent default fee token for an account, so users don't need to specify `feeToken` on every transaction. Learn more about fee token preferences [here](/docs/protocol/fees/spec-fee#fee-token-preferences).
 
@@ -699,7 +700,7 @@ StdPrecompiles.TIP_FEE_MANAGER.setUserToken(0x20c0000000000000000000000000000000
 </Tab>
 </Tabs>
 
-## Learning Resources
+## Fee-token learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/payments/send-a-payment.mdx
+++ b/src/pages/docs/guide/payments/send-a-payment.mdx
@@ -1,4 +1,5 @@
 ---
+title: Send a Payment
 description: Send stablecoin payments between accounts on Tempo. Include optional memos for reconciliation and tracking with TypeScript, Rust, or Solidity.
 interactive: true
 ---
@@ -23,7 +24,7 @@ On post-T6 networks, a blocked TIP-20 `transfer` / `transferFrom` still succeeds
 See [Configure Receive Policies](/docs/guide/payments/configure-receive-policies).
 :::
 
-## Demo
+## Send payment demo
 
 By the end of this guide you will be able to send payments on Tempo with an optional memo.
 
@@ -33,11 +34,11 @@ By the end of this guide you will be able to send payments on Tempo with an opti
   <SendPayment stepNumber={3} last />
 </Demo.Container>
 
-## Steps
+## Send payment implementation steps
 
 ::::steps
 
-### Set up Wagmi
+### Set up Wagmi for Tempo payments
 
 Ensure that you have set up your project with Wagmi, a Tempo chain config, and a wallet connector:
 
@@ -45,7 +46,7 @@ Ensure that you have set up your project with Wagmi, a Tempo chain config, and a
 - [TypeScript SDK](/docs/sdk/typescript)
 - [Wallet integration](/docs/quickstart/wallet-developers)
 
-### Add testnet funds¹
+### Add testnet stablecoin funds¹
 
 Before you can send a payment, you need to fund your account. In this guide you will be sending `AlphaUSD` (`0x20c000…0001`).
 
@@ -86,7 +87,7 @@ function AddFunds() {
 started quickly. For production, you will need to onramp & fund your account manually.
 :::
 
-### Add send payment logic
+### Add TIP-20 transfer logic
 
 Now that you have `AlphaUSD` you are ready to add logic to send a payment with an optional memo.
 
@@ -149,7 +150,7 @@ function SendPaymentWithMemo() {
 
 :::
 
-### Display receipt
+### Display the payment receipt
 
 Now that you can send a payment, you can display the transaction receipt on success.
 
@@ -183,7 +184,7 @@ function SendPaymentWithMemo() {
 
 :::
 
-### Next steps
+### Next steps after sending a payment
 
 Now that you have made a payment you can
 - **[Accept a payment](/docs/guide/payments/accept-a-payment)** to receive payments in your application
@@ -191,9 +192,9 @@ Now that you have made a payment you can
 - Send a payment [with a specific fee token](/docs/guide/payments/pay-fees-in-any-stablecoin)
 :::: 
 
-## Recipes
+## Stablecoin payment recipes
 
-### Basic transfer
+### Basic TIP-20 transfer
 
 Send a payment using the standard `transfer` function:
 
@@ -1008,7 +1009,7 @@ Send multiple payments in a single transaction using batch transactions:
   </Tab>
 </Tabs>
 
-### Payment events
+### Index payment events
 
 When you send a payment, the token contract emits events:
 
@@ -1017,14 +1018,14 @@ When you send a payment, the token contract emits events:
 
 You can filter these events to track payments in your off-chain systems.
 
-## Best practices
+## Stablecoin payment best practices
 
-### Loading state
+### Payment loading states
 Users should see a loading state when the payment is being processed.
 
 You can use the `isPending` property from the `useTransferSync` hook to show pending state to the user.
 
-### Error handling
+### Payment error handling
 If an error unexpectedly occurs, you can display an error message to the user by using the `error` property from the `useTransferSync` hook.
 
 ```tsx
@@ -1042,7 +1043,7 @@ function SendPayment() {
 }
 ```
 
-## Learning resources
+## Stablecoin payment learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/payments/send-parallel-transactions.mdx
+++ b/src/pages/docs/guide/payments/send-parallel-transactions.mdx
@@ -1,4 +1,5 @@
 ---
+title: Send Parallel Transactions
 description: Submit multiple transactions concurrently using Tempo's expiring nonce system under-the-hood.
 interactive: true
 ---
@@ -14,7 +15,7 @@ import { Cards, Card } from 'vocs'
 
 Tempo enables concurrent transaction execution through its [expiring nonce](/docs/guide/tempo-transaction#expiring-nonces) system. Unlike traditional sequential nonces that require transactions to be processed one at a time, expiring nonces allow multiple transactions to be submitted simultaneously without nonce conflicts. Each transaction uses an independent nonce that automatically expires after a set time window, enabling true parallel execution.
 
-## Demo
+## Parallel transaction demo
 
 By the end of this guide you will understand how to send parallel payments using expiring nonces under-the-hood.
 
@@ -24,11 +25,11 @@ By the end of this guide you will understand how to send parallel payments using
   <SendParallelPayments stepNumber={3} />
 </Demo.Container>
 
-## Steps
+## Parallel transaction implementation steps
 
 ::::steps
 
-### Set up Wagmi
+### Set up Wagmi for parallel transactions
 
 Ensure that you have set up your project with Wagmi, a Tempo chain config, and a wallet connector:
 
@@ -78,7 +79,7 @@ console.log('Transaction 2:', receipt2.transactionHash) // [!code focus]
 
 ::::
 
-## Learning Resources
+## Parallel transaction learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/payments/sponsor-user-fees.mdx
+++ b/src/pages/docs/guide/payments/sponsor-user-fees.mdx
@@ -1,4 +1,5 @@
 ---
+title: Sponsor User Fees
 description: Enable gasless transactions by sponsoring fees for your users. Set up a fee payer service and improve UX by removing friction from payment flows.
 interactive: true
 ---
@@ -18,7 +19,7 @@ Enable gasless transactions by sponsoring transaction fees for your users. Tempo
 Use Tempo's [hosted fee payer endpoints](/docs/developer-tools/fee-payer) for testnet development or approved mainnet integrations. Run your own fee payer when you need custom sponsorship policy, accounting, or operational control.
 :::
 
-## Demo
+## Fee sponsorship demo
 
 <Demo.Container name="Sponsor User Fees">
   <Connect stepNumber={1} />
@@ -26,7 +27,7 @@ Use Tempo's [hosted fee payer endpoints](/docs/developer-tools/fee-payer) for te
   <SendRelayerSponsoredPayment stepNumber={3} last />
 </Demo.Container>
 
-## Steps
+## Fee sponsorship implementation steps
 
 ::::steps
 
@@ -38,7 +39,7 @@ Tempo provides a public testnet fee payer service at `https://sponsor.moderato.t
 
 To sponsor transactions with your own infrastructure, run a JSON-RPC relay that validates incoming requests, fills Tempo Transactions, signs the fee payer payload, and broadcasts approved transactions. The fee payer account must be funded with the stablecoin it will use for fees.
 
-Your relay should expose the same core JSON-RPC methods described in the [Hosted Fee Payer API reference](/docs/developer-tools/fee-payer#api-reference), then apply your own sponsorship policy before signing.
+Your relay should expose the same core JSON-RPC methods described in the [Hosted Fee Payer API reference](/docs/developer-tools/fee-payer#hosted-fee-payer-api-reference), then apply your own sponsorship policy before signing.
 
 ### Configure your client to use the fee payer service
 
@@ -91,7 +92,7 @@ export const config = createConfig({
 Now transactions will be sponsored by your relay. For more details on how to send a transaction, see the [Send a payment](/docs/guide/payments/send-a-payment) guide.
 
 :::info
-You can also build your own fee paying service. See [Build your own fee paying service](#build-your-own-fee-paying-service) below.
+You can also build your own fee paying service. See [Build your own fee payer service](#build-your-own-fee-payer-service) below.
 :::
 
 :::code-group
@@ -147,7 +148,7 @@ function SendSponsoredPayment() {
 
 :::
 
-### Next Steps
+### Next steps for fee sponsorship
 
 Now that you've implemented fee sponsorship, you can:
 - Learn more about the [Tempo Transaction](/docs/protocol/transactions/spec-tempo-transaction#fee-payer-signature-details) type and fee payer signature details
@@ -156,7 +157,7 @@ Now that you've implemented fee sponsorship, you can:
 
 ::::
 
-## Build your own fee paying service
+## Build your own fee payer service
 
 Instead of using the hosted fee payer service, you can build your own.
 
@@ -379,21 +380,21 @@ The SDKs handle this automatically. Here's how each SDK manages the dual-signing
   </Tab>
 </Tabs>
 
-## Best practices
+## Fee sponsorship best practices
 
 1. **Set sponsorship limits**: Implement daily or per-user limits to control costs
 2. **Monitor expenses**: Track sponsorship costs regularly to stay within budget
 3. **Consider selective sponsorship**: Only sponsor fees for specific operations or user segments
 4. **Educate users**: Clearly communicate when fees are being sponsored
 
-### Security Considerations
+### Fee sponsorship security considerations
 
 - **Transaction-specific**: Fee payer signatures are tied to specific transactions
 - **No delegation risk**: Fee payer can't execute arbitrary transactions
 - **Balance checks**: Network verifies fee payer has sufficient balance
 - **Signature validation**: Both signatures must be valid
 
-## Learning Resources
+## Fee sponsorship learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/payments/transfer-memos.mdx
+++ b/src/pages/docs/guide/payments/transfer-memos.mdx
@@ -1,4 +1,5 @@
 ---
+title: Attach a Transfer Memo
 interactive: true
 description: Attach 32-byte reference memos to TIP-20 transfers for payment reconciliation, invoice matching, and exchange deposit tracking on Tempo.
 ---
@@ -13,7 +14,7 @@ import { SendPaymentWithMemo } from '../../../../components/guides/steps/payment
 
 Attach 32-byte references to [TIP-20](/docs/protocol/tip20/overview) transfers for payment reconciliation. Use memos to link onchain transactions to your internal records—customer IDs, invoice numbers, or any identifier that helps you match payments to your database.
 
-## Demo
+## Transfer memo demo
 
 <Demo.Container name="Transfer with Memo" footerVariant="source" src="tempoxyz/examples/tree/main/examples/payments">
   <Connect stepNumber={1} />
@@ -21,11 +22,11 @@ Attach 32-byte references to [TIP-20](/docs/protocol/tip20/overview) transfers f
   <SendPaymentWithMemo stepNumber={3} last />
 </Demo.Container>
 
-## Steps
+## Transfer memo implementation steps
 
 ::::steps
 
-### Set up your project
+### Set up your project for transfer memos
 
 Ensure you have Wagmi configured with Tempo:
 
@@ -113,7 +114,7 @@ export function WatchMemos({ depositAddress }: { depositAddress: `0x${string}` }
 
 ::::
 
-## Recipes
+## Transfer memo recipes
 
 ### Exchange deposit reconciliation
 
@@ -170,7 +171,7 @@ await Actions.token.transferSync(walletClient, {
 })
 ```
 
-## Best Practices
+## Transfer memo best practices
 
 ### Use consistent memo formats
 
@@ -194,7 +195,7 @@ const logs = await client.getLogs({
 })
 ```
 
-## Learning Resources
+## Transfer memo learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/payments/virtual-addresses.mdx
+++ b/src/pages/docs/guide/payments/virtual-addresses.mdx
@@ -16,7 +16,7 @@ Virtual addresses let you issue a distinct deposit address for each customer wit
 
 This page is intentionally about the operator flow rather than the spec. In preview environments the demo may run against pre-release infrastructure, but the flow is the same one operators will use on public testnet.
 
-## What happens
+## How virtual address deposits work
 
 <MermaidDiagram chart={`sequenceDiagram
     participant Sender
@@ -39,7 +39,7 @@ The important behavior is:
 - the **master wallet** receives the balance
 - the virtual address still appears in events, so you can attribute the deposit correctly
 
-## Live demo
+## Virtual address live demo
 
 This walkthrough shows the full flow:
 
@@ -83,7 +83,7 @@ Mining the TIP-1022 salt can take 30+ seconds depending on your browser, hardwar
   </Tab>
 </Tabs>
 
-## What to look for
+## What to verify in virtual address deposits
 
 When the demo succeeds, you should see all of the following:
 
@@ -122,7 +122,7 @@ A few things matter in production:
 - policy checks apply to the **resolved master wallet**, not the literal virtual address
 - avoid using virtual addresses in reward protocols (lending pools, DEX rewards, etc) unless explicitly supported, as they can't track or hold funds
 
-## Learn more
+## Learn more about TIP-20 virtual addresses
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/stablecoin-dex/executing-swaps.mdx
+++ b/src/pages/docs/guide/stablecoin-dex/executing-swaps.mdx
@@ -1,4 +1,5 @@
 ---
+title: Executing Swaps
 description: Learn to execute instant stablecoin swaps on Tempo's DEX. Get price quotes, set slippage protection, and batch approvals with swaps.
 interactive: true
 ---
@@ -22,11 +23,11 @@ By the end of this guide you will be able to execute swaps, get price quotes, an
 </Demo.Container>
 
 
-## Steps
+## Swap implementation steps
 
 ::::steps
 
-### Set up your client
+### Set up your swap client
 
 Ensure that you have set up your client by following the [guide](/docs/sdk/typescript).
 
@@ -156,7 +157,7 @@ function Sell() {
 
 :::
 
-### Approve Spend
+### Approve stablecoin spend
 
 To execute a swap, you need to approve the Stablecoin DEX contract to spend the token you're using to fund the swap.
 
@@ -382,7 +383,7 @@ function Sell() {
 
 ::::
 
-## Recipes
+## Stablecoin swap recipes
 
 ### Handling insufficient liquidity
 
@@ -421,7 +422,7 @@ function Swap() {
 }
 ```
 
-## Best Practices
+## Stablecoin swap best practices
 
 ### Always get quotes before swapping
 
@@ -431,7 +432,7 @@ Query the expected price before executing a swap to ensure you're getting a fair
 
 Use `minAmountOut` or `maxAmountIn` to protect against unfavorable price movements between quoting and execution.
 
-## Learning Resources
+## Stablecoin swap learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/stablecoin-dex/index.mdx
+++ b/src/pages/docs/guide/stablecoin-dex/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: Exchange Stablecoins
 description: Trade between stablecoins on Tempo's enshrined DEX. Execute swaps, provide liquidity, and query the onchain orderbook for optimal pricing.
 ---
 
@@ -6,28 +7,37 @@ import { Cards, Card } from 'vocs'
 
 # Exchange Stablecoins
 
-Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). The DEX enables optimal pricing for cross-stablecoin payments while minimizing chain load.
+Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). Start with quote-token behavior, then execute swaps, provide liquidity, or manage the fee-liquidity path for a stablecoin.
+
+## Stablecoin Exchange Paths
 
 <Cards>
   <Card
-    description="Learn about pathUSD, the root quote token that powers stablecoin interoperability"
+    description="Learn about pathUSD, the root quote token that powers stablecoin interoperability."
     to="/docs/protocol/exchange/quote-tokens#pathusd"
     icon="lucide:coins"
-    title="pathUSD"
+    title="Understand pathUSD"
   />
 
   <Card
-    description="Execute swaps between stablecoins"
+    description="Execute swaps between stablecoins."
     to="/docs/guide/stablecoin-dex/executing-swaps"
     icon="lucide:arrow-left-right"
-    title="Executing Swaps"
+    title="Execute Stablecoin Swaps"
   />
 
   <Card
-    description="Provide liquidity by placing limit orders or flip orders in the orderbook"
+    description="Provide liquidity by placing limit orders or flip orders in the orderbook."
     to="/docs/guide/stablecoin-dex/providing-liquidity"
     icon="lucide:droplet"
-    title="Providing Liquidity"
+    title="Provide Stablecoin Liquidity"
+  />
+
+  <Card
+    description="Keep fee pools balanced so users can pay transaction fees with your stablecoin."
+    to="/docs/guide/stablecoin-dex/managing-fee-liquidity"
+    icon="lucide:badge-dollar-sign"
+    title="Manage Fee Liquidity"
   />
 
 </Cards>

--- a/src/pages/docs/guide/stablecoin-dex/managing-fee-liquidity.mdx
+++ b/src/pages/docs/guide/stablecoin-dex/managing-fee-liquidity.mdx
@@ -1,4 +1,5 @@
 ---
+title: Managing Fee Liquidity
 description: Add and remove liquidity in the Fee AMM to enable stablecoin fee conversions. Monitor pools, check LP balances, and rebalance reserves.
 interactive: true
 ---
@@ -29,7 +30,7 @@ Browse current pool reserves and route availability in the [FeeAMM explorer view
   <BurnFeeAmmLiquidity stepNumber={6} last />
 </Demo.Container>
 
-## Steps
+## Fee liquidity management steps
 
 ::::steps
 
@@ -300,7 +301,7 @@ export const config = createConfig({
 
 ::::
 
-## Recipes
+## Fee liquidity recipes
 
 ### Monitor pool utilization
 
@@ -429,7 +430,7 @@ export const config = createConfig({
 :::
 
 
-## Best Practices
+## Fee liquidity best practices
 
 ### Monitor pool reserves
 
@@ -453,7 +454,7 @@ Focus liquidity on pools with:
 - New stablecoins that need initial bootstrapping
 - Validator tokens preferred by multiple validators
 
-## Learning Resources
+## Fee liquidity learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/stablecoin-dex/providing-liquidity.mdx
+++ b/src/pages/docs/guide/stablecoin-dex/providing-liquidity.mdx
@@ -1,4 +1,5 @@
 ---
+title: Providing Liquidity
 description: Place limit and flip orders to provide liquidity on the Stablecoin DEX orderbook. Learn to manage orders and set prices using ticks.
 interactive: true
 ---
@@ -18,7 +19,7 @@ Add liquidity for a token pair by placing orders on the Stablecoin DEX. You can 
 
 In this guide you will learn how to place buy and sell orders to provide liquidity on the Stablecoin DEX orderbook.
 
-## Demo
+## Liquidity provider demo
 
 <Demo.Container name="Place an Order" footerVariant="source" src="tempoxyz/examples/tree/main/examples/exchange">
   <Connect stepNumber={1} />
@@ -27,15 +28,15 @@ In this guide you will learn how to place buy and sell orders to provide liquidi
   <QueryOrder stepNumber={4} last />
 </Demo.Container>
 
-## Steps
+## Liquidity provider steps
 
 ::::steps
 
-### Set up your client
+### Set up your liquidity client
 
 Ensure that you have set up your client by following the [guide](/docs/sdk/typescript).
 
-### Approve spend
+### Approve stablecoin spend
 
 To place an order, you need to approve the Stablecoin DEX contract to spend the order's "spend" token.
 
@@ -91,7 +92,7 @@ function ApproveSpend(props: { orderType: 'buy' | 'sell' }) {
 :::
 
 
-### Place order
+### Place a liquidity order
 
 Once the spend is approved, you can place an order by calling the `place` action on the Stablecoin DEX.
 
@@ -151,7 +152,7 @@ function PlaceOrder(props: { orderType: 'buy' | 'sell' }) {
 
 :::
 
-### View order details
+### View liquidity order details
 
 After placing an order, you can query its details to see the current state, including the amount filled and remaining using [`Hooks.dex.useOrder`](https://wagmi.sh/tempo/hooks/dex.useOrder).
 
@@ -191,9 +192,9 @@ For more details on querying orders, see the [`Hooks.dex.useOrder`](https://wagm
 
 ::::
 
-## Recipes
+## Liquidity provider recipes
 
-### Cancel order
+### Cancel a liquidity order
 
 Cancel an order using its order ID.
 
@@ -272,7 +273,7 @@ function ManageOrder() {
 
 :::
 
-### Determining quote token
+### Determine the quote token
 Each token has a designated quote token that it trades against on the DEX. For most stablecoins, this will be `pathUSD`.
 
 Use the `token.useGetMetadata` hook to retrieve a token's quote token.
@@ -306,7 +307,7 @@ console.log('Quote Token:', metadata?.quoteToken) // returns `pathUSD` address
 ```
 :::
 
-### Flip order
+### Place a flip order
 
 Flip orders automatically switch between buy and sell sides when filled, providing continuous liquidity. Use viem's [`dex.placeFlip`](https://viem.sh/tempo/actions/dex.placeFlip) to create a flip order call.
 
@@ -397,12 +398,12 @@ const sellCall = Actions.dex.place.call({ // [!code hl]
 
 For more details including tick precision, limits, and calculation examples, see [Understanding Ticks](/docs/protocol/exchange/providing-liquidity#understanding-ticks).
 
-## Best practices
+## Liquidity provider best practices
 
-### Batch calls
+### Batch liquidity calls
 You can batch the calls to approve spend and place the order in a single transaction for efficiency. See the [Tempo Transactions guide](/docs/guide/tempo-transaction) for more details.
 
-## Learning resources
+## Liquidity learning resources
 
 <Cards>
   <Card

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -7,11 +7,11 @@ import { Cards, Card } from 'vocs'
 
 # Get Started
 
-Connect to Tempo and learn how to build stablecoin payment products. Start with network setup, fund a wallet, send a payment, then move into production workflows, protocol references, tooling, or infrastructure.
+Connect to Tempo and learn how to build stablecoin payment products. Start with network setup, fund a wallet, send your first payment, then choose the product workflow, reference, or operational surface you need next.
 
-If you are new to Tempo, start with **Integrate Tempo** to connect to the network, then move to **Build on Tempo** for payment workflows.
+If you are new to Tempo, start with **Connect to Tempo**, then use **Stablecoin Payments** as the first product guide.
 
-## First Steps
+## Start Here
 
 <Cards>
   <Card
@@ -27,27 +27,56 @@ If you are new to Tempo, start with **Integrate Tempo** to connect to the networ
     icon="lucide:wallet"
   />
   <Card
-    title="Send a Payment"
-    description="Send a stablecoin payment, configure fees, attach memos, and handle receipt policies."
-    to="/docs/guide/payments"
+    title="Send Your First Payment"
+    description="Make a stablecoin transfer, attach a memo, and see where fees and receive policies fit."
+    to="/docs/guide/payments/send-a-payment"
     icon="lucide:send"
   />
 </Cards>
 
-## Choose a Section
+## Choose a Build Path
 
 <Cards>
   <Card
-    title="Build on Tempo"
-    description="Payments, stablecoin issuance, exchange, private zones, and agentic payment workflows."
-    to="/docs/build"
-    icon="lucide:blocks"
+    title="Stablecoin Payments"
+    description="Send, accept, reconcile, and sponsor stablecoin payments on Tempo."
+    to="/docs/guide/payments"
+    icon="lucide:hand-coins"
   />
   <Card
-    title="Integrate Tempo"
-    description="Network details, faucet funds, wallet support, EVM differences, bridges, and ecosystem entry points."
-    to="/docs/quickstart/integrate-tempo"
-    icon="lucide:plug"
+    title="Issue Stablecoins"
+    description="Create, mint, manage, and distribute rewards for TIP-20 tokens."
+    to="/docs/guide/issuance"
+    icon="lucide:coins"
+  />
+  <Card
+    title="Exchange Stablecoins"
+    description="Use Tempo's stablecoin DEX for swaps, quote tokens, liquidity, and fee routing."
+    to="/docs/guide/stablecoin-dex"
+    icon="lucide:arrow-left-right"
+  />
+  <Card
+    title="Agentic Payments"
+    description="Accept one-time, pay-as-you-go, and streamed payments through the Machine Payments Protocol."
+    to="/docs/guide/machine-payments"
+    icon="lucide:bot"
+  />
+  <Card
+    title="Private Zones"
+    description="Use private zones for isolated execution, deposits, transfers, swaps, bridges, and withdrawals."
+    to="/docs/guide/private-zones"
+    icon="lucide:lock-keyhole"
+  />
+</Cards>
+
+## Reference and Operations
+
+<Cards>
+  <Card
+    title="Tools & SDKs"
+    description="SDKs, CLI, hosted services, wallet docs, JSON-RPC, and indexer tooling."
+    to="/docs/tools"
+    icon="lucide:terminal-square"
   />
   <Card
     title="Tempo Protocol"
@@ -56,37 +85,14 @@ If you are new to Tempo, start with **Integrate Tempo** to connect to the networ
     icon="lucide:file-code"
   />
   <Card
-    title="Tools & SDKs"
-    description="SDKs, CLI, hosted services, wallet docs, JSON-RPC, and indexer tooling."
-    to="/docs/tools"
-    icon="lucide:terminal-square"
-  />
-  <Card
     title="Run a Tempo Node"
-    description="Run Tempo infrastructure for direct RPC access, validation workflows, monitoring, and upgrades."
+    description="Operate Tempo infrastructure for direct RPC access, validation workflows, monitoring, and upgrades."
     to="/docs/guide/node"
     icon="lucide:server"
   />
 </Cards>
 
-## Common Workflows
-
-<Cards>
-  <Card
-    title="Issue a Stablecoin"
-    description="Create, mint, manage, and distribute rewards for a TIP-20 stablecoin."
-    to="/docs/guide/issuance"
-    icon="lucide:coins"
-  />
-  <Card
-    title="Find Partners"
-    description="Explore ecosystem partners across issuers, wallets, ramps, compliance, custody, and infrastructure."
-    to="/docs/partners"
-    icon="lucide:network"
-  />
-</Cards>
-
-## Resources
+## Ecosystem Resources
 
 <Cards>
   <Card

--- a/src/pages/docs/protocol/blockspace/overview.mdx
+++ b/src/pages/docs/protocol/blockspace/overview.mdx
@@ -1,4 +1,5 @@
 ---
+title: Blockspace Overview
 description: Technical specification for Tempo block structure including header fields, payment lanes, and system transaction ordering.
 ---
 

--- a/src/pages/docs/protocol/blockspace/payment-lane-specification.mdx
+++ b/src/pages/docs/protocol/blockspace/payment-lane-specification.mdx
@@ -1,4 +1,5 @@
 ---
+title: Payment Lane Specification
 description: Technical specification for Tempo payment lanes ensuring dedicated blockspace for payment transactions with predictable fees during congestion.
 ---
 

--- a/src/pages/docs/protocol/exchange/exchange-balance.mdx
+++ b/src/pages/docs/protocol/exchange/exchange-balance.mdx
@@ -1,4 +1,5 @@
 ---
+title: DEX Balance
 description: Hold token balances directly on the Stablecoin DEX to save gas costs on trades, receive maker proceeds automatically, and trade more efficiently.
 ---
 

--- a/src/pages/docs/protocol/exchange/executing-swaps.mdx
+++ b/src/pages/docs/protocol/exchange/executing-swaps.mdx
@@ -1,4 +1,5 @@
 ---
+title: Executing Swaps
 description: Learn how to execute swaps and quote prices on Tempo's Stablecoin DEX with exact-in and exact-out swap functions and slippage protection.
 ---
 

--- a/src/pages/docs/protocol/exchange/index.mdx
+++ b/src/pages/docs/protocol/exchange/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: Exchanging Stablecoins
 description: Tempo's enshrined decentralized exchange for trading between stablecoins with optimal pricing, limit orders, and flip orders for liquidity provision.
 ---
 

--- a/src/pages/docs/protocol/exchange/providing-liquidity.mdx
+++ b/src/pages/docs/protocol/exchange/providing-liquidity.mdx
@@ -1,4 +1,5 @@
 ---
+title: Providing Liquidity
 description: Provide liquidity on Tempo's DEX using limit orders and flip orders. Earn spreads while facilitating stablecoin trades with price-time priority.
 ---
 
@@ -10,7 +11,7 @@ When your orders are filled, you earn the spread between bid and ask prices whil
 
 You can only place orders on pairs between a token and its designated quote token. All TIP-20 tokens specify a quote token for trading pairs. [pathUSD](/docs/protocol/exchange/quote-tokens#pathusd) can be used as a simple choice for a quote token.
 
-## Overview
+## Orderbook liquidity overview
 
 The DEX uses an onchain orderbook where you can place orders at specific price ticks. Orders are matched using price-time priority, meaning better-priced orders fill first, and within the same price, earlier orders fill first.
 

--- a/src/pages/docs/protocol/exchange/quote-tokens.mdx
+++ b/src/pages/docs/protocol/exchange/quote-tokens.mdx
@@ -1,4 +1,5 @@
 ---
+title: Quote Tokens
 description: Quote tokens determine trading pairs on Tempo's DEX. Each TIP-20 specifies a quote token, with pathUSD available as an optional neutral choice.
 ---
 
@@ -33,7 +34,7 @@ pathUSD is a predeployed [TIP-20](/docs/protocol/tip20/spec) at genesis. Since i
 | `decimals()`   | `6`                                          |
 | `quoteToken()` | `address(0)`                                 |
 
-### Usage
+### Use pathUSD as a quote token
 
 When creating a USD stablecoin on Tempo, you can set pathUSD as its quote token:
 

--- a/src/pages/docs/protocol/exchange/spec.mdx
+++ b/src/pages/docs/protocol/exchange/spec.mdx
@@ -1,4 +1,5 @@
 ---
+title: Stablecoin DEX Specification
 description: Technical specification for Tempo's enshrined DEX with price-time priority orderbook, flip orders, and multi-hop routing for stablecoin trading.
 ---
 

--- a/src/pages/docs/protocol/fees/fee-amm/index.mdx
+++ b/src/pages/docs/protocol/fees/fee-amm/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: Fee AMM Overview
 description: Understand how the Fee AMM automatically converts transaction fees between stablecoins, enabling users to pay in any supported token.
 ---
 
@@ -12,7 +13,7 @@ The Fee AMM (Automated Market Maker) is a dedicated system for converting transa
 **Fee AMM vs. Exchange** — these are two different systems. The Fee AMM is protocol-driven: it converts transaction-fee payments into validators' preferred tokens at a fixed price, and only the protocol (and arbitrageurs rebalancing it) swaps against it — it is not a trading venue. For user-facing stablecoin trading (swaps, orders, prices, orderbook), use the [Exchange](/docs/protocol/exchange). See [Fee AMM vs. Exchange](#fee-amm-vs-exchange) below.
 :::
 
-## How It Works
+## How the Fee AMM converts stablecoin fees
 
 When a user pays fees in a stablecoin that differs from the validator's preference, the Fee AMM automatically converts the payment:
 
@@ -37,7 +38,7 @@ Tempo has two stablecoin-swapping systems that are easy to confuse. They serve d
 
 If you want to **trade** stablecoins or read market data, use the [Exchange](/docs/protocol/exchange). If you want to **enable fee payments** in your stablecoin or provide fee-conversion liquidity, you're in the right place — continue below.
 
-## Learn More
+## Learn more about fee conversion
 
 <Cards>
   <Card

--- a/src/pages/docs/protocol/fees/index.mdx
+++ b/src/pages/docs/protocol/fees/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: Transaction Fees
 description: Pay transaction fees in any USD stablecoin on Tempo. No native token required—fees are paid directly in TIP-20 stablecoins with automatic conversion.
 ---
 
@@ -12,7 +13,7 @@ For a stablecoin to be accepted, it must be USD-denominated, issued as a native 
 
 Tempo uses a fixed base fee (rather than a variable base fee as in EIP-1559), set so that a TIP-20 transfer costs less than $0.001. All fees accrue to the validator who proposes the block.
 
-## Learn More
+## Learn more about Tempo fees
 
 <Cards>
   <Card

--- a/src/pages/docs/protocol/fees/spec-fee-amm.mdx
+++ b/src/pages/docs/protocol/fees/spec-fee-amm.mdx
@@ -1,4 +1,5 @@
 ---
+title: Fee AMM Specification
 description: Technical specification for the Fee AMM enabling automatic stablecoin conversion for transaction fees with fixed-rate swaps and MEV protection.
 ---
 

--- a/src/pages/docs/protocol/index.mdx
+++ b/src/pages/docs/protocol/index.mdx
@@ -21,13 +21,13 @@ If you are building an app, start with the guides in **Build on Tempo** and come
     icon="lucide:coins"
   />
   <Card
-    title="Tempo Policies"
+    title="Tempo Policies (TIP-403)"
     description="TIP-403 policy checks, receive policies, access controls, and registry behavior."
     to="/docs/protocol/tip403/overview"
     icon="lucide:shield-check"
   />
   <Card
-    title="Fees"
+    title="Transaction Fees"
     description="Stablecoin fee payment, fee accounting, and the fee AMM used for conversion."
     to="/docs/protocol/fees"
     icon="lucide:badge-dollar-sign"
@@ -69,7 +69,7 @@ If you are building an app, start with the guides in **Build on Tempo** and come
   />
 </Cards>
 
-## Specifications
+## Specifications and Source
 
 <Cards>
   <Card

--- a/src/pages/docs/protocol/rpc/index.mdx
+++ b/src/pages/docs/protocol/rpc/index.mdx
@@ -26,7 +26,7 @@ Not all methods listed below are available on public endpoints. Method availabil
 | `consensus_subscribe` | Validator nodes over WebSocket only |
 | `admin_validatorKey` | Self-hosted nodes with `admin` API enabled |
 
-## `tempo_` namespace
+## Tempo-specific `tempo_` namespace
 
 ### `tempo_forkSchedule`
 
@@ -88,7 +88,7 @@ cast rpc tempo_fundAddress 0xYOUR_ADDRESS \
   --rpc-url https://rpc.moderato.tempo.xyz
 ```
 
-## `consensus_` namespace
+## Tempo consensus `consensus_` namespace
 
 Available on validator nodes only. Provides real-time consensus state for explorers, bridges, and indexers.
 
@@ -200,7 +200,7 @@ cast rpc consensus_getIdentityTransitionProof null null --rpc-url <VALIDATOR_RPC
 cast rpc consensus_getIdentityTransitionProof null true --rpc-url <VALIDATOR_RPC>
 ```
 
-## `admin_` namespace
+## Tempo admin `admin_` namespace
 
 Requires the `admin` API to be enabled on a self-hosted node (`--http.api admin`).
 
@@ -216,7 +216,7 @@ Returns the node's ed25519 validator public key if configured, or `null` for non
 cast rpc admin_validatorKey --rpc-url http://localhost:8545
 ```
 
-## Modified `eth_` methods
+## Tempo-modified `eth_` methods
 
 Tempo is fully [EVM compatible](/docs/quickstart/evm-compatibility), but the following standard methods behave differently due to the lack of a native gas token:
 

--- a/src/pages/docs/protocol/tip20-rewards/overview.mdx
+++ b/src/pages/docs/protocol/tip20-rewards/overview.mdx
@@ -1,4 +1,5 @@
 ---
+title: Tempo Token Rewards
 description: Built-in reward distribution mechanism for TIP-20 tokens enabling efficient, opt-in proportional rewards to token holders at scale.
 ---
 

--- a/src/pages/docs/protocol/tip20-rewards/spec.mdx
+++ b/src/pages/docs/protocol/tip20-rewards/spec.mdx
@@ -1,4 +1,5 @@
 ---
+title: Tempo Token Rewards Specification
 description: Technical specification for Tempo Token Rewards using reward-per-token accumulator pattern for scalable pro-rata rewards.
 ---
 

--- a/src/pages/docs/protocol/tip20/overview.mdx
+++ b/src/pages/docs/protocol/tip20/overview.mdx
@@ -1,4 +1,5 @@
 ---
+title: TIP-20 Tokens
 description: TIP-20 tokens are Tempo's native token standard for stablecoins with built-in fee payment, payment lanes, transfer memos, and compliance policies.
 ---
 
@@ -149,7 +150,7 @@ A TIP-20 token can declare a currency identifier that identifies the reference a
 3. **Tokens denominated in but not pegged to a currency** — do **not** use that currency's code. A tokenized gold product priced in USD should not use `"USD"`, because 1 unit is not designed to be worth 1 USD.
 4. **Tokens with no reference asset** — if a token does not track any external asset (e.g. a governance or utility token), use its own symbol as the currency.
 
-#### Examples
+#### Currency declaration examples
 
 | Token | Tracks | `currency` |
 |-------|--------|------------|

--- a/src/pages/docs/protocol/tip20/spec.mdx
+++ b/src/pages/docs/protocol/tip20/spec.mdx
@@ -1,4 +1,5 @@
 ---
+title: TIP-20 Tokens Specification
 description: Technical specification for TIP-20 tokens, the optimized token standard extending ERC-20 with memos, rewards distribution, and policy integration.
 ---
 

--- a/src/pages/docs/protocol/tip20/virtual-addresses.mdx
+++ b/src/pages/docs/protocol/tip20/virtual-addresses.mdx
@@ -162,7 +162,7 @@ Adopting virtual addresses is straightforward conceptually:
 
 If you want the exact transfer semantics, event shape, and validation rules, read [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) alongside the [TIP-20 specification](/docs/protocol/tip20/spec).
 
-## Learn more
+## Learn more about TIP-20 virtual addresses
 
 <Cards>
   <Card

--- a/src/pages/docs/protocol/tip403/overview.mdx
+++ b/src/pages/docs/protocol/tip403/overview.mdx
@@ -1,4 +1,5 @@
 ---
+title: Tempo Policy Registry (TIP-403)
 description: Learn how TIP-403 enables TIP-20 tokens to enforce access control through a shared policy registry with whitelist and blacklist support.
 ---
 

--- a/src/pages/docs/protocol/tip403/receive-policies.mdx
+++ b/src/pages/docs/protocol/tip403/receive-policies.mdx
@@ -203,7 +203,7 @@ event ReceiptBurned(
 
 `TransferBlocked.receipt` is the ABI-encoded receipt witness and must be directly usable as the `receipt` argument to `balanceOf`, `claim`, and `burnBlockedReceipt`.
 
-## Related
+## Related receive policy docs
 
 <Cards>
   <Card

--- a/src/pages/docs/protocol/tip403/spec.mdx
+++ b/src/pages/docs/protocol/tip403/spec.mdx
@@ -1,4 +1,5 @@
 ---
+title: Tempo Policy Registry (TIP-403) Specification
 description: Technical specification for the Tempo Policy Registry (TIP-403), enabling whitelist and blacklist access control for TIP-20 tokens on Tempo.
 ---
 

--- a/src/pages/docs/protocol/transactions/AccountKeychain.mdx
+++ b/src/pages/docs/protocol/transactions/AccountKeychain.mdx
@@ -1,4 +1,5 @@
 ---
+title: Account Keychain Precompile
 description: Technical specification for the Account Keychain precompile managing access keys with expiry timestamps, spending limits, and call-scope restrictions.
 ---
 
@@ -6,7 +7,7 @@ description: Technical specification for the Account Keychain precompile managin
 
 **Address:** `0xAAAAAAAA00000000000000000000000000000000`
 
-## Overview
+## Account Keychain overview
 
 The Account Keychain precompile manages authorized Access Keys for accounts, enabling Root Keys (e.g., passkeys) and admin access keys to provision secondary keys. Limited access keys can have expiry timestamps, recurring or one-time per-TIP20 token spending limits, and explicit call scopes that restrict which targets, selectors, and recipients an Access Key may invoke.
 

--- a/src/pages/docs/protocol/transactions/eip-4337.mdx
+++ b/src/pages/docs/protocol/transactions/eip-4337.mdx
@@ -57,6 +57,6 @@ Tempo Transactions pay fees directly in any USD stablecoin that has liquidity on
 
 Tempo has the ERC-4337 EntryPoint contract deployed for projects that require compatibility with existing 4337 tooling. Consider using native Tempo Transactions for lower gas costs and simpler integration.
 
-## Getting Started
+## Start with Tempo Transactions
 
 To start using Tempo Transactions, see the [Tempo Transactions guide](/docs/guide/tempo-transaction) for SDK integration in TypeScript, Rust, Go, and Python. For the full technical specification, see the [Tempo Transaction Specification](/docs/protocol/transactions/spec-tempo-transaction).

--- a/src/pages/docs/protocol/transactions/eip-7702.mdx
+++ b/src/pages/docs/protocol/transactions/eip-7702.mdx
@@ -57,6 +57,6 @@ The `aa_authorization_list` field in Tempo Transactions contains authorizations 
 
 For full details on the authorization format, see the [Tempo Transaction Specification](/docs/protocol/transactions/spec-tempo-transaction).
 
-## Getting Started
+## Start with Tempo Transactions
 
 To start using Tempo Transactions, see the [Tempo Transactions guide](/docs/guide/tempo-transaction) for SDK integration in TypeScript, Rust, Go, and Python.

--- a/src/pages/docs/protocol/transactions/index.mdx
+++ b/src/pages/docs/protocol/transactions/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: Tempo Transactions
 description: Learn about Tempo Transactions, a new EIP-2718 transaction type with passkey support, fee sponsorship, batching, and concurrent execution.
 ---
 
@@ -70,7 +71,7 @@ If you are an EVM smart contract developer, see the [Foundry guide for Tempo](/d
 <TempoTxProperties />
 
 
-## Learn more
+## Learn more about Tempo Transactions
 
 <Cards>
   <Card

--- a/src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx
+++ b/src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx
@@ -1,4 +1,5 @@
 ---
+title: Tempo Transactions Specification
 description: Technical specification for Tempo Transactions (EIP-2718) with WebAuthn signatures, parallelizable nonces, gas sponsorship, and batching.
 ---
 

--- a/src/pages/docs/quickstart/connection-details.mdx
+++ b/src/pages/docs/quickstart/connection-details.mdx
@@ -1,4 +1,5 @@
 ---
+title: Connect to the Network
 description: Connect to Tempo using browser wallets, CLI tools, or direct RPC endpoints. Get chain ID, URLs, and configuration details.
 mipd: true
 interactive: true
@@ -43,7 +44,7 @@ cast block-number --rpc-url https://rpc.tempo.xyz
 | **WebSocket URL** | `wss://rpc.tempo.xyz` |
 | **Block Explorer** | [`https://explore.tempo.xyz`](https://explore.tempo.xyz) |
 
-### Testnet
+### Tempo Testnet
 
 | **Property** | **Value** |
 |-------------------|-------|

--- a/src/pages/docs/quickstart/developer-tools.mdx
+++ b/src/pages/docs/quickstart/developer-tools.mdx
@@ -1,4 +1,5 @@
 ---
+title: Developer Tools
 description: Explore Tempo's developer ecosystem with indexers, embedded wallets, node infrastructure, and analytics partners for building payment apps.
 ---
 
@@ -97,7 +98,7 @@ Get started with the [Squid docs](https://docs.squidrouter.com/) or try the [bri
 
 [TIDX](/docs/developer-tools/indexer) is Tempo's hosted indexer for querying blocks, transactions, logs, token balances, and decoded events through SQL. Use the public mainnet endpoint at `https://indexer.tempo.xyz` or the testnet endpoint at `https://indexer.testnet.tempo.xyz`.
 
-The hosted indexer powers explorer-style reads and supports ClickHouse-backed analytical queries for expensive reads like holder lists and token activity. Try the [interactive TIDX example](/docs/developer-tools/indexer#interactive-example) or read the [TIDX README](https://github.com/tempoxyz/tidx) to run your own indexer.
+The hosted indexer powers explorer-style reads and supports ClickHouse-backed analytical queries for expensive reads like holder lists and token activity. Try the [interactive TIDX example](/docs/developer-tools/indexer#interactive-tidx-sql-example) or read the [TIDX README](https://github.com/tempoxyz/tidx) to run your own indexer.
 
 ### Allium
 

--- a/src/pages/docs/quickstart/evm-compatibility.mdx
+++ b/src/pages/docs/quickstart/evm-compatibility.mdx
@@ -1,4 +1,5 @@
 ---
+title: EVM Differences
 description: Learn how Tempo differs from Ethereum. Understand wallet behavior, fee token selection, VM layer changes, and fast finality consensus.
 ---
 

--- a/src/pages/docs/quickstart/faucet.mdx
+++ b/src/pages/docs/quickstart/faucet.mdx
@@ -1,4 +1,5 @@
 ---
+title: Faucet
 description: Get free test stablecoins on Tempo Testnet. Connect your wallet or enter any address to receive pathUSD, AlphaUSD, BetaUSD, and ThetaUSD.
 mipd: true
 interactive: true

--- a/src/pages/docs/quickstart/integrate-tempo.mdx
+++ b/src/pages/docs/quickstart/integrate-tempo.mdx
@@ -12,18 +12,18 @@ Use this section when you are connecting an existing app, wallet, contract, brid
 
 Tempo is EVM-compatible and targets the **Osaka** EVM hard fork. Most Ethereum tooling works as expected, with Tempo-specific differences documented where they matter.
 
-## First Connection
+## Connect and Fund
 
 <Cards>
   <Card
     icon="lucide:network"
-    title="Connect to the Network"
+    title="Connect to Tempo"
     description="Add Tempo chain configuration, RPC endpoints, explorer links, and wallet connection details."
     to="/docs/quickstart/connection-details"
   />
   <Card
     icon="lucide:droplets"
-    title="Get Testnet Faucet Funds"
+    title="Get Testnet Funds"
     description="Fund test wallets so you can deploy contracts, send payments, and exercise integration flows."
     to="/docs/quickstart/faucet"
   />
@@ -35,53 +35,53 @@ Tempo is EVM-compatible and targets the **Osaka** EVM hard fork. Most Ethereum t
   />
 </Cards>
 
-## App and Wallet Integration
+## App and Wallet Readiness
 
 <Cards>
   <Card
     icon="lucide:wallet"
-    title="Wallet Developers"
+    title="Wallet Integration"
     description="Support Tempo in wallets with stablecoin-native fees, chain metadata, and transaction behavior."
     to="/docs/quickstart/wallet-developers"
   />
   <Card
     icon="lucide:code-2"
-    title="EVM Differences"
+    title="Tempo EVM Compatibility"
     description="Understand the Tempo-specific behavior that differs from default Ethereum assumptions."
     to="/docs/quickstart/evm-compatibility"
   />
   <Card
     icon="lucide:boxes"
-    title="Predeployed Contracts"
+    title="System Contracts and Predeploys"
     description="Find Tempo predeploys and system contracts used by integrations and protocol features."
     to="/docs/quickstart/predeployed-contracts"
   />
   <Card
     icon="lucide:list"
-    title="Token List Registry"
+    title="Token Lists"
     description="Use Tempo token lists to discover supported assets and present stablecoins correctly."
     to="/docs/quickstart/tokenlist"
   />
 </Cards>
 
-## Interoperability
+## Bridges and Ecosystem
 
 <Cards>
   <Card
     icon="lucide:bridge"
-    title="Bridge via LayerZero"
+    title="LayerZero Bridge"
     description="Bridge supported assets to and from Tempo using LayerZero."
     to="/docs/guide/bridge-layerzero"
   />
   <Card
     icon="lucide:route"
-    title="Bridge via Relay"
+    title="Relay Bridge"
     description="Use Relay to move assets between Tempo and other supported networks."
     to="/docs/guide/bridge-relay"
   />
   <Card
     icon="lucide:network"
-    title="Ecosystem"
+    title="Tempo Ecosystem"
     description="Find bridges, wallets, analytics, infrastructure, compliance, and orchestration partners."
     to="/docs/ecosystem"
   />

--- a/src/pages/docs/quickstart/predeployed-contracts.mdx
+++ b/src/pages/docs/quickstart/predeployed-contracts.mdx
@@ -1,4 +1,5 @@
 ---
+title: Predeployed Contracts
 description: Discover Tempo's predeployed system contracts including TIP-20 Factory, Fee Manager, Stablecoin DEX, and standard utilities like Multicall3.
 ---
 

--- a/src/pages/docs/quickstart/tokenlist.mdx
+++ b/src/pages/docs/quickstart/tokenlist.mdx
@@ -15,7 +15,7 @@ As an example, here's Tempo's tokenlist, fetched from [tokenlist.tempo.xyz/list/
 
 <TokenListDemo />
 
-## Endpoints
+## Token list API endpoints
 
 | Endpoint | Description |
 |----------|-------------|

--- a/src/pages/docs/quickstart/verify-contracts.mdx
+++ b/src/pages/docs/quickstart/verify-contracts.mdx
@@ -210,7 +210,7 @@ curl -X POST https://contracts.tempo.xyz/v2/verify/42431/<CONTRACT_ADDRESS> \
   }'
 ```
 
-## API Reference
+## Contract verification API reference
 
 | Endpoint | Description |
 |----------|-------------|

--- a/src/pages/docs/quickstart/wallet-developers.mdx
+++ b/src/pages/docs/quickstart/wallet-developers.mdx
@@ -1,4 +1,5 @@
 ---
+title: Wallet Developer Guide
 description: Integrate Tempo into your wallet. Use Tempo Transactions for fee token selection, fee sponsorship, batching, and concurrent execution.
 showOutline: 1
 ---
@@ -13,7 +14,7 @@ To deliver the best experience for your users, integrate [Tempo Transactions](/d
 
 [SDKs](/docs/guide/tempo-transaction#integration-guides) are available for TypeScript, Rust, Go, Python, and Foundry. Integration typically takes less than an hour.
 
-## Steps
+## Wallet integration steps
 
 ::::steps
 
@@ -144,7 +145,7 @@ Tempo provides a public tokenlist service that hosts token and network assets. Y
 
 If you've integrated a third-party account abstraction provider for batching, sponsorship, or smart accounts, Tempo Transactions provide these features natively at the protocol level. See the [feature comparison](/docs/protocol/transactions/eip-7702#feature-comparison) for details.
 
-## Recipes
+## Wallet integration recipes
 
 ### Get user's fee token
 

--- a/src/pages/docs/sdk/foundry/index.mdx
+++ b/src/pages/docs/sdk/foundry/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: Foundry for Tempo
 description: Build, test, and deploy smart contracts on Tempo using Foundry. Access Tempo protocol features with forge, cast, anvil, and chisel.
 ---
 
@@ -20,7 +21,7 @@ Install the latest Foundry release to get Tempo support.
 
 :::::steps
 
-### Install `foundryup`
+### Install `foundryup` for Tempo
 
 If you don't have `foundryup` installed yet:
 
@@ -63,11 +64,11 @@ forge install tempoxyz/tempo-std
 
 :::::
 
-## Configure `foundry.toml`
+## Configure `foundry.toml` for Tempo
 
 The Tempo template gives you a working starting point, but it is often useful to make Tempo explicit in `foundry.toml`.
 
-### Configure RPC aliases
+### Configure Tempo RPC aliases
 
 Set a default Tempo RPC alias and keep a separate alias for Moderato testnet:
 
@@ -95,13 +96,13 @@ This network flag enables Tempo-specific network behavior while still letting Fo
 
 If you need advanced testing against historical network behavior, pin a specific Tempo hardfork explicitly in `foundry.toml` or via inline config. Most projects should avoid hardfork pinning so local tests track the current Tempo rules for the network they target.
 
-### Verification config
+### Configure Tempo contract verification
 
 Tempo's contract verifier is Sourcify-compatible. Configure verification with `VERIFIER_URL=https://contracts.tempo.xyz` or `--verifier-url https://contracts.tempo.xyz`.
 
 The `[etherscan]` table in `foundry.toml` is for Etherscan-style verifiers, not Tempo's verifier.
 
-### Using `foundry-toolchain` in your CI
+### Use `foundry-toolchain` in Tempo CI
 
 Use the [`foundry-toolchain`](https://github.com/foundry-rs/foundry-toolchain) GitHub Action to install Foundry in your CI.
 Tempo support is included in the latest Foundry release, so no special configuration is needed.
@@ -111,11 +112,11 @@ Tempo support is included in the latest Foundry release, so no special configura
   uses: foundry-rs/foundry-toolchain@v1
 ```
 
-## Use Foundry for your workflows
+## Use Foundry for Tempo workflows
 
 All standard Foundry commands are supported out of the box.
 
-### Test & deploy with `forge` locally
+### Test and deploy Tempo contracts locally with `forge`
 
 ```bash
 # Build your contracts
@@ -128,7 +129,7 @@ forge test
 forge script script/Mail.s.sol
 ```
 
-### Test & deploy with `forge` on Tempo Testnet
+### Test and deploy with `forge` on Tempo Testnet
 
 ```bash
 # Set environment variables
@@ -202,7 +203,7 @@ For more verification options including verifying existing contracts and API ver
 - **Silent failures**: Calling a non-existent function without a fallback succeeds silently
 :::
 
-### Interact & debug with `cast`
+### Interact and debug Tempo contracts with `cast`
 
 ```bash
 # Check that your contract is deployed:
@@ -296,7 +297,7 @@ If the access key will be used with passkey or WebAuthn signatures, pass `2` for
 
 Access-key transactions cannot create contracts, so use a root key for deployments or other flows that perform `CREATE`.
 
-### Local Development with Anvil
+### Local Tempo development with Anvil
 
 Anvil supports Tempo mode for local testing and forking Tempo networks:
 
@@ -336,7 +337,7 @@ cast batch-send \
   --private-key $PRIVATE_KEY
 ```
 
-## Tempo-Specific CLI Flags
+## Tempo-specific Foundry CLI flags
 
 The following flags are available for `cast` and `forge script` for Tempo-specific features:
 
@@ -354,7 +355,7 @@ The following flags are available for `cast` and `forge script` for Tempo-specif
 
 Ledger and Trezor wallets are not yet compatible with any `--tempo.*` option.
 
-## cast keychain
+## `cast keychain` for Tempo access keys
 
 `cast keychain` provides a CLI interface to Tempo's [Account Keychain precompile](/docs/protocol/transactions/AccountKeychain).
 

--- a/src/pages/docs/sdk/foundry/mpp.mdx
+++ b/src/pages/docs/sdk/foundry/mpp.mdx
@@ -20,7 +20,7 @@ Every Foundry tool works transparently with MPP-gated endpoints:
 - **`anvil`** — local forks of paid endpoints
 - **`chisel`** — interactive REPL sessions
 
-## How it works
+## How MPP works with Foundry
 
 When you point any Foundry tool at an MPP-gated RPC URL, the built-in transport intercepts `402` responses and resolves them using MPP's [session flow](/docs/guide/machine-payments/pay-as-you-go):
 
@@ -36,7 +36,7 @@ When you point any Foundry tool at an MPP-gated RPC URL, the built-in transport 
 Channel reuse means the first call to an MPP endpoint has roughly one confirmation of overhead (~500ms on Tempo), but all subsequent calls add near-zero latency.
 :::
 
-## Setup
+## Foundry MPP setup
 
 :::note
 Some endpoints use a one-shot `charge` intent instead of session-based channels. Foundry handles both — charge payments sign a single TIP-20 transfer without opening a channel.
@@ -83,9 +83,9 @@ cast block-number --rpc-url https://rpc.mpp.tempo.xyz
 
 :::::
 
-## Examples
+## Foundry MPP examples
 
-### cast
+### MPP requests with `cast`
 
 Query chain state through a paid endpoint:
 
@@ -99,7 +99,7 @@ cast call 0x20c0000000000000000000000000000000000000 \
   --rpc-url https://rpc.mpp.tempo.xyz
 ```
 
-### forge script
+### MPP requests in `forge script`
 
 Run deployment or read scripts against a paid endpoint:
 
@@ -122,7 +122,7 @@ contract ReadBlock is Script {
 forge script script/ReadBlock.s.sol --rpc-url https://rpc.mpp.tempo.xyz
 ```
 
-### forge test with forks
+### MPP requests in forked `forge test`
 
 Fork a paid endpoint in tests using `vm.createSelectFork`:
 
@@ -146,7 +146,7 @@ contract MppForkTest is Test {
 forge test --match-test test_fork_via_mpp -vvv
 ```
 
-### anvil
+### MPP requests with Anvil
 
 Fork a paid endpoint locally. Local RPC calls stay local, but any upstream fetches Anvil makes to the fork URL go through MPP:
 
@@ -154,7 +154,7 @@ Fork a paid endpoint locally. Local RPC calls stay local, but any upstream fetch
 anvil --fork-url https://rpc.mpp.tempo.xyz
 ```
 
-### chisel
+### MPP requests with Chisel
 
 Interactive REPL against a paid endpoint:
 
@@ -169,9 +169,9 @@ Type: uint256
 └ Decimal: 1234567
 ```
 
-## Configuration
+## Foundry MPP configuration
 
-### Deposit amount
+### MPP deposit amount
 
 Set the fallback deposit amount used when the server does not suggest one:
 
@@ -182,7 +182,7 @@ cast block-number --rpc-url https://rpc.mpp.tempo.xyz
 
 The deposit determines how many RPC calls you can make before the channel needs a top-up. When a channel is exhausted, Foundry automatically tops it up.
 
-### Key discovery
+### MPP key discovery
 
 Foundry discovers MPP signing keys in this order:
 
@@ -198,13 +198,13 @@ Foundry needs a usable inline private key — entries without one are skipped.
 
 When the server offers multiple chains or currencies, Foundry picks the first key that matches both the chain ID and currency from the challenge.
 
-### Channel persistence
+### MPP channel persistence
 
 Open channels are saved to `$TEMPO_HOME/foundry/channels.json` (default `~/.tempo/foundry/channels.json`). This allows channel reuse across process invocations — you won't re-open a channel every time you run `cast` or `forge`.
 
 Channels are automatically evicted when fully spent or closed. If the server restarts and returns `410 Gone`, Foundry clears stale local state and opens a fresh channel on the next request.
 
-## Testnet
+## Tempo MPP testnet workflow
 
 Use the Moderato testnet MPP endpoint for development:
 
@@ -217,11 +217,11 @@ cast block-number --rpc-url https://rpc.mpp.tempo.xyz
 
 Fund your testnet wallet with `tempo wallet fund` before making requests.
 
-### Gas sponsorship
+### MPP gas sponsorship
 
 Some MPP endpoints sponsor gas fees on behalf of the caller. When the server's challenge includes a `feePayer` flag, Foundry delegates gas payment to the server, so no native balance is needed for gas.
 
-## Troubleshooting
+## Troubleshoot MPP with Foundry
 
 | Error | Cause | Fix |
 |---|---|---|
@@ -230,7 +230,7 @@ Some MPP endpoints sponsor gas fees on behalf of the caller. When the server's c
 | `410 Gone` | Stale local channel state | Re-run the command — Foundry clears stale state and opens a fresh channel |
 | `access key does not exist` | Signing key not yet provisioned on-chain | Foundry retries automatically with a key provisioning bundle — no action needed |
 
-## Next steps
+## Next steps for MPP with Foundry
 
 <Cards>
   <Card

--- a/src/pages/docs/sdk/foundry/signature-verifier.mdx
+++ b/src/pages/docs/sdk/foundry/signature-verifier.mdx
@@ -13,7 +13,7 @@ The Foundry project template for Tempo ships with a working example that demonst
 forge init --template tempo my-project && cd my-project
 ```
 
-## How it works
+## How signature verification works in Foundry
 
 The template's `Mail` contract supports two modes:
 
@@ -85,7 +85,7 @@ contract Mail {
 }
 ```
 
-## Testing
+## Test signature verification in Foundry
 
 The template includes tests for both signature types. Tempo support is enabled by the template's Foundry config. If you copy this pattern into an existing project, make sure `foundry.toml` enables Tempo mode:
 
@@ -142,7 +142,7 @@ forge test -vvv
 
 The secp256k1 and P256 relay tests use Tempo mode through the template's Foundry config.
 
-## Related
+## Related signature verification docs
 
 - [TIP-1020: Signature Verification Precompile](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md)
 - [T6 Network Upgrade](/docs/protocol/upgrades/t6)

--- a/src/pages/docs/sdk/go/index.mdx
+++ b/src/pages/docs/sdk/go/index.mdx
@@ -1,8 +1,9 @@
 ---
+title: Go SDK
 description: Build blockchain apps with the Tempo Go SDK. Send transactions, batch calls, and handle fee sponsorship with idiomatic Go code.
 ---
 
-# Go
+# Go SDK
 
 Tempo distributes a Go SDK for building application clients. The SDK provides packages for RPC communication, transaction signing, and key management.
 
@@ -11,7 +12,7 @@ The Tempo Go SDK can be used to perform common operations with the chain, such a
 
 ::::steps
 
-## Install
+## Install the Go SDK
 
 To install the Tempo Go SDK:
 
@@ -23,7 +24,7 @@ go get github.com/tempoxyz/tempo-go@v0.3.0
 The SDK requires Go 1.21 or higher.
 :::
 
-## Create an RPC Client
+## Create a Go RPC client
 
 To interact with Tempo, first create an RPC client connected to a Tempo node:
 
@@ -54,7 +55,7 @@ c := client.New("https://rpc.tempo.xyz",
 )
 ```
 
-## Create a Signer
+## Create a Go transaction signer
 
 Create a signer to sign transactions. The signer manages your private key and generates signatures:
 
@@ -77,7 +78,7 @@ func main() {
 }
 ```
 
-## Send a Transaction
+## Send a Tempo transaction with Go
 
 Build and send a transaction using the builder pattern:
 
@@ -122,9 +123,9 @@ func main() {
 
 ::::
 
-## Examples
+## Go SDK examples
 
-### Read Chain Data
+### Read chain data with Go
 
 Query the blockchain for basic information:
 
@@ -138,7 +139,7 @@ nonce, _ := c.GetTransactionCount(ctx, "0x742d35Cc6634C0532925a3b844Bc9e7595f0bE
 fmt.Printf("Block: %d, Chain: %d, Nonce: %d\n", blockNum, chainID, nonce)
 ```
 
-### Token Transfer
+### Send a token transfer with Go
 
 Send a TIP-20 token transfer using go-ethereum's ABI encoding:
 
@@ -161,7 +162,7 @@ tx := transaction.NewBuilder(big.NewInt(4217)).
     Build()
 ```
 
-### Transfer with Memo
+### Send a memo transfer with Go
 
 Include a memo for payment reconciliation:
 
@@ -184,7 +185,7 @@ tx := transaction.NewBuilder(big.NewInt(4217)).
     Build()
 ```
 
-### Batch Multiple Calls
+### Batch multiple calls with Go
 
 Execute multiple operations atomically in a single transaction:
 
@@ -233,7 +234,7 @@ go func() { c.SendRawTransaction(ctx, serialize(tx1)) }()
 go func() { c.SendRawTransaction(ctx, serialize(tx2)) }()
 ```
 
-### Fee Sponsorship
+### Fee sponsorship with Go
 
 Have another account pay for transaction fees:
 
@@ -251,7 +252,7 @@ transaction.SignTransaction(tx, userSigner)
 transaction.AddFeePayerSignature(tx, feePayerSigner)
 ```
 
-### Transaction Validity Window
+### Transaction validity windows in Go
 
 Set a time window during which the transaction is valid:
 
@@ -269,7 +270,7 @@ tx := transaction.NewBuilder(big.NewInt(4217)).
     Build()
 ```
 
-### Batch RPC Requests
+### Batch RPC requests with Go
 
 Send multiple RPC calls efficiently in a single HTTP request:
 
@@ -285,7 +286,7 @@ for _, resp := range responses {
 }
 ```
 
-## Account Keychain
+## Account Keychain in the Go SDK
 
 The `keychain` package provides typed helpers for Tempo's [Account Keychain precompile](/docs/protocol/transactions/AccountKeychain), enabling access key management and signing directly from Go.
 
@@ -373,7 +374,7 @@ func main() {
 }
 ```
 
-### Signing with an Access Key
+### Sign with an access key in Go
 
 Use `keychain.SignWithAccessKey` to sign a transaction as an access key holder:
 
@@ -394,7 +395,7 @@ serialized, _ := transaction.Serialize(tx, nil)
 hash, _ := c.SendRawTransaction(ctx, serialized)
 ```
 
-### Query Remaining Spending Limit
+### Query remaining spending limits with Go
 
 ```go [query_limit.go]
 calldata := keychain.EncodeGetRemainingLimitCalldata(
@@ -407,7 +408,7 @@ remaining := keychain.ParseRemainingLimitResult(result)
 fmt.Printf("Remaining: %s\n", remaining.String())
 ```
 
-## Packages
+## Go SDK packages
 
 | Package | Description |
 | --- | --- |
@@ -416,7 +417,7 @@ fmt.Printf("Remaining: %s\n", remaining.String())
 | `signer` | Key management and signature generation |
 | `keychain` | Account Keychain precompile: access key management and signing |
 
-## Next Steps
+## Next steps for the Go SDK
 
 After setting up the Go SDK, you can:
 

--- a/src/pages/docs/sdk/index.mdx
+++ b/src/pages/docs/sdk/index.mdx
@@ -1,10 +1,11 @@
 ---
+title: Tempo SDKs
 description: Integrate Tempo into your applications with SDKs for TypeScript, Go, Rust, and Foundry. Build blockchain apps in your preferred language.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# SDKs
+# Tempo SDKs
 
 Tempo is building clients in multiple languages to make integration as easy as possible.
 

--- a/src/pages/docs/sdk/python/index.mdx
+++ b/src/pages/docs/sdk/python/index.mdx
@@ -1,8 +1,9 @@
 ---
+title: Python SDK
 description: Build blockchain apps with the Tempo Python SDK. Send transactions, batch calls, and handle fee sponsorship using web3.py.
 ---
 
-# Python
+# Python SDK
 
 Tempo distributes a Python SDK as a [web3.py](https://web3py.readthedocs.io/) extension. The SDK adds native support for Tempo Transactions, including call batching, fee sponsorship, and access key management.
 
@@ -10,7 +11,7 @@ The Tempo Python SDK can be used to perform common operations with the chain, su
 
 ::::steps
 
-## Install
+## Install the Python SDK
 
 To install the Tempo Python SDK:
 
@@ -22,7 +23,7 @@ pip install pytempo
 The SDK requires Python 3.9 or higher and web3.py 7.0+.
 :::
 
-## Create a Client
+## Create a Python client
 
 To interact with Tempo, create a web3.py client connected to a Tempo node:
 
@@ -35,7 +36,7 @@ block_number = w3.eth.block_number
 print(f"Connected to Tempo at block {block_number}")
 ```
 
-## Send a Transaction
+## Send a Tempo transaction with Python
 
 Build and send a transaction using the `TempoTransaction` class:
 
@@ -68,9 +69,9 @@ print(f"Transaction hash: {tx_hash.hex()}")
 
 ::::
 
-## Examples
+## Python SDK examples
 
-### Token Transfer
+### Send a token transfer with Python
 
 Send a TIP-20 token transfer using pytempo's typed contract helpers:
 
@@ -93,7 +94,7 @@ tx = TempoTransaction.create(
 )
 ```
 
-### Pay Fees in a Stablecoin
+### Pay fees in a stablecoin with Python
 
 Use a TIP-20 token to pay for transaction fees instead of the native token:
 
@@ -114,7 +115,7 @@ tx = TempoTransaction.create(
 )
 ```
 
-### Batch Multiple Calls
+### Batch multiple calls with Python
 
 Execute multiple operations atomically in a single transaction:
 
@@ -173,7 +174,7 @@ w3.eth.send_raw_transaction(signed_tx1.encode())
 w3.eth.send_raw_transaction(signed_tx2.encode())
 ```
 
-### Fee Sponsorship
+### Fee sponsorship with Python
 
 Have another account pay for transaction fees:
 
@@ -193,7 +194,7 @@ final_tx = signed_by_user.sign(fee_payer_private_key, for_fee_payer=True) # [!co
 w3.eth.send_raw_transaction(final_tx.encode())
 ```
 
-### Transaction Validity Window
+### Transaction validity windows in Python
 
 Set a time window during which the transaction is valid:
 
@@ -214,7 +215,7 @@ tx = TempoTransaction.create(
 )
 ```
 
-## Account Keychain
+## Account Keychain in the Python SDK
 
 The `AccountKeychain` class provides typed helpers for Tempo's [Account Keychain precompile](/docs/protocol/transactions/AccountKeychain), enabling access key management directly from Python.
 
@@ -327,7 +328,7 @@ remaining = AccountKeychain.get_remaining_limit(
 print(f"Remaining: {remaining}")
 ```
 
-### Signing with an Access Key
+### Sign with an access key in Python
 
 Use `sign_access_key` to sign a transaction as an access key holder:
 
@@ -350,7 +351,7 @@ signed_tx = tx.sign_access_key( # [!code hl]
 tx_hash = w3.eth.send_raw_transaction(signed_tx.encode())
 ```
 
-## Next Steps
+## Next steps for the Python SDK
 
 After setting up the Python SDK, you can:
 

--- a/src/pages/docs/sdk/rust/index.mdx
+++ b/src/pages/docs/sdk/rust/index.mdx
@@ -1,8 +1,9 @@
 ---
+title: Rust SDK
 description: Build blockchain apps with the Tempo Rust SDK using Alloy. Query chains, send transactions, and manage tokens with type-safe Rust code.
 ---
 
-# Rust
+# Rust SDK
 
 Tempo distributes a Rust SDK in the form of an [Alloy](https://alloy.rs) crate. Alloy is a popular Rust crate for interacting with EVM-compatible blockchains.
 
@@ -10,7 +11,7 @@ The Tempo Alloy crate can be used to perform common operations with the chain, s
 
 ::::steps
 
-## Install
+## Install the Rust SDK
 
 To install the Tempo extension, you will need to install [Alloy](https://alloy.rs) and Tempo:
 
@@ -23,7 +24,7 @@ cargo add tempo-alloy --git https://github.com/tempoxyz/tempo --tag v1.4.2
 We use [`tokio`](https://tokio.rs) in this example, but you can use any async runtime.
 :::
 
-## Configure A Provider
+## Configure a Rust provider
 
 To use the Tempo extension crate, you will need to create a [`Provider`] using the [`TempoNetwork`](https://tempoxyz.github.io/tempo/tempo_alloy/struct.TempoNetwork.html). This will enable the usage of Tempo specific types on the [`Provider`] instance.
 
@@ -46,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-## Use Actions
+## Use Tempo actions in Rust
 
 Now we are ready to use the provider to interact with the network. We can use the provider to send transactions, read data, and more.
 

--- a/src/pages/docs/sdk/typescript/index.mdx
+++ b/src/pages/docs/sdk/typescript/index.mdx
@@ -1,4 +1,5 @@
 ---
+title: TypeScript SDKs
 description: Build blockchain apps with Tempo using Viem and Wagmi. Send transactions, manage tokens, and integrate AMM pools with TypeScript.
 ---
 
@@ -36,7 +37,7 @@ The Tempo extensions cover common chain operations such as querying state, sendi
 
 :::
 
-## Viem
+## Viem SDK for Tempo
 
 The T3-compatible `viem` release includes the updated access-key ABI, including periodic limits and call scoping. See the [T3 network upgrade](/docs/protocol/upgrades/t3) for migration details.
 
@@ -49,7 +50,7 @@ The T3-compatible `viem` release includes the updated access-key ABI, including 
   />
 </Cards>
 
-## Wagmi
+## Wagmi SDK for Tempo
 
 <Cards>
   <Card

--- a/src/pages/docs/sdk/typescript/prool/setup.mdx
+++ b/src/pages/docs/sdk/typescript/prool/setup.mdx
@@ -1,14 +1,15 @@
 ---
+title: Prool Setup
 description: Set up infinite pooled Tempo node instances in TypeScript with Prool for testing and local development of blockchain applications.
 ---
 
-# Setup
+# Prool Setup
 
 Setup infinite pooled Tempo node instances in TypeScript using [`prool`](https://github.com/wevm/prool) by following the steps below.
 
 ::::steps
 
-## Install
+## Install Prool for Tempo
 
 :::code-group
 ```bash [npm]
@@ -26,7 +27,7 @@ bun i prool
 
 - [Prool](https://github.com/wevm/prool) is a library that provides programmatic HTTP testing instances for Ethereum.
 
-## Create Instance
+## Create a Prool instance
 
 You can programmatically start a Tempo node instance in TypeScript using `Instance.tempo`:
 
@@ -62,7 +63,7 @@ await instance.start()
 ```
 :::
 
-## Next Steps
+## Next steps for Prool
 
 After you have set up Tempo with Prool, you can now:
 
@@ -70,4 +71,3 @@ After you have set up Tempo with Prool, you can now:
 - Run Tempo locally alongside your Vite or Next.js development server
 
 ::::
-

--- a/src/pages/docs/tools.mdx
+++ b/src/pages/docs/tools.mdx
@@ -11,17 +11,17 @@ Use this section when you need the implementation surface for Tempo: libraries, 
 
 If you are integrating a product, start with the TypeScript SDKs and hosted services. If you are operating infrastructure or debugging low-level behavior, start with the CLI and RPC reference.
 
-## Developer Surfaces
+## Build with SDKs
 
 <Cards>
   <Card
-    title="SDKs"
+    title="Tempo SDKs"
     description="Use TypeScript, Go, Foundry, Python, and Rust tooling for Tempo applications."
     to="/docs/sdk"
     icon="lucide:package"
   />
   <Card
-    title="CLI"
+    title="Tempo CLI"
     description="Manage wallets, make requests, download binaries, and run node-related commands."
     to="/docs/cli"
     icon="lucide:terminal"
@@ -40,17 +40,17 @@ If you are integrating a product, start with the TypeScript SDKs and hosted serv
   />
 </Cards>
 
-## References and Data
+## Operate and Inspect
 
 <Cards>
   <Card
-    title="JSON-RPC Reference"
+    title="JSON-RPC API"
     description="Browse Tempo RPC methods, request shapes, and protocol-level API behavior."
     to="/docs/protocol/rpc"
     icon="lucide:braces"
   />
   <Card
-    title="Indexer (tidx)"
+    title="Tempo Indexer (tidx)"
     description="Query Tempo blocks, transactions, logs, token balances, and decoded events through SQL."
     to="/docs/developer-tools/indexer"
     icon="lucide:database"

--- a/src/pages/docs/wallet/index.mdx
+++ b/src/pages/docs/wallet/index.mdx
@@ -12,13 +12,13 @@ Tempo Wallet CLI is the command-line way to use Tempo Wallet from scripts, termi
 
 Together they let you browse paid APIs, preview costs, and execute paid requests from a terminal, script, or AI agent without writing any integration code.
 
-## Install
+## Install Tempo Wallet CLI
 
 ```bash
 curl -fsSL https://tempo.xyz/install | bash
 ```
 
-## Authenticate
+## Authenticate with Tempo Wallet CLI
 
 ```bash
 tempo wallet login
@@ -75,7 +75,7 @@ codex exec "Read https://tempo.xyz/SKILL.md and set up tempo"
 
 This installs `tempo-wallet` and `tempo-request` skills automatically. The agent can then discover services, preview costs, and make paid requests within scoped spending limits.
 
-## Next
+## Next Tempo Wallet steps
 
 - [Wallet CLI](/docs/cli/wallet): canonical docs and command reference
 - [Reference](/docs/wallet/reference): legacy command reference

--- a/src/pages/docs/wallet/recipes.mdx
+++ b/src/pages/docs/wallet/recipes.mdx
@@ -3,9 +3,9 @@ title: Tempo Wallet CLI Recipes
 description: Use Tempo Wallet CLI recipes for agent setup, MPP service discovery, paid requests, credits, sessions, funding, and transfers.
 ---
 
-# Recipes
+# Tempo Wallet Recipes
 
-## Core Flow
+## Tempo Wallet core flow
 
 ```bash
 tempo wallet -t whoami
@@ -16,7 +16,7 @@ tempo request --dry-run <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 tempo request --max-spend 1.00 <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 ```
 
-## Wallet Operations
+## Tempo Wallet operations
 
 ```bash
 # Wallet readiness and balances
@@ -46,7 +46,7 @@ tempo wallet -t keys
 
 Use access-key spending limits and `tempo request --max-spend` for agent workflows. Credits are separate from token balances and only work with eligible one-time MPP charges.
 
-## Service Discovery
+## Tempo Wallet service discovery
 
 ```bash
 # Search services by keyword
@@ -60,7 +60,7 @@ Tip: copy endpoint URL, method, and payload shape directly from service details.
 
 Service details also show pricing, payment mode, and whether `supportsCredits: true` is available.
 
-## Request Execution
+## Tempo Wallet request execution
 
 Preview before paying:
 
@@ -83,7 +83,7 @@ tempo wallet -t transfer --credits --dry-run --mpp-challenge-file "$headers"
 tempo wallet -t transfer --credits --mpp-challenge-file "$headers"
 ```
 
-## Session Management
+## Tempo Wallet session management
 
 ```bash
 # List sessions
@@ -104,7 +104,7 @@ tempo wallet sessions close --finalize
 
 Sessions are MPP payment channels used by pay-as-you-go services. One-time charges may use direct token payment or MPP Credits when the service supports credits.
 
-## Agent and Script Mode
+## Tempo Wallet agent and script mode
 
 Use TOON output (`-t`) when command output is consumed by agents or scripts.
 
@@ -115,7 +115,7 @@ tempo wallet -t services <SERVICE_ID>
 tempo request -t --dry-run --max-spend 1.00 <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 ```
 
-## Failure Recovery Shortcuts
+## Tempo Wallet failure recovery shortcuts
 
 ```bash
 # Wallet not ready / auth missing
@@ -141,7 +141,7 @@ tempo wallet fund --credits
 
 If issues persist, continue with [Troubleshooting](/docs/cli/wallet).
 
-## End-to-End Script Pattern
+## Tempo Wallet end-to-end script pattern
 
 ```bash
 # 1) Ensure wallet is ready
@@ -157,7 +157,7 @@ tempo request --dry-run <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 tempo request --max-spend 1.00 <SERVICE_ENDPOINT_URL> --json '{"input":"hello"}'
 ```
 
-## See Also
+## Related Tempo Wallet docs
 
 1. [Reference](/docs/wallet/reference)
 2. [Wallet CLI Reference](/docs/cli/wallet)

--- a/src/pages/docs/wallet/reference.mdx
+++ b/src/pages/docs/wallet/reference.mdx
@@ -9,7 +9,7 @@ description: Complete reference for Tempo Wallet CLI, tempo wallet, tempo reques
 
 Manages your onchain identity and provides service discovery for [MPP](https://mpp.dev) endpoints.
 
-### Auth
+### Wallet auth commands
 
 | Command | Description |
 | --- | --- |
@@ -20,7 +20,7 @@ Manages your onchain identity and provides service discovery for [MPP](https://m
 | `tempo wallet whoami` | Print readiness, address, balances, and key state |
 | `tempo wallet whoami --credits` | Show MPP Credits balance |
 
-### Keys
+### Wallet key commands
 
 Each wallet can have multiple access keys with independent spending limits. This is how you constrain what an agent or script can spend.
 
@@ -30,7 +30,7 @@ Each wallet can have multiple access keys with independent spending limits. This
 | `tempo wallet revoke <access-key> --dry-run` | Preview access-key revocation |
 | `tempo wallet revoke <access-key>` | Revoke an access key |
 
-### Funds
+### Wallet funding commands
 
 | Command | Description |
 | --- | --- |
@@ -41,7 +41,7 @@ Each wallet can have multiple access keys with independent spending limits. This
 | `tempo wallet transfer <amount> <token> <to> --dry-run` | Preview a token transfer |
 | `tempo wallet transfer --credits --mpp-challenge-file <file>` | Pay a captured MPP challenge with credits |
 
-### Services
+### Wallet service commands
 
 The service directory indexes [MPP](https://mpp.dev)-registered providers. Each service entry includes endpoint URLs, HTTP methods, pricing, request schemas, payment mode, and credit support when available.
 
@@ -51,7 +51,7 @@ The service directory indexes [MPP](https://mpp.dev)-registered providers. Each 
 | `tempo wallet services --search <query>` | Filter services by keyword |
 | `tempo wallet services <id>` | Show a service's endpoints, methods, and request schemas |
 
-### Sessions
+### Wallet session commands
 
 Sessions are the local state for [pay-as-you-go](/docs/guide/machine-payments/pay-as-you-go) payment channels. Tempo Wallet CLI tracks them locally and can reconcile against onchain state.
 
@@ -84,7 +84,7 @@ A curl-like HTTP client that handles [MPP](https://mpp.dev) payment negotiation 
 | `tempo request <url> -H 'Header: Value'` | Add a custom header |
 | `tempo request -D <file> <url>` | Write response headers to a file |
 
-## Global flags
+## Tempo Wallet global flags
 
 | Flag | Scope | Description |
 | --- | --- | --- |
@@ -95,7 +95,7 @@ A curl-like HTTP client that handles [MPP](https://mpp.dev) payment negotiation 
 | `--describe` | supported commands | Output command schema as JSON for programmatic tooling |
 | `--schema` | supported built-in setup commands | Output command schema for programmatic tooling |
 
-## Source
+## Tempo Wallet source
 
 - Repository: [`tempoxyz/wallet-cli`](https://github.com/tempoxyz/wallet-cli)
 - Full help: `tempo wallet --help`, `tempo request --help`

--- a/src/pages/docs/wallet/use-with-agents.mdx
+++ b/src/pages/docs/wallet/use-with-agents.mdx
@@ -3,9 +3,9 @@ title: Use Tempo Wallet CLI with Agents
 description: Connect Tempo Wallet CLI to AI agents for MPP service discovery, payment previews, spend caps, credits, and paid HTTP requests.
 ---
 
-# Use with Agents
+# Use Tempo Wallet CLI with Agents
 
-## Quickstart
+## Agent wallet quickstart
 
 Paste this into your agent to set up Tempo Wallet CLI:
 
@@ -23,7 +23,7 @@ codex exec "Read https://tempo.xyz/SKILL.md and set up tempo"
 ```
 :::
 
-## Auto-installed Skills
+## Auto-installed Tempo wallet skills
 
 When you run the setup prompt, your agent installs Tempo's built-in skills automatically. No manual skill wiring required.
 
@@ -32,7 +32,7 @@ When you run the setup prompt, your agent installs Tempo's built-in skills autom
 
 This works in supported skill-enabled agents including **Claude Code**, **Amp**, **Codex**, and similar environments.
 
-## Agent-Ready by Design
+## Tempo Wallet is agent-ready by design
 
 1. **TOON output mode (`-t` / `--toon-output`)** gives compact, machine-readable, token-efficient output so agent tooling can parse command responses reliably.
 2. **Built-in service discovery** (`tempo wallet services`) lets agents search providers, inspect endpoint details, and use verified method/path metadata instead of guessing URLs or payload shapes.
@@ -40,7 +40,7 @@ This works in supported skill-enabled agents including **Claude Code**, **Amp**,
 4. **`--max-spend` and scoped access keys** let you enforce budgets per request and per key.
 5. **MPP Credits support** lets agents pay eligible one-time charges from a separate credits balance after checking `tempo wallet -t whoami --credits`.
 
-## Agent Pattern
+## Tempo Wallet agent pattern
 
 ```bash
 tempo wallet -t whoami
@@ -59,6 +59,6 @@ tempo request -t --dry-run -D "$headers" -X POST --json '{"input":"hello"}' <SER
 tempo wallet -t transfer --credits --dry-run --mpp-challenge-file "$headers"
 ```
 
-## Troubleshooting
+## Troubleshoot agent wallet flows
 
 If agent runs fail, continue with [Troubleshooting](/docs/cli/wallet).

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1093,17 +1093,25 @@ export default defineConfig({
 
     const docsHomeSidebar = [
       {
-        text: 'First Steps',
+        text: 'Start Here',
         items: [
           { text: 'Connect to Tempo', link: '/docs/quickstart/integrate-tempo' },
           { text: 'Get Funds', link: '/docs/guide/getting-funds' },
-          { text: 'Send a Payment', link: '/docs/guide/payments' },
-          { text: 'Use Tempo Transactions', link: '/docs/guide/tempo-transaction' },
-          { text: 'Issue a Stablecoin', link: '/docs/guide/issuance' },
+          { text: 'Send Your First Payment', link: '/docs/guide/payments/send-a-payment' },
         ],
       },
       {
-        text: 'Resources',
+        text: 'Build Paths',
+        items: [
+          { text: 'Stablecoin Payments', link: '/docs/guide/payments' },
+          { text: 'Issue Stablecoins', link: '/docs/guide/issuance' },
+          { text: 'Exchange Stablecoins', link: '/docs/guide/stablecoin-dex' },
+          { text: 'Agentic Payments', link: '/docs/guide/machine-payments' },
+          { text: 'Private Zones', link: '/docs/guide/private-zones' },
+        ],
+      },
+      {
+        text: 'Reference and Operations',
         items: [
           { text: 'Tools & SDKs', link: '/docs/tools' },
           { text: 'Tempo Protocol', link: '/docs/protocol' },


### PR DESCRIPTION
## Summary

- Reworked docs headings and SEO frontmatter so pages have clearer, more specific titles and subheadings for findability.
- Editorialized the docs hub flow, including the Get Started, Build on Tempo, Tools & SDKs, Integrate Tempo, Protocol, payments, issuance, and stablecoin DEX indexes.
- Surfaced important workflow cards such as rewards distribution and fee liquidity management while preserving existing URL paths.

## Validation

- `git diff --cached --check`
- `bun run check:types`
- Local dev server served the updated docs pages at `http://127.0.0.1:5173/docs`.

Note: `bun run check` and `bun run build` were not used as blockers because this branch is docs-only and the repo currently has unrelated pre-existing Biome/build issues outside this docs-heading pass.