### PR TITLE
fix: redirect legacy docs host paths to developers docs

### DIFF
--- a/src/lib/docs-routing.test.ts
+++ b/src/lib/docs-routing.test.ts
@@ -37,6 +37,23 @@ function findHostRedirect(source: string, host: string) {
   )
 }
 
+function findHostRedirectIndex(source: string, host: string) {
+  return vercelConfig.redirects.findIndex(
+    (redirect) =>
+      redirect.source === source &&
+      Array.isArray(redirect.has) &&
+      redirect.has.some(
+        (condition) =>
+          typeof condition === 'object' &&
+          condition !== null &&
+          'type' in condition &&
+          'value' in condition &&
+          condition.type === 'host' &&
+          condition.value === host,
+      ),
+  )
+}
+
 describe('docs routing redirects', () => {
   it.each([
     ['/', 'https://tempo.xyz/developers'],
@@ -49,6 +66,40 @@ describe('docs routing redirects', () => {
       destination,
       permanent: true,
     })
+  })
+
+  it.each([
+    ['/guide/bridge-usdc-stargate', 'https://tempo.xyz/developers/docs/guide/bridge-layerzero'],
+    ['/guide/bridge-usdc-relay', 'https://tempo.xyz/developers/docs/guide/bridge-relay'],
+    [
+      '/guide/node/validator-config-v2',
+      'https://tempo.xyz/developers/docs/guide/node/network-upgrades',
+    ],
+    ['/AccountKeychain', 'https://tempo.xyz/developers/docs/protocol/transactions/AccountKeychain'],
+    ['/developer-tools', 'https://tempo.xyz/developers/docs/ecosystem'],
+    ['/learn/partners', 'https://tempo.xyz/developers/docs/partners'],
+    ['/docs/learn/partners', 'https://tempo.xyz/developers/docs/partners'],
+    ['/docs/guide/using-tempo-with-ai/partners', 'https://tempo.xyz/developers/docs/partners'],
+    ['/build/partners', 'https://tempo.xyz/developers/docs/partners'],
+    ['/network-upgrades', 'https://tempo.xyz/developers/docs/guide/node/network-upgrades'],
+    [
+      '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|hosted-services|changelog|partners)',
+      'https://tempo.xyz/developers/docs/:section',
+    ],
+    [
+      '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|developer-tools|hosted-services)/:path*',
+      'https://tempo.xyz/developers/docs/:section/:path*',
+    ],
+  ])('redirects legacy docs host %s to %s before the host catch-all', (source, destination) => {
+    expect(findHostRedirect(source, 'docs.tempo.xyz')).toMatchObject({
+      source,
+      destination,
+      permanent: true,
+    })
+
+    expect(findHostRedirectIndex(source, 'docs.tempo.xyz')).toBeLessThan(
+      findHostRedirectIndex('/:path*', 'docs.tempo.xyz'),
+    )
   })
 
   it.each([

--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,138 @@
       "permanent": true
     },
     {
+      "source": "/guide/bridge-usdc-stargate",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/bridge-layerzero",
+      "permanent": true
+    },
+    {
+      "source": "/guide/bridge-usdc-relay",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/bridge-relay",
+      "permanent": true
+    },
+    {
+      "source": "/guide/node/validator-config-v2",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/node/network-upgrades",
+      "permanent": true
+    },
+    {
+      "source": "/AccountKeychain",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/protocol/transactions/AccountKeychain",
+      "permanent": true
+    },
+    {
+      "source": "/developer-tools",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/ecosystem",
+      "permanent": true
+    },
+    {
+      "source": "/learn/partners",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/partners",
+      "permanent": true
+    },
+    {
+      "source": "/docs/learn/partners",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/partners",
+      "permanent": true
+    },
+    {
+      "source": "/docs/guide/using-tempo-with-ai/partners",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/partners",
+      "permanent": true
+    },
+    {
+      "source": "/build/partners",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/partners",
+      "permanent": true
+    },
+    {
+      "source": "/network-upgrades",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/node/network-upgrades",
+      "permanent": true
+    },
+    {
+      "source": "/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|hosted-services|changelog|partners)",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/:section",
+      "permanent": true
+    },
+    {
+      "source": "/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|developer-tools|hosted-services)/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "docs.tempo.xyz"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/:section/:path*",
+      "permanent": true
+    },
+    {
       "source": "/:path*",
       "has": [
         {


### PR DESCRIPTION
## Summary
- redirect legacy docs.tempo.xyz top-level docs paths directly to their tempo.xyz/developers/docs destinations
- simplify docs-host API redirects to /api and /api/:path* while keeping app-local API redirects explicit so /api/og, /api/feedback, and /api/mcp remain routable
- preserve already-prefixed /developers paths on docs.tempo.xyz
- cover known renamed docs paths such as old bridge and partner URLs

Note: this handles the docs-host side of the migration. The companion tempo-web PR fixes the /developers/docs/... proxy ordering so these destinations do not hit the trailing-slash loop: https://github.com/tempoxyz/tempo-web/pull/393

## Testing
- bun test src/lib/docs-routing.test.ts