### PR TITLE
Document validator operator signer options

### DIFF
--- a/src/pages/docs/guide/node/validator-keys.mdx
+++ b/src/pages/docs/guide/node/validator-keys.mdx
@@ -18,7 +18,7 @@ Use different signing keys and operator keys for testnet and mainnet. A testnet 
 | Key / Address | Type | What it does | Sensitivity | How to change |
 |---|---|---|---|---|
 | **Signing key** | Ed25519 keypair | Identifies your validator in the consensus protocol. Used for DKG participation, block proposals, and voting. | **Critical** — anyone with this key can impersonate your validator. | [Rotate validator identity](/docs/guide/node/validator-lifecycle#rotate-validator-identity) |
-| **Validator operator address** | Ethereum address (`0x…`) | The control address that authorizes on-chain operations: IP updates, key rotation, ownership transfer, and deactivation. | **High** — controls all validator configuration. | [Transfer validator ownership](/docs/guide/node/validator-lifecycle#transfer-validator-ownership) |
+| **Validator operator address** | Ethereum address (`0x…`) | The control address that authorizes on-chain operations: IP updates, fee-recipient updates, key rotation, ownership transfer, and deactivation. | **High** — controls all validator configuration. | [Transfer validator ownership](/docs/guide/node/validator-lifecycle#transfer-validator-ownership) |
 | **Fee recipient** | Ethereum address (`0x…`) | Receives transaction fees from blocks your validator proposes. | **Low** — changing it only redirects future fee revenue, no security impact. | [Update fee recipient](/docs/guide/node/validator-lifecycle#update-the-fee-recipient) |
 | **Signing share** | BLS12-381 key share | A share of the committee's threshold signing key, used to sign block notarizations and finalizations. | **Managed automatically** — updated every DKG ceremony (~3 hours). Lost shares are recovered from the network on restart. | Automatic (see [recovery](#signing-share-recovery)) |
 
@@ -109,6 +109,27 @@ tempo consensus generate-signing-key \
 ## Signing key rotation
 
 The ed25519 signing key can be rotated while preserving your validator index and committee slot. See [Rotate validator identity](/docs/guide/node/validator-lifecycle#rotate-validator-identity) for the full procedure.
+
+## Validator operator address custody
+
+The validator operator address is an Ethereum address, but it does not need to be controlled by a plaintext EOA private key. The Tempo CLI can submit validator on-chain operations with a local wallet key, a hardware wallet, or a remote KMS signer.
+
+| Signer | CLI flag | Notes |
+|---|---|---|
+| Local wallet key file | `--wallet-key <PATH>` | Use only where local key custody is appropriate |
+| Ledger | `--ledger` | Uses the first Ledger Live account |
+| Trezor | `--trezor` | Uses the first Trezor Live account |
+| AWS KMS | `--aws` | Requires `AWS_KMS_KEY_ID` and AWS credentials in the environment |
+| GCP KMS | `--gcp` | Requires `GCP_PROJECT_ID`, `GCP_LOCATION`, `GCP_KEY_RING`, `GCP_KEY_NAME`, and `GCP_KEY_VERSION` |
+
+Use these signer flags for CLI commands that submit ValidatorConfig transactions, including rotation, IP updates, fee-recipient updates, deactivation, and ownership transfer.
+
+:::info
+The validator identity signature and the transaction signer are different:
+
+- The ed25519 consensus signing key proves ownership of the validator public key during registration and rotation.
+- The Ethereum transaction signer controls the validator operator address or contract owner address. It can be backed by a hardware wallet or remote KMS.
+:::
 
 ## Signing share recovery
 

--- a/src/pages/docs/guide/node/validator-keys.mdx
+++ b/src/pages/docs/guide/node/validator-keys.mdx
@@ -122,13 +122,13 @@ The validator operator address is an Ethereum address, but it does not need to b
 | AWS KMS | `--aws` | Requires `AWS_KMS_KEY_ID` and AWS credentials in the environment |
 | GCP KMS | `--gcp` | Requires `GCP_PROJECT_ID`, `GCP_LOCATION`, `GCP_KEY_RING`, `GCP_KEY_NAME`, and `GCP_KEY_VERSION` |
 
-Use these signer flags for CLI commands that submit ValidatorConfig transactions, including rotation, IP updates, fee-recipient updates, deactivation, and ownership transfer.
+Use these signer flags for CLI commands that submit transactions to the validator contract, including rotation, IP updates, fee-recipient updates, deactivation, and ownership transfer.
 
 :::info
 The validator identity signature and the transaction signer are different:
 
 - The ed25519 consensus signing key proves ownership of the validator public key during registration and rotation.
-- The Ethereum transaction signer controls the validator operator address or contract owner address. It can be backed by a hardware wallet or remote KMS.
+- The Ethereum transaction signer controls the validator operator address. It can be backed by a hardware wallet or remote KMS.
 :::
 
 ## Signing share recovery
@@ -143,4 +143,4 @@ All key and identity operations are executed through the ValidatorConfig V2 prec
 address constant VALIDATOR_CONFIG_V2 = 0xCCCCCCCC00000000000000000000000000000001;
 ```
 
-All write operations require either the contract owner or the validator's own address.
+Public validator write operations require the validator operator address.

--- a/src/pages/docs/guide/node/validator-lifecycle.mdx
+++ b/src/pages/docs/guide/node/validator-lifecycle.mdx
@@ -35,7 +35,7 @@ Self-service data resets are coming soon. Once available, you will be able to ro
 
 ## Managing your validator
 
-The lifecycle commands below submit ValidatorConfig transactions. The transaction signer must control the validator operator address or contract owner address, but it does not need to be a plaintext EOA key. Use the CLI signer backend that matches your custody setup; see [validator operator address custody](/docs/guide/node/validator-keys#validator-operator-address-custody).
+The lifecycle commands below submit transactions to the validator contract. The transaction signer must control the validator operator address, but it does not need to be a plaintext EOA key. Use the CLI signer backend that matches your custody setup; see [validator operator address custody](/docs/guide/node/validator-keys#validator-operator-address-custody).
 
 ### Rotate validator identity
 
@@ -55,8 +55,6 @@ tempo consensus validator <old_pubkey> --rpc-url https://rpc.testnet.tempo.xyz
 ```
 ::::
 :::
-
-The simplest way to rotate is using the `tempo` CLI, which handles signature creation and the on-chain transaction in one step.
 
 ::::code-group
 ```bash [Mainnet]

--- a/src/pages/docs/guide/node/validator-lifecycle.mdx
+++ b/src/pages/docs/guide/node/validator-lifecycle.mdx
@@ -33,7 +33,11 @@ If you need to reset your validator's data, you must rotate to a new validator i
 Self-service data resets are coming soon. Once available, you will be able to rotate to a new identity and reset your data without coordinating with the Tempo team. See [Rotate validator identity](#rotate-validator-identity).
 :::
 
-## Rotate validator identity
+## Managing your validator
+
+The lifecycle commands below submit ValidatorConfig transactions. The transaction signer must control the validator operator address or contract owner address, but it does not need to be a plaintext EOA key. Use the CLI signer backend that matches your custody setup; see [validator operator address custody](/docs/guide/node/validator-keys#validator-operator-address-custody).
+
+### Rotate validator identity
 
 The ed25519 key can be changed while keeping your validator index stable. This is useful for key rotation or recovery without leaving and re-joining the committee. [Generate a new signing key](/docs/guide/node/validator-keys#generating-a-signing-key) first.
 
@@ -52,7 +56,7 @@ tempo consensus validator <old_pubkey> --rpc-url https://rpc.testnet.tempo.xyz
 ::::
 :::
 
-The simplest way to rotate is using the `tempo` CLI, which handles signature creation and the on-chain transaction in one step. The transaction signer can be a local wallet key, hardware wallet, or remote KMS signer; see [validator operator address custody](/docs/guide/node/validator-keys#validator-operator-address-custody).
+The simplest way to rotate is using the `tempo` CLI, which handles signature creation and the on-chain transaction in one step.
 
 ::::code-group
 ```bash [Mainnet]
@@ -62,7 +66,6 @@ tempo consensus rotate-validator \
   --ingress <NEW_IP:PORT> \
   --egress <NEW_IP> \
   --signing-key <NEW_PRIVATE_KEY_PATH> \
-  --wallet-key <ETHEREUM_WALLET_KEY_PATH> \
   --rpc-url https://rpc.tempo.xyz
 ```
 ```bash [Testnet]
@@ -72,12 +75,9 @@ tempo consensus rotate-validator \
   --ingress <NEW_IP:PORT> \
   --egress <NEW_IP> \
   --signing-key <NEW_PRIVATE_KEY_PATH> \
-  --ledger \
   --rpc-url https://rpc.testnet.tempo.xyz
 ```
 ::::
-
-Replace `--wallet-key ...` or `--ledger` with `--trezor`, `--aws`, or `--gcp` when using another supported signer backend.
 
 If self-service rotation is not yet enabled for your validator, use `tempo consensus create-rotate-validator-signature` to generate the signature and provide it to the Tempo team.
 
@@ -87,7 +87,7 @@ Rotation preserves your validator index and active validator count. The old entr
 
 After rotation, your validator goes through the [standard state transitions](/docs/guide/node/validator-status#state-transitions) with the new identity.
 
-## Update IP addresses
+### Update IP addresses
 
 If your node's network endpoints change, update them on-chain. The change takes effect at the next finalized block.
 
@@ -96,25 +96,21 @@ If your node's network endpoints change, update them on-chain. The change takes 
 tempo consensus set-validator-ip-address <address/pubkey/index> \
   --ingress <NEW_IP:NEW_PORT> \
   --egress <NEW_IP> \
-  --rpc-url https://rpc.tempo.xyz \
-  --wallet-key <PATH_TO_VALIDATOR_WALLET_KEY>
+  --rpc-url https://rpc.tempo.xyz
 ```
 ```bash [Testnet]
 tempo consensus set-validator-ip-address <address/pubkey/index> \
   --ingress <NEW_IP:NEW_PORT> \
   --egress <NEW_IP> \
-  --rpc-url https://rpc.testnet.tempo.xyz \
-  --aws
+  --rpc-url https://rpc.testnet.tempo.xyz
 ```
 ::::
-
-Replace the signer flag with `--ledger`, `--trezor`, `--aws`, `--gcp`, or `--wallet-key <PATH>` depending on how the validator operator address is custodied.
 
 :::warning
 Ingress addresses must be unique across all active validators. The transaction will revert if another active validator already uses the same `IP:port`.
 :::
 
-## Update the fee recipient
+### Update the fee recipient
 
 The fee recipient used by your validator when constructing block proposals is managed on-chain. This can be updated and takes effect on the next finalized block.
 
@@ -122,20 +118,16 @@ The fee recipient used by your validator when constructing block proposals is ma
 ```bash [Mainnet]
 tempo consensus set-validator-fee-recipient <address/pubkey/index> \
   --fee-recipient <ETHEREUM_ADDRESS> \
-  --rpc-url https://rpc.tempo.xyz \
-  --wallet-key <PATH_TO_VALIDATOR_WALLET_KEY>
+  --rpc-url https://rpc.tempo.xyz
 ```
 ```bash [Testnet]
 tempo consensus set-validator-fee-recipient <address/pubkey/index> \
   --fee-recipient <ETHEREUM_ADDRESS> \
-  --rpc-url https://rpc.testnet.tempo.xyz \
-  --gcp
+  --rpc-url https://rpc.testnet.tempo.xyz
 ```
 ::::
 
-The same signer flags are supported here as for rotation and IP updates.
-
-## Transfer validator ownership
+### Transfer validator ownership
 
 Rebind your validator entry to a new control address:
 
@@ -143,20 +135,18 @@ Rebind your validator entry to a new control address:
 ```bash [Mainnet]
 tempo consensus transfer-validator-ownership <address/pubkey/index> \
   --rpc-url https://rpc.tempo.xyz \
-  --wallet-key <PATH_TO_VALIDATOR_WALLET_KEY> \
   --new-private-key <PATH_TO_NEW_VALIDATOR_PRIVATE_KEY>
 ```
 ```bash [Testnet]
 tempo consensus transfer-validator-ownership <address/pubkey/index> \
   --rpc-url https://rpc.testnet.tempo.xyz \
-  --ledger \
   --new-private-key <PATH_TO_NEW_VALIDATOR_PRIVATE_KEY>
 ```
 ::::
 
-The transaction signer for the current operator address can use any supported CLI signer backend. The `--new-private-key` argument is used to derive the replacement operator address, and that new address must not already be used by another active validator.
+The `--new-private-key` argument is used to derive the replacement operator address. That new address must not already be used by another active validator.
 
-## Deactivate your validator
+### Deactivate your validator
 
 Deactivate your validator when you want to leave the active set.
 
@@ -167,19 +157,15 @@ Your validator remains a dealer in the committee for at least one more epoch aft
 ::::code-group
 ```bash [Mainnet]
 tempo consensus deactivate-validator <address/pubkey/index> \
-  --rpc-url https://rpc.tempo.xyz \
-  --wallet-key <PATH_TO_VALIDATOR_WALLET_KEY>
+  --rpc-url https://rpc.tempo.xyz
 ```
 ```bash [Testnet]
 tempo consensus deactivate-validator <address/pubkey/index> \
-  --rpc-url https://rpc.testnet.tempo.xyz \
-  --trezor
+  --rpc-url https://rpc.testnet.tempo.xyz
 ```
 ::::
 
-Use the signer backend that controls the validator operator address.
-
-### Exit timeline
+#### Exit timeline
 
 Deactivation is not instant — your validator is phased out over two epochs:
 

--- a/src/pages/docs/guide/node/validator-lifecycle.mdx
+++ b/src/pages/docs/guide/node/validator-lifecycle.mdx
@@ -52,7 +52,7 @@ tempo consensus validator <old_pubkey> --rpc-url https://rpc.testnet.tempo.xyz
 ::::
 :::
 
-The simplest way to rotate is using the `tempo` CLI, which handles signature creation and the on-chain transaction in one step:
+The simplest way to rotate is using the `tempo` CLI, which handles signature creation and the on-chain transaction in one step. The transaction signer can be a local wallet key, hardware wallet, or remote KMS signer; see [validator operator address custody](/docs/guide/node/validator-keys#validator-operator-address-custody).
 
 ::::code-group
 ```bash [Mainnet]
@@ -62,7 +62,7 @@ tempo consensus rotate-validator \
   --ingress <NEW_IP:PORT> \
   --egress <NEW_IP> \
   --signing-key <NEW_PRIVATE_KEY_PATH> \
-  --private-key <ETHEREUM_PRIVATE_KEY_PATH> \
+  --wallet-key <ETHEREUM_WALLET_KEY_PATH> \
   --rpc-url https://rpc.tempo.xyz
 ```
 ```bash [Testnet]
@@ -72,10 +72,12 @@ tempo consensus rotate-validator \
   --ingress <NEW_IP:PORT> \
   --egress <NEW_IP> \
   --signing-key <NEW_PRIVATE_KEY_PATH> \
-  --private-key <ETHEREUM_PRIVATE_KEY_PATH> \
+  --ledger \
   --rpc-url https://rpc.testnet.tempo.xyz
 ```
 ::::
+
+Replace `--wallet-key ...` or `--ledger` with `--trezor`, `--aws`, or `--gcp` when using another supported signer backend.
 
 If self-service rotation is not yet enabled for your validator, use `tempo consensus create-rotate-validator-signature` to generate the signature and provide it to the Tempo team.
 
@@ -95,16 +97,18 @@ tempo consensus set-validator-ip-address <address/pubkey/index> \
   --ingress <NEW_IP:NEW_PORT> \
   --egress <NEW_IP> \
   --rpc-url https://rpc.tempo.xyz \
-  --private-key <PATH_TO_VALIDATOR_PRIVATE_KEY>
+  --wallet-key <PATH_TO_VALIDATOR_WALLET_KEY>
 ```
 ```bash [Testnet]
 tempo consensus set-validator-ip-address <address/pubkey/index> \
   --ingress <NEW_IP:NEW_PORT> \
   --egress <NEW_IP> \
   --rpc-url https://rpc.testnet.tempo.xyz \
-  --private-key <PATH_TO_VALIDATOR_PRIVATE_KEY>
+  --aws
 ```
 ::::
+
+Replace the signer flag with `--ledger`, `--trezor`, `--aws`, `--gcp`, or `--wallet-key <PATH>` depending on how the validator operator address is custodied.
 
 :::warning
 Ingress addresses must be unique across all active validators. The transaction will revert if another active validator already uses the same `IP:port`.
@@ -119,15 +123,17 @@ The fee recipient used by your validator when constructing block proposals is ma
 tempo consensus set-validator-fee-recipient <address/pubkey/index> \
   --fee-recipient <ETHEREUM_ADDRESS> \
   --rpc-url https://rpc.tempo.xyz \
-  --private-key <PATH_TO_VALIDATOR_PRIVATE_KEY>
+  --wallet-key <PATH_TO_VALIDATOR_WALLET_KEY>
 ```
 ```bash [Testnet]
 tempo consensus set-validator-fee-recipient <address/pubkey/index> \
   --fee-recipient <ETHEREUM_ADDRESS> \
   --rpc-url https://rpc.testnet.tempo.xyz \
-  --private-key <PATH_TO_VALIDATOR_PRIVATE_KEY>
+  --gcp
 ```
 ::::
+
+The same signer flags are supported here as for rotation and IP updates.
 
 ## Transfer validator ownership
 
@@ -137,18 +143,18 @@ Rebind your validator entry to a new control address:
 ```bash [Mainnet]
 tempo consensus transfer-validator-ownership <address/pubkey/index> \
   --rpc-url https://rpc.tempo.xyz \
-  --private-key <PATH_TO_VALIDATOR_PRIVATE_KEY> \
+  --wallet-key <PATH_TO_VALIDATOR_WALLET_KEY> \
   --new-private-key <PATH_TO_NEW_VALIDATOR_PRIVATE_KEY>
 ```
 ```bash [Testnet]
 tempo consensus transfer-validator-ownership <address/pubkey/index> \
   --rpc-url https://rpc.testnet.tempo.xyz \
-  --private-key <PATH_TO_VALIDATOR_PRIVATE_KEY> \
+  --ledger \
   --new-private-key <PATH_TO_NEW_VALIDATOR_PRIVATE_KEY>
 ```
 ::::
 
-The new address must not already be used by another active validator.
+The transaction signer for the current operator address can use any supported CLI signer backend. The `--new-private-key` argument is used to derive the replacement operator address, and that new address must not already be used by another active validator.
 
 ## Deactivate your validator
 
@@ -162,14 +168,16 @@ Your validator remains a dealer in the committee for at least one more epoch aft
 ```bash [Mainnet]
 tempo consensus deactivate-validator <address/pubkey/index> \
   --rpc-url https://rpc.tempo.xyz \
-  --private-key <PATH_TO_VALIDATOR_PRIVATE_KEY>
+  --wallet-key <PATH_TO_VALIDATOR_WALLET_KEY>
 ```
 ```bash [Testnet]
 tempo consensus deactivate-validator <address/pubkey/index> \
   --rpc-url https://rpc.testnet.tempo.xyz \
-  --private-key <PATH_TO_VALIDATOR_PRIVATE_KEY>
+  --trezor
 ```
 ::::
+
+Use the signer backend that controls the validator operator address.
 
 ### Exit timeline
 


### PR DESCRIPTION
## Summary
- clarify that the validator operator address does not need to be controlled by a plaintext EOA private key
- document supported Tempo CLI signer backends for validator on-chain operations: local wallet key, Ledger, Trezor, AWS KMS, and GCP KMS
- update validator lifecycle examples for rotation, IP updates, fee-recipient updates, ownership transfer, and deactivation

## Verification
- git diff --check
- bun run check (fails on existing unrelated lint issues in src/components/* after dependency install)
- bun run build (blocked by Vocs llms external fetch timeout)

Prompted by: @hamdiallam