### PR TITLE
fix: improve callout readability

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -145,6 +145,53 @@
     border-top: 1px solid var(--vocs-border-color-primary);
   }
 
+  aside[data-v][data-v-callout] {
+    --tempo-callout-accent: var(--vocs-text-color-muted);
+
+    background: color-mix(
+      in srgb,
+      var(--tempo-callout-accent) 10%,
+      var(--vocs-background-color-surface)
+    );
+    border-color: color-mix(in srgb, var(--tempo-callout-accent) 28%, transparent);
+    color: var(--vocs-text-color-primary);
+  }
+
+  aside[data-v][data-v-callout][data-v-context="info"] {
+    --tempo-callout-accent: var(--info);
+  }
+
+  aside[data-v][data-v-callout][data-v-context="tip"] {
+    --tempo-callout-accent: var(--vocs-color-iris);
+  }
+
+  aside[data-v][data-v-callout][data-v-context="warning"] {
+    --tempo-callout-accent: var(--warning);
+  }
+
+  aside[data-v][data-v-callout][data-v-context="danger"] {
+    --tempo-callout-accent: var(--negative);
+  }
+
+  aside[data-v][data-v-callout][data-v-context="success"] {
+    --tempo-callout-accent: var(--positive);
+  }
+
+  aside[data-v][data-v-callout] p[data-v],
+  aside[data-v][data-v-callout] li[data-v],
+  aside[data-v][data-v-callout] a[data-v],
+  aside[data-v][data-v-callout] code[data-v] {
+    color: var(--vocs-text-color-primary);
+  }
+
+  aside[data-v][data-v-callout] li::marker {
+    color: var(--vocs-text-color-primary);
+  }
+
+  aside[data-v][data-v-callout] > [data-v-callout-icon] {
+    color: var(--tempo-callout-accent);
+  }
+
   [data-docs-sidebar-toggle] {
     display: inline-flex;
 


### PR DESCRIPTION
## Motivation

Callouts were difficult to scan because the content inherited each variant's accent color, often on a white or very subtle surface.

## Summary

- Render callout body text, links, list markers, and inline code in the primary text color for all Vocs callout variants.
- Keep each variant's accent on the callout icon, border, and tinted surface.
- Cover `note`, `info`, `tip`, `warning`, `danger`, and future `success` callouts with the same scoped pattern.
- Verified 87 authored pages containing 146 callouts: 70 info, 40 warning, 25 tip, 6 note, 5 danger.

![Note callout](https://gist.githubusercontent.com/brendanjryan/d5ec571cc573fb397a80f145a65c6ad7/raw/8b61e6d8a8f3c6cb1cf17eb34bb48077e720da7c/note-bridge-bungee.svg)

![Info callout](https://gist.githubusercontent.com/brendanjryan/d5ec571cc573fb397a80f145a65c6ad7/raw/c2da7f68b3025cb2f961e0d1b96a2f5fc6715d28/info-indexer-api.svg)

![Tip callout](https://gist.githubusercontent.com/brendanjryan/d5ec571cc573fb397a80f145a65c6ad7/raw/e37bf8c9926f5b2a2376a535e62745412d76c8f9/tip-rust-sdk.svg)

![Warning callout](https://gist.githubusercontent.com/brendanjryan/d5ec571cc573fb397a80f145a65c6ad7/raw/e66fc0d404ee730a0093daf98d21b0bbb43464e6/warning-send-payment.svg)

![Danger callout](https://gist.githubusercontent.com/brendanjryan/d5ec571cc573fb397a80f145a65c6ad7/raw/881c26d52c08b0302252f434a0c4a786507b7fa3/danger-system-requirements.svg)

## Key design considerations

- Scoped the override to Vocs callout markup so badges, banners, and prose links keep their existing treatment.
- Used a shared `--tempo-callout-accent` variable so each variant keeps a recognizable accent without sacrificing readability.
