### PR TITLE
fix: add production rewrite for /api/mcp to mcp.tempo.xyz

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -463,6 +463,10 @@
   ],
   "rewrites": [
     {
+      "source": "/api/mcp",
+      "destination": "https://mcp.tempo.xyz/"
+    },
+    {
       "source": "/developers/RSC/R/developers.txt",
       "destination": "/developers/RSC/R/_root.txt"
     },


### PR DESCRIPTION
## Problem

The **Try the MCP server** explorer on [/developers/docs/guide/using-tempo-with-ai#connect-to-tempos-mcp-server](https://tempo.xyz/developers/docs/guide/using-tempo-with-ai#connect-to-tempos-mcp-server) fails in production.

`TempoMcpExplorer` POSTs to `/api/mcp`. This works locally because `vite.config.ts` proxies `/api/mcp` → `https://mcp.tempo.xyz`, but production has no equivalent rewrite. The request falls through to the marketing app, which `308`-redirects `/api/mcp` → `/api/mcp/`, which then `404`s.

```
POST /api/mcp  →  308  →  /api/mcp/  →  404.html
```

## Fix

Add a Vercel reverse-proxy rewrite mirroring the dev proxy:

```json
{ "source": "/api/mcp", "destination": "https://mcp.tempo.xyz/" }
```

A same-origin reverse proxy is required (rather than calling `mcp.tempo.xyz` directly from the browser) because `mcp.tempo.xyz` does not return `access-control-allow-origin` on POST responses, so a direct cross-origin fetch is blocked by CORS.

## Verification

- Root-path rewrites from this `vercel.json` are confirmed live in prod (the sibling `/ingest/*` → PostHog rewrite returns `200`), so this rewrite will take effect.
- Full end-to-end verification requires a deploy/preview.