### PR TITLE
Add Open USD blog post

### DIFF
--- a/blogs/AGENTS.md
+++ b/blogs/AGENTS.md
@@ -13,12 +13,12 @@ To keep a post as a draft (written but not published), move it into the `drafts/
 title: "Tuning Reth for payments: how we hit 21,200 TPS"
 excerpt: "One or two sentences shown on the index and as the post's lede."
 date: 2026-06-02
-category: technical # network-upgrades | events | technical | case-studies
+category: technical # announcements | network-upgrades | events | technical | case-studies
 featured: true # optional — pins the post to the hero card on /blog
 ---
 ```
 
-`category` must be one of the four slugs above (the build fails loudly otherwise). At most one post should be `featured`; if none is, the newest post takes the hero card.
+`category` must be one of the five slugs above (the build fails loudly otherwise). At most one post should be `featured`; if none is, the newest post takes the hero card.
 
 ## Body
 

--- a/blogs/open-usd-ousd.md
+++ b/blogs/open-usd-ousd.md
@@ -1,0 +1,43 @@
+---
+title: "Open USD is coming to Tempo"
+excerpt: "Open USD will be issued natively on Tempo from day one, giving enterprises and developers another stablecoin option for payment, settlement, treasury, and distribution flows."
+date: 2026-07-01
+category: announcements
+---
+
+*Today Open Standard introduced Open USD (OUSD), a new stablecoin designed as open infrastructure for global money movement. OUSD will be issued natively on Tempo from day one, giving enterprises and developers another stablecoin they can use in payment, settlement, treasury, and distribution flows.*
+
+Open Standard describes OUSD around three principles: built for scale, shared reserve economics for participants, and collaborative management through an independent entity.
+
+*From the [Open Standard announcement](https://joinopenstandard.com/blog/introducing-open-usd).*
+
+Combined with Tempo's purpose-built infrastructure for payments, including near-instant settlement, sub-cent fees, and built-in privacy and compliance features, OUSD can help grow stablecoin adoption in real-world payments use cases.
+
+For businesses that choose OUSD, Tempo will support it natively with the liquidity, ecosystem access, and infrastructure needed for payment use cases.
+
+## Why Tempo
+
+Tempo is built for payments at scale, designed for enterprises and developers building across payment, settlement, treasury, and distribution flows. As stablecoin-first payments infrastructure, Tempo comes with features including:
+
+- **A stablecoin-native token standard:** Tempo's token standard, TIP-20, is designed for stablecoin payments, with structured memo fields for reconciliation, policies for compliance, and the ability to abstract gas fees in any stablecoin.
+- **Deterministic, low-cost settlement:** Tempo has near-instant settlement, sub-cent transaction fees, and high throughput to sustain demanding payments workloads.
+- **Fees paid in stablecoins:** Pay transaction fees in any USD-denominated stablecoin, rather than a separate gas token. The Fee AMM converts automatically to each validator's preferred stablecoin with no extra integration.
+- **A built-in stablecoin DEX:** Tempo features an enshrined decentralized exchange designed for trading between stablecoins of the same underlying asset, providing efficient pricing for cross-stablecoin payments.
+- **Modern wallet signing:** Fee sponsorship for gasless experiences, batched and scheduled payments, passkey authentication, and scoped access keys for payroll, subscriptions, and agents.
+- **Opt-in privacy:** Tempo Zones for private balances and transfers, with the auditability enterprises need to fulfill compliance requirements.
+
+## More stablecoin choice for businesses
+
+OUSD adds another option for businesses building with stablecoins. Some companies will use open-loop stablecoins like OUSD. Others will issue or distribute their own stablecoins for specific customer networks, geographies, or commercial models.
+
+OUSD will sit alongside other stablecoins in the Tempo ecosystem, and we plan to support it with deep liquidity, ecosystem support across ramps, exchanges, and DeFi, and payments infrastructure designed for production use.
+
+We're excited for Tempo to support OUSD natively on day one, bringing more stablecoin options for businesses.
+
+Combined with Tempo's stablecoin-native token standard, near-instant settlement, sub-cent fees paid in any stablecoin, built-in stablecoin DEX, and privacy and compliance features, we're committed to providing the infrastructure for enterprises to use OUSD across real-world payments use cases.
+
+> Dan Romero, Business Lead, Tempo
+
+## Get started
+
+Read the [Open Standard announcement](https://joinopenstandard.com/blog/introducing-open-usd) to learn more about OUSD. If you're evaluating stablecoins for global payouts, cross-border payments, treasury operations, embedded finance, commerce, payroll, agentic payments, tokenized deposits, or other payments use cases, [get in touch](https://tempo.xyz/contact) to see how Tempo can support you.

--- a/src/marketing/app/blog/_lib/categories.ts
+++ b/src/marketing/app/blog/_lib/categories.ts
@@ -2,6 +2,7 @@
 // Kept free of node/build imports so client components can use it directly.
 
 export const categories = [
+  { slug: 'announcements', label: 'Announcements', badge: 'announcement' },
   { slug: 'network-upgrades', label: 'Network upgrades', badge: 'network upgrade' },
   { slug: 'events', label: 'Events', badge: 'events' },
   { slug: 'technical', label: 'Technical posts', badge: 'technical' },

--- a/src/marketing/blogPlugin.ts
+++ b/src/marketing/blogPlugin.ts
@@ -40,7 +40,7 @@ function inlineSvgImages(html: string): string {
   })
 }
 
-const CATEGORY_SLUGS = ['network-upgrades', 'events', 'technical', 'case-studies']
+const CATEGORY_SLUGS = ['announcements', 'network-upgrades', 'events', 'technical', 'case-studies']
 
 // ALL-CAPS markdown files (AGENTS.md, DIAGRAMS.md, …) are documentation for
 // authors, not posts.

--- a/src/marketing/main.tsx
+++ b/src/marketing/main.tsx
@@ -99,7 +99,7 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
   '/blog': {
     title: 'Blog',
     description:
-      'Engineering deep dives, network upgrades, events, and case studies from the Tempo team.',
+      'Announcements, engineering deep dives, network upgrades, events, and case studies from the Tempo team.',
   },
 }
 

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -11,7 +11,7 @@ import {
 
 const BLOG_TITLE = 'Blog'
 const BLOG_DESCRIPTION =
-  'Engineering deep dives, network upgrades, events, and case studies from the Tempo team.'
+  'Announcements, engineering deep dives, network upgrades, events, and case studies from the Tempo team.'
 
 const postBySlug = new Map<string, PostSeo>(
   posts.map((post) => [

--- a/vite.marketing.config.ts
+++ b/vite.marketing.config.ts
@@ -108,7 +108,7 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
   blog: {
     title: 'Blog',
     description:
-      'Engineering deep dives, network upgrades, events, and case studies from the Tempo team.',
+      'Announcements, engineering deep dives, network upgrades, events, and case studies from the Tempo team.',
   },
 }
 


### PR DESCRIPTION
## Summary
- add the Open USD announcement post at `/blog/open-usd-ousd`
- add an `announcements` blog category so the post is classified correctly
- update blog metadata copy and author docs to include announcements

Prompted by: tom

## Validation
- `pnpm check:types`
- `pnpm exec tsx -e "import { loadRenderedPosts } from './src/marketing/blogPlugin.ts'; (async () => { const posts = await loadRenderedPosts(); const post = posts.find((p) => p.slug === 'open-usd-ousd'); if (!post) throw new Error('missing post'); console.log(JSON.stringify({ slug: post.slug, title: post.title, date: post.date, category: post.category, featured: post.featured, htmlIncludesGetStarted: post.html.includes('Get started') }, null, 2)); })();"`

## Notes
- `pnpm build` is currently blocked in the docs/Vocs build by an external OpenAPI fetch timeout before the marketing/blog build runs.
