### PR TITLE
fix: route ai search endpoint through the `/developers` proxy

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -33,6 +33,8 @@ exclude = [
   "^https?://([a-z0-9-]+\\.)*example\\.(com|org|net)",
   # SVG xmlns reference, not a real link.
   "^http://www\\.w3\\.org/2000/svg$",
+  # POST-only AI search endpoint referenced in vocs.config.ts.
+  "^https://tempo\\.xyz/developers/api/search$",
 ]
 
 # Reuse cached results across runs.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -68,6 +68,12 @@ export default defineConfig({
     retriever: process.env.CLOUDFLARE_API_TOKEN
       ? Retriever.local({
           embedding: Embedding.cloudflare(),
+          // Production pages are served behind the tempo.xyz `/developers`
+          // proxy; the default origin-relative endpoint escapes the prefix.
+          endpoint:
+            process.env.VERCEL_ENV === 'production'
+              ? 'https://tempo.xyz/developers/api/search'
+              : undefined,
           hybrid: true,
           reranker: Reranker.cloudflare(),
           sources: [


### PR DESCRIPTION
The search dialog fetches the retriever endpoint as an origin-relative path derived from `basePath` (`/api/search`). Users browse the docs behind the `tempo.xyz/developers` proxy, so the request resolved against tempo.xyz's root and hit tempo-web's trailing-slash 308 instead of the docs app.

Production builds now set the endpoint to `https://tempo.xyz/developers/api/search`, which the existing `/developers/*` proxy already forwards to the docs app (verified live with a `202` from the index warm-up). Previews and local dev keep the default relative endpoint since they are browsed on the app's own origin.

Production needs a redeploy after merge to pick up the new endpoint.
