### PR TITLE
fix: redirect legacy developers docs paths

### DIFF
--- a/src/lib/docs-routing.test.ts
+++ b/src/lib/docs-routing.test.ts
@@ -106,6 +106,8 @@ describe('docs routing redirects', () => {
     ['/tools', '/docs/tools'],
     ['/tools/:path*', '/docs/tools/:path*'],
     ['/partners', '/docs/partners'],
+    ['/developers/:section(guide|protocol)/:path*', '/developers/docs/:section/:path*'],
+    ['/developers/learn', '/developers/docs'],
     ['/api', '/docs/api'],
     ['/api/authentication', '/docs/api/authentication'],
     ['/api/conventions', '/docs/api/conventions'],

--- a/vercel.json
+++ b/vercel.json
@@ -231,6 +231,16 @@
       "permanent": true
     },
     {
+      "source": "/developers/:section(guide|protocol)/:path*",
+      "destination": "/developers/docs/:section/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/developers/learn",
+      "destination": "/developers/docs",
+      "permanent": true
+    },
+    {
       "source": "/api",
       "destination": "/docs/api",
       "permanent": true


### PR DESCRIPTION
## Summary\n- redirect legacy /developers/guide/* and /developers/protocol/* paths to /developers/docs/*\n- redirect /developers/learn to /developers/docs\n- add routing test coverage\n\n## Test\n- pnpm vitest run src/lib/docs-routing.test.ts