### PR TITLE
chore: bump `viem`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "unified": "^11.0.5",
     "unplugin-auto-import": "^21.0.0",
     "unplugin-icons": "^23.0.1",
-    "viem": "^2.53.1",
+    "viem": "^2.54.5",
     "vocs": "^2.3.3",
     "wagmi": "3.6.20",
     "waku": "^1.0.0-beta.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,13 +50,13 @@ importers:
         version: 2.0.0(react@19.2.7)(vue@3.5.38(typescript@6.0.3))
       '@wagmi/core':
         specifier: 3.5.4
-        version: 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+        version: 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))
       abitype:
         specifier: ^1.2.4
         version: 1.2.4(typescript@6.0.3)(zod@4.4.3)
       accounts:
         specifier: ^0.14.11
-        version: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
+        version: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
       cva:
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4(typescript@6.0.3)
@@ -133,14 +133,14 @@ importers:
         specifier: ^23.0.1
         version: 23.0.1(@svgr/core@8.1.0(typescript@6.0.3))(@vue/compiler-sfc@3.5.38)
       viem:
-        specifier: ^2.53.1
-        version: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+        specifier: ^2.54.5
+        version: 2.54.5(typescript@6.0.3)(zod@4.4.3)
       vocs:
         specifier: ^2.3.3
         version: 2.3.3(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       wagmi:
         specifier: 3.6.20
-        version: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+        version: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))
       waku:
         specifier: ^1.0.0-beta.6
         version: 1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -3965,6 +3965,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.30:
+    resolution: {integrity: sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   p-event@6.0.1:
     resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
     engines: {node: '>=16.17'}
@@ -4784,8 +4792,8 @@ packages:
       typescript:
         optional: true
 
-  viem@2.53.1:
-    resolution: {integrity: sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==}
+  viem@2.54.5:
+    resolution: {integrity: sha512-oHDE8I3yXxxTwfTZ87ic8gBTAZnDbfILNVwYf0UtDTm7UwMgbAlitbXJxP1yWWcQ2gRAYqszo6PCjS3mwsoWqw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -5045,6 +5053,18 @@ packages:
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7045,23 +7065,23 @@ snapshots:
     dependencies:
       vue: 3.5.38(typescript@6.0.3)
 
-  '@wagmi/connectors@8.0.19(@wagmi/core@3.5.4)(accounts@0.14.11)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.19(@wagmi/core@3.5.4)(accounts@0.14.11)(typescript@6.0.3)(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))
+      viem: 2.54.5(typescript@6.0.3)(zod@4.4.3)
     optionalDependencies:
-      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
+      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
       typescript: 6.0.3
 
-  '@wagmi/core@3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))':
+  '@wagmi/core@3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.3)
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.54.5(typescript@6.0.3)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     optionalDependencies:
       '@tanstack/query-core': 5.101.2
-      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
+      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/react'
@@ -7069,15 +7089,15 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))':
+  '@wagmi/core@3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.3)
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.54.5(typescript@6.0.3)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     optionalDependencies:
       '@tanstack/query-core': 5.101.2
-      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
+      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/react'
@@ -7180,23 +7200,23 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  accounts@0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20):
+  accounts@0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20):
     dependencies:
       hono: 4.12.27
       idb-keyval: 6.2.2
       jose: 6.2.3
       mipd: 0.0.7(typescript@6.0.3)
-      mppx: 0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+      mppx: 0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))
       ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
       wata: 0.4.0(react@19.2.7)(typescript@6.0.3)
       webauthx: 0.1.2(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
       zustand: 5.0.12(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     optionalDependencies:
-      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))
       react: 19.2.7
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
-      wagmi: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+      viem: 2.54.5(typescript@6.0.3)(zod@4.4.3)
+      wagmi: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@types/react'
@@ -8321,6 +8341,10 @@ snapshots:
     dependencies:
       ws: 8.20.1
 
+  isows@1.0.7(ws@8.21.0):
+    dependencies:
+      ws: 8.21.0
+
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 26.1.0
@@ -9035,12 +9059,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.5(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.7.0
       incur: 0.4.10
       ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.54.5(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -9152,6 +9176,21 @@ snapshots:
       - zod
 
   ox@0.14.29(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@6.0.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.30(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -10208,16 +10247,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.53.1(typescript@6.0.3)(zod@4.4.3):
+  viem@2.54.5(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
-      isows: 1.0.7(ws@8.20.1)
-      ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
-      ws: 8.20.1
+      isows: 1.0.7(ws@8.21.0)
+      ox: 0.14.30(typescript@6.0.3)(zod@4.4.3)
+      ws: 8.21.0
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -10441,14 +10480,14 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
-  wagmi@3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3)):
+  wagmi@3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.5(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
-      '@wagmi/connectors': 8.0.19(@wagmi/core@3.5.4)(accounts@0.14.11)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
-      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.19(@wagmi/core@3.5.4)(accounts@0.14.11)(typescript@6.0.3)(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))
+      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.5(typescript@6.0.3)(zod@4.4.3))
       react: 19.2.7
       use-sync-external-store: 1.4.0(react@19.2.7)
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.54.5(typescript@6.0.3)(zod@4.4.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -10581,6 +10620,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.20.1: {}
+
+  ws@8.21.0: {}
 
   yallist@3.1.1: {}
 

--- a/src/components/guides/Demo.tsx
+++ b/src/components/guides/Demo.tsx
@@ -17,6 +17,7 @@ import { usePostHogTracking } from '../../lib/posthog'
 import { useTempoWalletConnector, useWebAuthnConnector } from '../../wagmi.config'
 import { Container as ParentContainer } from '../Container'
 import { isFundableWalletConnector } from '../lib/wallets'
+import { baseUnits } from './amount'
 import { alphaUsd } from './tokens'
 
 export { alphaUsd, betaUsd, pathUsd, thetaUsd } from './tokens'
@@ -261,7 +262,9 @@ export namespace Container {
           <span />
         ) : (
           <span className="flex gap-1">
-            <span className="text-gray10">{formatUnits(balance ?? 0n, metadata.decimals)}</span>
+            <span className="text-gray10">
+              {formatUnits(baseUnits(balance), metadata.decimals)}
+            </span>
             {metadata.symbol}
           </span>
         )}

--- a/src/components/guides/VirtualAddressesLiveDemo.tsx
+++ b/src/components/guides/VirtualAddressesLiveDemo.tsx
@@ -21,6 +21,7 @@ import { Abis, Actions, tempoActions, withFeePayer } from 'viem/tempo'
 import { useClient, useConnect, useConnection, useDisconnect, useWriteContract } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useWebAuthnConnector } from '../../wagmi.config'
+import { baseUnits } from './amount'
 import { Button, ExplorerAccountLink, ExplorerLink, Logout, Step, StringFormatter } from './Demo'
 import { alphaUsd, pathUsd } from './tokens'
 
@@ -322,7 +323,7 @@ export function VirtualAddressesLiveDemo() {
           })
           .catch(() => {})
 
-        if (target === address && feeBalance && feeBalance > parseUnits('10', 6)) return
+        if (target === address && feeBalance && baseUnits(feeBalance) > parseUnits('10', 6)) return
 
         await Actions.token.transferSync(adminClient, {
           account: demoAdmin,
@@ -340,7 +341,7 @@ export function VirtualAddressesLiveDemo() {
       const balances = await Promise.all(
         requiredTokens.map((token) => getTokenBalance(target, token)),
       )
-      if (balances.every((balance) => balance > 0n)) return
+      if (balances.every((balance) => baseUnits(balance) > 0n)) return
 
       await Actions.faucet.fund(client as unknown as Client<Transport, Chain>, {
         account: target,

--- a/src/components/guides/amount.ts
+++ b/src/components/guides/amount.ts
@@ -1,0 +1,6 @@
+export type TokenAmount = bigint | { amount: bigint } | null | undefined
+
+export function baseUnits(amount: TokenAmount) {
+  if (typeof amount === 'bigint') return amount
+  return amount?.amount ?? 0n
+}

--- a/src/components/guides/steps/amm/BurnFeeAmmLiquidity.tsx
+++ b/src/components/guides/steps/amm/BurnFeeAmmLiquidity.tsx
@@ -5,6 +5,7 @@ import { parseUnits } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -48,7 +49,7 @@ export function BurnFeeAmmLiquidity(props: DemoStepProps) {
   })
 
   const hasSufficientBalance =
-    lpBalance && lpBalance >= parseUnits('10', validatorMetadata?.decimals || 6)
+    baseUnits(lpBalance) >= parseUnits('10', validatorMetadata?.decimals || 6)
   const active = React.useMemo(() => {
     return Boolean(address && tokenAddress && hasSufficientBalance)
   }, [address, tokenAddress, hasSufficientBalance])

--- a/src/components/guides/steps/amm/CheckFeeAmmPool.tsx
+++ b/src/components/guides/steps/amm/CheckFeeAmmPool.tsx
@@ -4,6 +4,7 @@ import { formatUnits } from 'viem'
 import { useConnection } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -36,7 +37,7 @@ export function CheckFeeAmmPool(props: DemoStepProps) {
   })
 
   const active = React.useMemo(() => {
-    return Boolean(address && tokenAddress && pool && lpBalance && lpBalance > 0n)
+    return Boolean(address && tokenAddress && pool && baseUnits(lpBalance) > 0n)
   }, [address, tokenAddress, pool, lpBalance])
 
   return (

--- a/src/components/guides/steps/amm/MintFeeAmmLiquidity.tsx
+++ b/src/components/guides/steps/amm/MintFeeAmmLiquidity.tsx
@@ -7,6 +7,7 @@ import { Hooks } from 'wagmi/tempo'
 import LucideCheck from '~icons/lucide/check'
 import LucideCircle from '~icons/lucide/circle'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, Step } from '../../Demo'
 import { alphaUsd, pathUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -98,7 +99,7 @@ export function MintFeeAmmLiquidity(props: DemoStepProps & { waitForBalance?: bo
   }, [address, tokenAddress, pathUsdMinted, alphaUsdMinted, mintFeeLiquidity])
 
   const active = React.useMemo(() => {
-    const balanceCheck = waitForBalance ? Boolean(tokenBalance && tokenBalance > 0n) : true
+    const balanceCheck = waitForBalance ? Boolean(baseUnits(tokenBalance) > 0n) : true
     return Boolean(address && tokenAddress && balanceCheck)
   }, [address, tokenAddress, tokenBalance, waitForBalance])
 

--- a/src/components/guides/steps/exchange/BuySwap.tsx
+++ b/src/components/guides/steps/exchange/BuySwap.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { formatUnits, parseUnits } from 'viem'
 import { Actions, Addresses } from 'viem/tempo'
-import { useConnection, useConnectionEffect, useSendCallsSync } from 'wagmi'
+import { useClient, useConnection, useConnectionEffect, useSendCallsSync } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 
 import { Button, ExplorerLink } from '../../Demo'
@@ -9,6 +9,7 @@ import { alphaUsd, betaUsd } from '../../tokens'
 
 export function BuySwap({ onSuccess }: { onSuccess?: () => void }) {
   const { address } = useConnection()
+  const client = useClient()
 
   const { data: tokenInMetadata } = Hooks.token.useGetMetadata({
     token: betaUsd,
@@ -49,19 +50,21 @@ export function BuySwap({ onSuccess }: { onSuccess?: () => void }) {
     },
   })
 
-  const calls = [
-    Actions.token.approve.call({
-      spender: Addresses.stablecoinDex,
-      amount: maxAmountIn,
-      token: betaUsd,
-    }),
-    Actions.dex.buy.call({
-      amountOut: amount,
-      maxAmountIn,
-      tokenIn: betaUsd,
-      tokenOut: alphaUsd,
-    }),
-  ]
+  const calls = client
+    ? [
+        Actions.token.approve.call(client as never, {
+          spender: Addresses.stablecoinDex,
+          amount: maxAmountIn,
+          token: betaUsd,
+        }),
+        Actions.dex.buy.call({
+          amountOut: amount,
+          maxAmountIn,
+          tokenIn: betaUsd,
+          tokenOut: alphaUsd,
+        }),
+      ]
+    : []
 
   return (
     <div className="flex flex-col gap-3">
@@ -69,7 +72,7 @@ export function BuySwap({ onSuccess }: { onSuccess?: () => void }) {
         <h3 className="font-semibold text-sm">Buy 10 AlphaUSD with BetaUSD</h3>
         <Button
           variant={sendCalls.isSuccess ? 'default' : 'accent'}
-          disabled={!address}
+          disabled={!address || !client}
           onClick={() => {
             sendCalls.sendCallsSync({
               calls,

--- a/src/components/guides/steps/exchange/MakeSwaps.tsx
+++ b/src/components/guides/steps/exchange/MakeSwaps.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { parseUnits } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
+import { baseUnits } from '../../amount'
 
 import { Step } from '../../Demo'
 import { alphaUsd, betaUsd } from '../../tokens'
@@ -33,8 +34,8 @@ export function MakeSwaps({ stepNumber, last = false }: DemoStepProps) {
   const active = React.useMemo(() => {
     return (
       !!address &&
-      (alphaUsdBalance || 0n) > parseUnits('11', alphaUsdMetadata?.decimals || 6) &&
-      (betaUsdBalance || 0n) > parseUnits('11', betaUsdMetadata?.decimals || 6)
+      baseUnits(alphaUsdBalance) > parseUnits('11', alphaUsdMetadata?.decimals || 6) &&
+      baseUnits(betaUsdBalance) > parseUnits('11', betaUsdMetadata?.decimals || 6)
     )
   }, [
     address,

--- a/src/components/guides/steps/exchange/PlaceOrder.tsx
+++ b/src/components/guides/steps/exchange/PlaceOrder.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import { type Log, parseUnits } from 'viem'
 import { Actions, Addresses } from 'viem/tempo'
-import { useConnection, useConnectionEffect, useSendCallsSync } from 'wagmi'
+import { useClient, useConnection, useConnectionEffect, useSendCallsSync } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
 import { Button, ExplorerLink, Step } from '../../Demo'
@@ -12,6 +12,7 @@ import type { DemoStepProps } from '../types'
 export function PlaceOrder(props: DemoStepProps) {
   const { stepNumber, last = false } = props
   const { address } = useConnection()
+  const client = useClient()
   const { setData, clearData, getData } = useDemoContext()
 
   const orderId = getData('orderId')
@@ -46,19 +47,21 @@ export function PlaceOrder(props: DemoStepProps) {
 
   const amount = parseUnits('100', metadata?.decimals || 6)
 
-  const calls = [
-    Actions.token.approve.call({
-      spender: Addresses.stablecoinDex,
-      amount,
-      token: pathUsd,
-    }),
-    Actions.dex.place.call({
-      amount,
-      tick: 0,
-      token: alphaUsd,
-      type: 'buy',
-    }),
-  ]
+  const calls = client
+    ? [
+        Actions.token.approve.call(client as never, {
+          spender: Addresses.stablecoinDex,
+          amount,
+          token: pathUsd,
+        }),
+        Actions.dex.place.call({
+          amount,
+          tick: 0,
+          token: alphaUsd,
+          type: 'buy',
+        }),
+      ]
+    : []
 
   const active = React.useMemo(() => {
     return !!address && !orderId
@@ -71,7 +74,7 @@ export function PlaceOrder(props: DemoStepProps) {
       actions={
         <Button
           variant={active ? (sendCalls.isSuccess ? 'default' : 'accent') : 'default'}
-          disabled={!active}
+          disabled={!active || !client}
           onClick={() => {
             sendCalls.sendCallsSync({
               calls,

--- a/src/components/guides/steps/exchange/SellSwap.tsx
+++ b/src/components/guides/steps/exchange/SellSwap.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { formatUnits, parseUnits } from 'viem'
 import { Actions, Addresses } from 'viem/tempo'
-import { useConnection, useConnectionEffect, useSendCallsSync } from 'wagmi'
+import { useClient, useConnection, useConnectionEffect, useSendCallsSync } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 
 import { Button, ExplorerLink } from '../../Demo'
@@ -9,6 +9,7 @@ import { alphaUsd, betaUsd } from '../../tokens'
 
 export function SellSwap({ onSuccess }: { onSuccess?: () => void }) {
   const { address } = useConnection()
+  const client = useClient()
 
   const { data: tokenInMetadata } = Hooks.token.useGetMetadata({
     token: alphaUsd,
@@ -49,19 +50,21 @@ export function SellSwap({ onSuccess }: { onSuccess?: () => void }) {
     },
   })
 
-  const calls = [
-    Actions.token.approve.call({
-      spender: Addresses.stablecoinDex,
-      amount,
-      token: alphaUsd,
-    }),
-    Actions.dex.sell.call({
-      amountIn: amount,
-      minAmountOut,
-      tokenIn: alphaUsd,
-      tokenOut: betaUsd,
-    }),
-  ]
+  const calls = client
+    ? [
+        Actions.token.approve.call(client as never, {
+          spender: Addresses.stablecoinDex,
+          amount,
+          token: alphaUsd,
+        }),
+        Actions.dex.sell.call({
+          amountIn: amount,
+          minAmountOut,
+          tokenIn: alphaUsd,
+          tokenOut: betaUsd,
+        }),
+      ]
+    : []
 
   return (
     <div className="flex flex-col gap-3">
@@ -69,7 +72,7 @@ export function SellSwap({ onSuccess }: { onSuccess?: () => void }) {
         <h3 className="font-semibold text-sm">Sell 10 AlphaUSD for BetaUSD</h3>
         <Button
           variant={sendCalls.isSuccess ? 'default' : 'accent'}
-          disabled={!address}
+          disabled={!address || !client}
           onClick={() => {
             sendCalls.sendCallsSync({
               calls,

--- a/src/components/guides/steps/issuance/BurnToken.tsx
+++ b/src/components/guides/steps/issuance/BurnToken.tsx
@@ -5,6 +5,7 @@ import { pad, parseUnits, stringToHex } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -61,7 +62,7 @@ export function BurnToken(props: DemoStepProps) {
   }
 
   const hasSufficientBalance =
-    balance && metadata && balance >= parseUnits('100', metadata.decimals)
+    balance && metadata && baseUnits(balance) >= parseUnits('100', metadata.decimals)
   const canBurn = !!tokenAddress && !!hasRole && hasSufficientBalance
 
   return (

--- a/src/components/guides/steps/issuance/BurnTokenBlocked.tsx
+++ b/src/components/guides/steps/issuance/BurnTokenBlocked.tsx
@@ -5,6 +5,7 @@ import { parseUnits } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, FAKE_RECIPIENT, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -59,7 +60,9 @@ export function BurnTokenBlocked(props: DemoStepProps) {
   }
 
   const hasSufficientBalance =
-    recipientBalance && metadata && recipientBalance >= parseUnits('100', metadata.decimals)
+    recipientBalance &&
+    metadata &&
+    baseUnits(recipientBalance) >= parseUnits('100', metadata.decimals)
 
   const active = React.useMemo(() => {
     return Boolean(

--- a/src/components/guides/steps/issuance/CreateToken.tsx
+++ b/src/components/guides/steps/issuance/CreateToken.tsx
@@ -4,6 +4,7 @@ import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { cx } from '../../../../../cva.config'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, Login, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -40,7 +41,7 @@ export function CreateToken(props: DemoStepProps) {
     if (showLogin) return true
 
     // If this is the last step has to be logged in and funded.
-    const activeWithBalance = Boolean(address && balance && balance > 0n)
+    const activeWithBalance = Boolean(address && baseUnits(balance) > 0n)
     if (last) return activeWithBalance
 
     // If this is an intermediate step, also needs to not have succeeded

--- a/src/components/guides/steps/issuance/MintToken.tsx
+++ b/src/components/guides/steps/issuance/MintToken.tsx
@@ -5,6 +5,7 @@ import { type Address, pad, parseUnits, stringToHex } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -61,7 +62,8 @@ export function MintToken(props: DemoStepProps & { recipient?: Address }) {
     })
   }
 
-  const hasSufficientBalance = balance && metadata && balance >= parseUnits('90', metadata.decimals)
+  const hasSufficientBalance =
+    balance && metadata && baseUnits(balance) >= parseUnits('90', metadata.decimals)
 
   return (
     <Step

--- a/src/components/guides/steps/payments/AddFunds.tsx
+++ b/src/components/guides/steps/payments/AddFunds.tsx
@@ -7,6 +7,7 @@ import { mnemonicToAccount } from 'viem/accounts'
 import { Actions } from 'viem/tempo'
 import { useBlockNumber, useClient, useConnection } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
+import { baseUnits } from '../../amount'
 import { Button, Login, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -21,7 +22,7 @@ export function AddFunds(props: DemoStepProps) {
   })
   const { data: blockNumber } = useBlockNumber({
     query: {
-      enabled: Boolean(address && (!balance || balance < 0)),
+      enabled: Boolean(address && (!balance || baseUnits(balance) < 0)),
       refetchInterval: 1_500,
     },
   })
@@ -67,7 +68,7 @@ export function AddFunds(props: DemoStepProps) {
 
   const actions = React.useMemo(() => {
     if (showLogin) return <Login />
-    if (balance && balance > 0n)
+    if (baseUnits(balance) > 0n)
       return (
         <Button
           disabled={fundAccount.isPending}
@@ -95,7 +96,7 @@ export function AddFunds(props: DemoStepProps) {
   return (
     <Step
       active={active}
-      completed={Boolean(address && balance && balance > 0n)}
+      completed={Boolean(address && baseUnits(balance) > 0n)}
       actions={actions}
       error={fundAccount.error}
       number={stepNumber}

--- a/src/components/guides/steps/payments/AddFundsToOthers.tsx
+++ b/src/components/guides/steps/payments/AddFundsToOthers.tsx
@@ -7,6 +7,7 @@ import { mnemonicToAccount } from 'viem/accounts'
 import { Actions } from 'viem/tempo'
 import { useBlockNumber, useClient, useConnection } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerAccountLink, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -33,7 +34,7 @@ export function AddFundsToOthers(props: DemoStepProps) {
   })
   const { data: blockNumber } = useBlockNumber({
     query: {
-      enabled: Boolean(address && (!balance || balance < 0)),
+      enabled: Boolean(address && (!balance || baseUnits(balance) < 0)),
       refetchInterval: 1_500,
     },
   })
@@ -81,7 +82,7 @@ export function AddFundsToOthers(props: DemoStepProps) {
   }, [fundAccount.isSuccess, last])
 
   const actions = React.useMemo(() => {
-    if (balance && balance > 0n && fundAccount.isSuccess)
+    if (baseUnits(balance) > 0n && fundAccount.isSuccess)
       return (
         <Button
           disabled={!isValidTarget || fundAccount.isPending}

--- a/src/components/guides/steps/payments/PayWithFeeToken.tsx
+++ b/src/components/guides/steps/payments/PayWithFeeToken.tsx
@@ -5,6 +5,7 @@ import { formatUnits, isAddress, pad, parseUnits, stringToHex } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { TokenSelector } from '../../../TokenSelector'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, FAKE_RECIPIENT, Step } from '../../Demo'
 import { alphaUsd, betaUsd, pathUsd, thetaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -79,10 +80,10 @@ export function PayWithFeeToken(props: DemoStepProps & { feeToken?: Address }) {
     return Boolean(
       address &&
         alphaBalance &&
-        alphaBalance > 0n &&
+        baseUnits(alphaBalance) > 0n &&
         feeTokenBalance &&
-        feeTokenBalance > 0n &&
-        (feeToken !== alphaUsd ? pool && pool.reserveValidatorToken > 0n : true),
+        baseUnits(feeTokenBalance) > 0n &&
+        (feeToken !== alphaUsd ? pool && baseUnits(pool.reserveValidatorToken) > 0n : true),
     )
   }, [address, alphaBalance, feeTokenBalance, pool, feeToken])
 
@@ -123,7 +124,9 @@ export function PayWithFeeToken(props: DemoStepProps & { feeToken?: Address }) {
               <div className="flex flex-col gap-1.5">
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">Payment Token: AlphaUSD</span>
-                  <span className="text-gray12">balance: {formatUnits(alphaBalance ?? 0n, 6)}</span>
+                  <span className="text-gray12">
+                    balance: {formatUnits(baseUnits(alphaBalance), 6)}
+                  </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">Fee Token</span>
@@ -139,7 +142,7 @@ export function PayWithFeeToken(props: DemoStepProps & { feeToken?: Address }) {
                     {`Fee Token: ${feeTokenMetadata ? feeTokenMetadata.name : ''}`}
                   </span>
                   <span className="text-gray12">
-                    balance: {formatUnits(feeTokenBalance ?? 0n, 6)}
+                    balance: {formatUnits(baseUnits(feeTokenBalance), 6)}
                   </span>
                 </div>
               </div>

--- a/src/components/guides/steps/payments/PayWithIssuedToken.tsx
+++ b/src/components/guides/steps/payments/PayWithIssuedToken.tsx
@@ -4,6 +4,7 @@ import { formatUnits, isAddress, pad, parseUnits, stringToHex } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, FAKE_RECIPIENT, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -76,11 +77,11 @@ export function PayWithIssuedToken(props: DemoStepProps) {
     return Boolean(
       address &&
         alphaBalance &&
-        alphaBalance > 0n &&
+        baseUnits(alphaBalance) > 0n &&
         feeTokenBalance &&
-        feeTokenBalance > 0n &&
+        baseUnits(feeTokenBalance) > 0n &&
         pool &&
-        pool.reserveValidatorToken > 0n,
+        baseUnits(pool.reserveValidatorToken) > 0n,
     )
   }, [address, alphaBalance, feeTokenBalance, pool])
 
@@ -121,14 +122,16 @@ export function PayWithIssuedToken(props: DemoStepProps) {
               <div className="flex flex-col gap-1.5">
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">Payment Token: AlphaUSD</span>
-                  <span className="text-gray12">balance: {formatUnits(alphaBalance ?? 0n, 6)}</span>
+                  <span className="text-gray12">
+                    balance: {formatUnits(baseUnits(alphaBalance), 6)}
+                  </span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">
                     {`Fee Token: ${feeTokenMetadata ? feeTokenMetadata.name : ''}`}
                   </span>
                   <span className="text-gray12">
-                    balance: {formatUnits(feeTokenBalance ?? 0n, 6)}
+                    balance: {formatUnits(baseUnits(feeTokenBalance), 6)}
                   </span>
                 </div>
               </div>

--- a/src/components/guides/steps/payments/SendParallelPayments.tsx
+++ b/src/components/guides/steps/payments/SendParallelPayments.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { parseUnits } from 'viem'
 import { useConfig, useConnection, useConnectionEffect, useTransaction } from 'wagmi'
 import { Actions, Hooks } from 'wagmi/tempo'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, FAKE_RECIPIENT, FAKE_RECIPIENT_2, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -146,7 +147,7 @@ export function SendParallelPayments(props: DemoStepProps) {
   return (
     <Step
       active={
-        Boolean(address && balance && balance >= parseUnits('100', 6)) &&
+        Boolean(address && baseUnits(balance) >= parseUnits('100', 6)) &&
         (last ? true : !bothSucceeded)
       }
       completed={bothSucceeded}
@@ -163,13 +164,13 @@ export function SendParallelPayments(props: DemoStepProps) {
         ) : (
           <Button
             variant={
-              address && balance && balance >= parseUnits('100', 6)
+              address && baseUnits(balance) >= parseUnits('100', 6)
                 ? bothSucceeded
                   ? 'default'
                   : 'accent'
                 : 'default'
             }
-            disabled={!(address && balance && balance >= parseUnits('100', 6))}
+            disabled={!(address && baseUnits(balance) >= parseUnits('100', 6))}
             onClick={() => setExpanded(true)}
             type="button"
             className="font-normal text-[14px] -tracking-[2%]"
@@ -220,9 +221,9 @@ export function SendParallelPayments(props: DemoStepProps) {
               <div className="flex items-start">
                 <Button
                   variant={
-                    address && balance && balance >= parseUnits('100', 6) ? 'accent' : 'default'
+                    address && baseUnits(balance) >= parseUnits('100', 6) ? 'accent' : 'default'
                   }
-                  disabled={!(address && balance && balance >= parseUnits('100', 6)) || isSending}
+                  disabled={!(address && baseUnits(balance) >= parseUnits('100', 6)) || isSending}
                   onClick={handleSendParallel}
                   type="button"
                   className="font-normal text-[14px] -tracking-[2%]"

--- a/src/components/guides/steps/payments/SendPayment.tsx
+++ b/src/components/guides/steps/payments/SendPayment.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { isAddress, pad, parseUnits, stringToHex } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, FAKE_RECIPIENT, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -61,7 +62,7 @@ export function SendPayment(props: DemoStepProps) {
 
   return (
     <Step
-      active={Boolean(address && balance && balance > 0n) && (last ? true : !sendPayment.isSuccess)}
+      active={Boolean(address && baseUnits(balance) > 0n) && (last ? true : !sendPayment.isSuccess)}
       completed={sendPayment.isSuccess}
       actions={
         expanded ? (
@@ -76,13 +77,13 @@ export function SendPayment(props: DemoStepProps) {
         ) : (
           <Button
             variant={
-              address && balance && balance > 0n
+              address && baseUnits(balance) > 0n
                 ? sendPayment.isSuccess
                   ? 'default'
                   : 'accent'
                 : 'default'
             }
-            disabled={!(address && balance && balance > 0n)}
+            disabled={!(address && baseUnits(balance) > 0n)}
             onClick={() => setExpanded(true)}
             type="button"
             className="font-normal text-[14px] -tracking-[2%]"
@@ -130,11 +131,11 @@ export function SendPayment(props: DemoStepProps) {
               </div>
               <Button
                 variant={
-                  address && balance && balance > 0n && isValidRecipient && !memoError
+                  address && baseUnits(balance) > 0n && isValidRecipient && !memoError
                     ? 'accent'
                     : 'default'
                 }
-                disabled={!(address && balance && balance > 0n && isValidRecipient) || !!memoError}
+                disabled={!(address && baseUnits(balance) > 0n && isValidRecipient) || !!memoError}
                 onClick={handleTransfer}
                 type="button"
                 className="font-normal text-[14px] -tracking-[2%]"

--- a/src/components/guides/steps/payments/SendPaymentWithMemo.tsx
+++ b/src/components/guides/steps/payments/SendPaymentWithMemo.tsx
@@ -5,6 +5,7 @@ import { fromHex, isAddress, pad, parseUnits, stringToHex } from 'viem'
 import { Abis } from 'viem/tempo'
 import { useConnection, useConnectionEffect, useWatchContractEvent } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, FAKE_RECIPIENT, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -102,7 +103,7 @@ export function SendPaymentWithMemo(props: DemoStepProps) {
 
   return (
     <Step
-      active={Boolean(address && balance && balance > 0n) && (last ? true : !sendPayment.isSuccess)}
+      active={Boolean(address && baseUnits(balance) > 0n) && (last ? true : !sendPayment.isSuccess)}
       completed={sendPayment.isSuccess}
       actions={
         expanded ? (
@@ -117,13 +118,13 @@ export function SendPaymentWithMemo(props: DemoStepProps) {
         ) : (
           <Button
             variant={
-              address && balance && balance > 0n
+              address && baseUnits(balance) > 0n
                 ? sendPayment.isSuccess
                   ? 'default'
                   : 'accent'
                 : 'default'
             }
-            disabled={!(address && balance && balance > 0n)}
+            disabled={!(address && baseUnits(balance) > 0n)}
             onClick={() => setExpanded(true)}
             type="button"
             className="font-normal text-[14px] -tracking-[2%]"
@@ -175,7 +176,7 @@ export function SendPaymentWithMemo(props: DemoStepProps) {
                   variant={
                     address &&
                     balance &&
-                    balance > 0n &&
+                    baseUnits(balance) > 0n &&
                     isValidRecipient &&
                     !memoError &&
                     memo.trim()
@@ -183,7 +184,7 @@ export function SendPaymentWithMemo(props: DemoStepProps) {
                       : 'default'
                   }
                   disabled={
-                    !(address && balance && balance > 0n && isValidRecipient && memo.trim()) ||
+                    !(address && baseUnits(balance) > 0n && isValidRecipient && memo.trim()) ||
                     !!memoError
                   }
                   onClick={handleTransfer}

--- a/src/components/guides/steps/payments/SponsorUserFees.tsx
+++ b/src/components/guides/steps/payments/SponsorUserFees.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { formatUnits, isAddress, pad, parseUnits, stringToHex } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, FAKE_RECIPIENT, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -48,7 +49,7 @@ export function SendRelayerSponsoredPayment(props: DemoStepProps) {
   }
 
   const active = React.useMemo(() => {
-    return Boolean(address && userBalance && userBalance > 0n)
+    return Boolean(address && baseUnits(userBalance) > 0n)
   }, [address, userBalance])
 
   return (
@@ -87,7 +88,9 @@ export function SendRelayerSponsoredPayment(props: DemoStepProps) {
               <div className="flex flex-col gap-1.5">
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">Payment Token: AlphaUSD</span>
-                  <span className="text-gray12">balance: {formatUnits(userBalance ?? 0n, 6)}</span>
+                  <span className="text-gray12">
+                    balance: {formatUnits(baseUnits(userBalance), 6)}
+                  </span>
                 </div>
               </div>
               <div className="mt-2 border-gray4 border-t pt-2 text-[12px] text-gray9">

--- a/src/components/guides/steps/rewards/ClaimReward.tsx
+++ b/src/components/guides/steps/rewards/ClaimReward.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useConnection, useConnectionEffect, useWaitForTransactionReceipt } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -55,7 +56,7 @@ export function ClaimReward(props: DemoStepProps) {
 
   const active = React.useMemo(() => {
     const activeWithBalance = Boolean(
-      address && balance && balance > 0n && tokenAddress && flowDependenciesMet,
+      address && baseUnits(balance) > 0n && tokenAddress && flowDependenciesMet,
     )
     if (last) return activeWithBalance
     return activeWithBalance && !isSuccess

--- a/src/components/guides/steps/rewards/OptInToRewards.tsx
+++ b/src/components/guides/steps/rewards/OptInToRewards.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useConnection, useConnectionEffect, useWaitForTransactionReceipt } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -52,7 +53,7 @@ export function OptInToRewards(props: DemoStepProps) {
   })
 
   const active = React.useMemo(() => {
-    const activeWithBalance = Boolean(address && balance && balance > 0n && tokenAddress)
+    const activeWithBalance = Boolean(address && baseUnits(balance) > 0n && tokenAddress)
     if (last) return activeWithBalance
     return activeWithBalance && !isSuccess
   }, [address, balance, tokenAddress, isSuccess, last])

--- a/src/components/guides/steps/rewards/StartReward.tsx
+++ b/src/components/guides/steps/rewards/StartReward.tsx
@@ -5,6 +5,7 @@ import { parseUnits } from 'viem'
 import { useConnection, useConnectionEffect, useWaitForTransactionReceipt } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -64,7 +65,7 @@ export function StartReward(props: DemoStepProps) {
     const activeWithBalance = Boolean(
       address &&
         balance &&
-        balance > 0n &&
+        baseUnits(balance) > 0n &&
         tokenAddress &&
         metadata &&
         (rewardOptedIn || (!!rewardInfo && rewardInfo.rewardRecipient !== REWARD_RECIPIENT_UNSET)),

--- a/src/components/guides/steps/wallet/AddFundsToWallet.tsx
+++ b/src/components/guides/steps/wallet/AddFundsToWallet.tsx
@@ -8,6 +8,7 @@ import { Actions } from 'viem/tempo'
 import { useBlockNumber, useClient, useConnections } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { isFundableWalletConnector } from '../../../lib/wallets'
+import { baseUnits } from '../../amount'
 import { Button, Step } from '../../Demo'
 import { alphaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -32,7 +33,7 @@ export function AddFundsToWallet(props: DemoStepProps) {
   })
   const { data: blockNumber } = useBlockNumber({
     query: {
-      enabled: Boolean(hasNonWebAuthnWallet && (!balance || balance < 0)),
+      enabled: Boolean(hasNonWebAuthnWallet && (!balance || baseUnits(balance) < 0)),
       refetchInterval: 1_500,
     },
   })
@@ -72,7 +73,7 @@ export function AddFundsToWallet(props: DemoStepProps) {
   }, [hasNonWebAuthnWallet, balance, last])
 
   const actions = React.useMemo(() => {
-    if (balance && balance > 0n)
+    if (baseUnits(balance) > 0n)
       return (
         <Button
           disabled={!hasNonWebAuthnWallet || fundAccount.isPending}
@@ -100,7 +101,7 @@ export function AddFundsToWallet(props: DemoStepProps) {
   return (
     <Step
       active={active}
-      completed={Boolean(hasNonWebAuthnWallet && balance && balance > 0n)}
+      completed={Boolean(hasNonWebAuthnWallet && baseUnits(balance) > 0n)}
       actions={actions}
       error={fundAccount.error}
       number={stepNumber}

--- a/src/components/guides/steps/wallet/SetFeeToken.tsx
+++ b/src/components/guides/steps/wallet/SetFeeToken.tsx
@@ -4,6 +4,7 @@ import { type Address, isAddress } from 'viem'
 import { useChainId, useConfig, useConnections } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { isBrowserWalletConnectorId } from '../../../lib/wallets'
+import { baseUnits } from '../../amount'
 import { Button, ExplorerLink, Step, StringFormatter } from '../../Demo'
 import { alphaUsd, betaUsd, thetaUsd } from '../../tokens'
 import type { DemoStepProps } from '../types'
@@ -61,7 +62,7 @@ export function SetFeeToken(props: DemoStepProps) {
   const isFeeTokenValid = selectedOption.value !== 'other' || isAddress(customFeeToken)
   const defaultChainId = chainId ?? config?.chains?.[0]?.id
 
-  const hasBalance = Boolean(balance && balance > 0n)
+  const hasBalance = Boolean(baseUnits(balance) > 0n)
   const hasUserToken = Boolean(userToken.data?.address)
 
   const canSubmit = Boolean(

--- a/src/components/guides/zones/DepositToZone.tsx
+++ b/src/components/guides/zones/DepositToZone.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../lib/private-zones.ts'
 import { useRootWebAuthnAccount } from '../../../lib/useRootWebAuthnAccount.ts'
 import { useZoneAuthorization, type ZoneAuthClientLike } from '../../../lib/useZoneAuthorization.ts'
+import { baseUnits } from '../amount'
 import { Button, ExplorerLink, Logout, Step } from '../Demo'
 import { SignInButtons } from '../EmbedPasskeys'
 import { pathUsd } from '../tokens'
@@ -263,7 +264,7 @@ function ConnectedZoneFlow(props: { address: Hex; mode: DepositMode }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(baseUnits(rootBalance) > 0n)
   const zoneDepositProcessed = Boolean(
     targetZoneBalance !== undefined &&
       typeof zoneBalanceQuery.data === 'bigint' &&

--- a/src/components/guides/zones/SendTokensAcrossZones.tsx
+++ b/src/components/guides/zones/SendTokensAcrossZones.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../../lib/private-zones.ts'
 import { useRootWebAuthnAccount } from '../../../lib/useRootWebAuthnAccount.ts'
 import { useZoneAuthorization, type ZoneAuthClientLike } from '../../../lib/useZoneAuthorization.ts'
+import { baseUnits } from '../amount'
 import { Button, ExplorerLink, Logout, ReceiptHash, Step } from '../Demo'
 import { SignInButtons } from '../EmbedPasskeys'
 import { pathUsd } from '../tokens'
@@ -385,7 +386,7 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(baseUnits(rootBalance) > 0n)
   const topUpReceipt = topUpMutation.data?.receipt
   const routedSendReceipt = sendMutation.data?.receipt
   const settlementTxHash = settlementQuery.data?.txHash

--- a/src/components/guides/zones/SendTokensWithinZone.tsx
+++ b/src/components/guides/zones/SendTokensWithinZone.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../lib/private-zones.ts'
 import { useRootWebAuthnAccount } from '../../../lib/useRootWebAuthnAccount.ts'
 import { useZoneAuthorization, type ZoneAuthClientLike } from '../../../lib/useZoneAuthorization.ts'
+import { baseUnits } from '../amount'
 import { Button, ExplorerLink, FAKE_RECIPIENT, Logout, ReceiptHash, Step } from '../Demo'
 import { SignInButtons } from '../EmbedPasskeys'
 import { pathUsd } from '../tokens'
@@ -219,7 +220,7 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(baseUnits(rootBalance) > 0n)
   const topUpReceipt = topUpMutation.data?.receipt
   const expectedMaxZoneBalance = transferMutation.data?.startingZoneBalance
     ? transferMutation.data.startingZoneBalance - TRANSFER_AMOUNT

--- a/src/components/guides/zones/SwapAcrossZones.tsx
+++ b/src/components/guides/zones/SwapAcrossZones.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../lib/private-zones.ts'
 import { useRootWebAuthnAccount } from '../../../lib/useRootWebAuthnAccount.ts'
 import { useZoneAuthorization, type ZoneAuthClientLike } from '../../../lib/useZoneAuthorization.ts'
+import { baseUnits } from '../amount'
 import { Button, ExplorerLink, Logout, ReceiptHash, Step } from '../Demo'
 import { SignInButtons } from '../EmbedPasskeys'
 import { betaUsd, pathUsd } from '../tokens'
@@ -444,7 +445,7 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(baseUnits(rootBalance) > 0n)
   const topUpReceipt = topUpMutation.data?.receipt
   const routedSwapReceipt = swapMutation.data?.receipt
   const settlementTxHash = settlementQuery.data?.txHash

--- a/src/components/guides/zones/WithdrawFromZone.tsx
+++ b/src/components/guides/zones/WithdrawFromZone.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../lib/private-zones.ts'
 import { useRootWebAuthnAccount } from '../../../lib/useRootWebAuthnAccount.ts'
 import { useZoneAuthorization, type ZoneAuthClientLike } from '../../../lib/useZoneAuthorization.ts'
+import { baseUnits } from '../amount'
 import { Button, ExplorerLink, Logout, Step } from '../Demo'
 import { SignInButtons } from '../EmbedPasskeys'
 import { pathUsd } from '../tokens'
@@ -334,7 +335,7 @@ function ConnectedZoneFlow(props: { address: Hex; mode: WithdrawalMode }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(baseUnits(rootBalance) > 0n)
   const settlementTxHash = withdrawalConfirmationQuery.data?.txHash
   const withdrawalConfirmed = Boolean(settlementTxHash)
   const topUpReceipt = topUpMutation.data?.receipt


### PR DESCRIPTION
Bumps `viem` to `2.54.5` and updates docs demos for structured token amounts and the latest token approval call shape.