### PR TITLE
chore(deps): update viem to 2.54.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "unified": "^11.0.5",
     "unplugin-auto-import": "^21.0.0",
     "unplugin-icons": "^23.0.1",
-    "viem": "^2.53.1",
+    "viem": "^2.54.6",
     "vocs": "^2.3.3",
     "wagmi": "3.6.20",
     "waku": "^1.0.0-beta.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,13 +50,13 @@ importers:
         version: 2.0.0(react@19.2.7)(vue@3.5.38(typescript@6.0.3))
       '@wagmi/core':
         specifier: 3.5.4
-        version: 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+        version: 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
       abitype:
         specifier: ^1.2.4
         version: 1.2.4(typescript@6.0.3)(zod@4.4.3)
       accounts:
         specifier: ^0.14.11
-        version: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
+        version: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
       cva:
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4(typescript@6.0.3)
@@ -133,14 +133,14 @@ importers:
         specifier: ^23.0.1
         version: 23.0.1(@svgr/core@8.1.0(typescript@6.0.3))(@vue/compiler-sfc@3.5.38)
       viem:
-        specifier: ^2.53.1
-        version: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+        specifier: ^2.54.6
+        version: 2.54.6(typescript@6.0.3)(zod@4.4.3)
       vocs:
         specifier: ^2.3.3
         version: 2.3.3(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       wagmi:
         specifier: 3.6.20
-        version: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+        version: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
       waku:
         specifier: ^1.0.0-beta.6
         version: 1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -3965,6 +3965,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.30:
+    resolution: {integrity: sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   p-event@6.0.1:
     resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
     engines: {node: '>=16.17'}
@@ -4784,8 +4792,8 @@ packages:
       typescript:
         optional: true
 
-  viem@2.53.1:
-    resolution: {integrity: sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==}
+  viem@2.54.6:
+    resolution: {integrity: sha512-OfybECKJYVmhiNqz+SHhed+O2h6niQ+0Wjg9J0b4bV+/QrvLgjxhfKO7hZqsuK1YtZ/0BErBKy708Zp+cU5T0Q==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -5045,6 +5053,18 @@ packages:
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7045,23 +7065,23 @@ snapshots:
     dependencies:
       vue: 3.5.38(typescript@6.0.3)
 
-  '@wagmi/connectors@8.0.19(@wagmi/core@3.5.4)(accounts@0.14.11)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.19(@wagmi/core@3.5.4)(accounts@0.14.11)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
+      viem: 2.54.6(typescript@6.0.3)(zod@4.4.3)
     optionalDependencies:
-      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
+      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
       typescript: 6.0.3
 
-  '@wagmi/core@3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))':
+  '@wagmi/core@3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.3)
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.54.6(typescript@6.0.3)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     optionalDependencies:
       '@tanstack/query-core': 5.101.2
-      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
+      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/react'
@@ -7069,15 +7089,15 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))':
+  '@wagmi/core@3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.3)
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.54.6(typescript@6.0.3)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     optionalDependencies:
       '@tanstack/query-core': 5.101.2
-      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
+      accounts: 0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/react'
@@ -7180,23 +7200,23 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  accounts@0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20):
+  accounts@0.14.11(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.17)(@wagmi/core@3.5.4)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.20):
     dependencies:
       hono: 4.12.27
       idb-keyval: 6.2.2
       jose: 6.2.3
       mipd: 0.0.7(typescript@6.0.3)
-      mppx: 0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+      mppx: 0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
       ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
       wata: 0.4.0(react@19.2.7)(typescript@6.0.3)
       webauthx: 0.1.2(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
       zustand: 5.0.12(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     optionalDependencies:
-      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
       react: 19.2.7
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
-      wagmi: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+      viem: 2.54.6(typescript@6.0.3)(zod@4.4.3)
+      wagmi: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@types/react'
@@ -8321,6 +8341,10 @@ snapshots:
     dependencies:
       ws: 8.20.1
 
+  isows@1.0.7(ws@8.21.0):
+    dependencies:
+      ws: 8.21.0
+
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 26.1.0
@@ -9035,12 +9059,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.7.0
       incur: 0.4.10
       ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.54.6(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -9152,6 +9176,21 @@ snapshots:
       - zod
 
   ox@0.14.29(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@6.0.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.30(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -10208,16 +10247,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.53.1(typescript@6.0.3)(zod@4.4.3):
+  viem@2.54.6(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
-      isows: 1.0.7(ws@8.20.1)
-      ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
-      ws: 8.20.1
+      isows: 1.0.7(ws@8.21.0)
+      ox: 0.14.30(typescript@6.0.3)(zod@4.4.3)
+      ws: 8.21.0
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -10441,14 +10480,14 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
-  wagmi@3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3)):
+  wagmi@3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
-      '@wagmi/connectors': 8.0.19(@wagmi/core@3.5.4)(accounts@0.14.11)(typescript@6.0.3)(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
-      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.53.1(typescript@6.0.3)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.19(@wagmi/core@3.5.4)(accounts@0.14.11)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
+      '@wagmi/core': 3.5.4(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
       react: 19.2.7
       use-sync-external-store: 1.4.0(react@19.2.7)
-      viem: 2.53.1(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.54.6(typescript@6.0.3)(zod@4.4.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -10581,6 +10620,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.20.1: {}
+
+  ws@8.21.0: {}
 
   yallist@3.1.1: {}
 

--- a/src/components/guides/Demo.tsx
+++ b/src/components/guides/Demo.tsx
@@ -2,7 +2,7 @@
 import { useQueryClient } from '@tanstack/react-query'
 import type { VariantProps } from 'cva'
 import * as React from 'react'
-import { type Address, type BaseError, formatUnits } from 'viem'
+import type { Address, BaseError } from 'viem'
 import { tempoModerato } from 'viem/chains'
 import { useAccount, useConnect, useConnections, useDisconnect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
@@ -261,7 +261,7 @@ export namespace Container {
           <span />
         ) : (
           <span className="flex gap-1">
-            <span className="text-gray10">{formatUnits(balance ?? 0n, metadata.decimals)}</span>
+            <span className="text-gray10">{balance.formatted}</span>
             {metadata.symbol}
           </span>
         )}

--- a/src/components/guides/VirtualAddressesLiveDemo.tsx
+++ b/src/components/guides/VirtualAddressesLiveDemo.tsx
@@ -322,7 +322,7 @@ export function VirtualAddressesLiveDemo() {
           })
           .catch(() => {})
 
-        if (target === address && feeBalance && feeBalance > parseUnits('10', 6)) return
+        if (target === address && feeBalance && feeBalance.amount > parseUnits('10', 6)) return
 
         await Actions.token.transferSync(adminClient, {
           account: demoAdmin,

--- a/src/components/guides/steps/amm/MintFeeAmmLiquidity.tsx
+++ b/src/components/guides/steps/amm/MintFeeAmmLiquidity.tsx
@@ -98,7 +98,7 @@ export function MintFeeAmmLiquidity(props: DemoStepProps & { waitForBalance?: bo
   }, [address, tokenAddress, pathUsdMinted, alphaUsdMinted, mintFeeLiquidity])
 
   const active = React.useMemo(() => {
-    const balanceCheck = waitForBalance ? Boolean(tokenBalance && tokenBalance > 0n) : true
+    const balanceCheck = waitForBalance ? Boolean(tokenBalance && tokenBalance.amount > 0n) : true
     return Boolean(address && tokenAddress && balanceCheck)
   }, [address, tokenAddress, tokenBalance, waitForBalance])
 

--- a/src/components/guides/steps/exchange/MakeSwaps.tsx
+++ b/src/components/guides/steps/exchange/MakeSwaps.tsx
@@ -33,8 +33,8 @@ export function MakeSwaps({ stepNumber, last = false }: DemoStepProps) {
   const active = React.useMemo(() => {
     return (
       !!address &&
-      (alphaUsdBalance || 0n) > parseUnits('11', alphaUsdMetadata?.decimals || 6) &&
-      (betaUsdBalance || 0n) > parseUnits('11', betaUsdMetadata?.decimals || 6)
+      (alphaUsdBalance?.amount ?? 0n) > parseUnits('11', alphaUsdMetadata?.decimals || 6) &&
+      (betaUsdBalance?.amount ?? 0n) > parseUnits('11', betaUsdMetadata?.decimals || 6)
     )
   }, [
     address,

--- a/src/components/guides/steps/issuance/BurnToken.tsx
+++ b/src/components/guides/steps/issuance/BurnToken.tsx
@@ -61,7 +61,7 @@ export function BurnToken(props: DemoStepProps) {
   }
 
   const hasSufficientBalance =
-    balance && metadata && balance >= parseUnits('100', metadata.decimals)
+    balance && metadata && balance.amount >= parseUnits('100', metadata.decimals)
   const canBurn = !!tokenAddress && !!hasRole && hasSufficientBalance
 
   return (

--- a/src/components/guides/steps/issuance/BurnTokenBlocked.tsx
+++ b/src/components/guides/steps/issuance/BurnTokenBlocked.tsx
@@ -59,7 +59,7 @@ export function BurnTokenBlocked(props: DemoStepProps) {
   }
 
   const hasSufficientBalance =
-    recipientBalance && metadata && recipientBalance >= parseUnits('100', metadata.decimals)
+    recipientBalance && metadata && recipientBalance.amount >= parseUnits('100', metadata.decimals)
 
   const active = React.useMemo(() => {
     return Boolean(

--- a/src/components/guides/steps/issuance/CreateToken.tsx
+++ b/src/components/guides/steps/issuance/CreateToken.tsx
@@ -40,7 +40,7 @@ export function CreateToken(props: DemoStepProps) {
     if (showLogin) return true
 
     // If this is the last step has to be logged in and funded.
-    const activeWithBalance = Boolean(address && balance && balance > 0n)
+    const activeWithBalance = Boolean(address && balance && balance.amount > 0n)
     if (last) return activeWithBalance
 
     // If this is an intermediate step, also needs to not have succeeded

--- a/src/components/guides/steps/issuance/MintToken.tsx
+++ b/src/components/guides/steps/issuance/MintToken.tsx
@@ -61,7 +61,8 @@ export function MintToken(props: DemoStepProps & { recipient?: Address }) {
     })
   }
 
-  const hasSufficientBalance = balance && metadata && balance >= parseUnits('90', metadata.decimals)
+  const hasSufficientBalance =
+    balance && metadata && balance.amount >= parseUnits('90', metadata.decimals)
 
   return (
     <Step

--- a/src/components/guides/steps/payments/AddFunds.tsx
+++ b/src/components/guides/steps/payments/AddFunds.tsx
@@ -21,7 +21,7 @@ export function AddFunds(props: DemoStepProps) {
   })
   const { data: blockNumber } = useBlockNumber({
     query: {
-      enabled: Boolean(address && (!balance || balance < 0)),
+      enabled: Boolean(address && (!balance || balance.amount < 0)),
       refetchInterval: 1_500,
     },
   })
@@ -67,7 +67,7 @@ export function AddFunds(props: DemoStepProps) {
 
   const actions = React.useMemo(() => {
     if (showLogin) return <Login />
-    if (balance && balance > 0n)
+    if (balance && balance.amount > 0n)
       return (
         <Button
           disabled={fundAccount.isPending}
@@ -95,7 +95,7 @@ export function AddFunds(props: DemoStepProps) {
   return (
     <Step
       active={active}
-      completed={Boolean(address && balance && balance > 0n)}
+      completed={Boolean(address && balance && balance.amount > 0n)}
       actions={actions}
       error={fundAccount.error}
       number={stepNumber}

--- a/src/components/guides/steps/payments/AddFundsToOthers.tsx
+++ b/src/components/guides/steps/payments/AddFundsToOthers.tsx
@@ -33,7 +33,7 @@ export function AddFundsToOthers(props: DemoStepProps) {
   })
   const { data: blockNumber } = useBlockNumber({
     query: {
-      enabled: Boolean(address && (!balance || balance < 0)),
+      enabled: Boolean(address && (!balance || balance.amount < 0)),
       refetchInterval: 1_500,
     },
   })
@@ -81,7 +81,7 @@ export function AddFundsToOthers(props: DemoStepProps) {
   }, [fundAccount.isSuccess, last])
 
   const actions = React.useMemo(() => {
-    if (balance && balance > 0n && fundAccount.isSuccess)
+    if (balance && balance.amount > 0n && fundAccount.isSuccess)
       return (
         <Button
           disabled={!isValidTarget || fundAccount.isPending}

--- a/src/components/guides/steps/payments/PayWithFeeToken.tsx
+++ b/src/components/guides/steps/payments/PayWithFeeToken.tsx
@@ -1,7 +1,7 @@
 'use client'
 import * as React from 'react'
 import type { Address } from 'viem'
-import { formatUnits, isAddress, pad, parseUnits, stringToHex } from 'viem'
+import { isAddress, pad, parseUnits, stringToHex } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { TokenSelector } from '../../../TokenSelector'
@@ -79,9 +79,9 @@ export function PayWithFeeToken(props: DemoStepProps & { feeToken?: Address }) {
     return Boolean(
       address &&
         alphaBalance &&
-        alphaBalance > 0n &&
+        alphaBalance.amount > 0n &&
         feeTokenBalance &&
-        feeTokenBalance > 0n &&
+        feeTokenBalance.amount > 0n &&
         (feeToken !== alphaUsd ? pool && pool.reserveValidatorToken > 0n : true),
     )
   }, [address, alphaBalance, feeTokenBalance, pool, feeToken])
@@ -123,7 +123,7 @@ export function PayWithFeeToken(props: DemoStepProps & { feeToken?: Address }) {
               <div className="flex flex-col gap-1.5">
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">Payment Token: AlphaUSD</span>
-                  <span className="text-gray12">balance: {formatUnits(alphaBalance ?? 0n, 6)}</span>
+                  <span className="text-gray12">balance: {alphaBalance?.formatted ?? '0'}</span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">Fee Token</span>
@@ -138,9 +138,7 @@ export function PayWithFeeToken(props: DemoStepProps & { feeToken?: Address }) {
                   <span className="font-medium text-gray10">
                     {`Fee Token: ${feeTokenMetadata ? feeTokenMetadata.name : ''}`}
                   </span>
-                  <span className="text-gray12">
-                    balance: {formatUnits(feeTokenBalance ?? 0n, 6)}
-                  </span>
+                  <span className="text-gray12">balance: {feeTokenBalance?.formatted ?? '0'}</span>
                 </div>
               </div>
             </div>

--- a/src/components/guides/steps/payments/PayWithIssuedToken.tsx
+++ b/src/components/guides/steps/payments/PayWithIssuedToken.tsx
@@ -1,6 +1,6 @@
 'use client'
 import * as React from 'react'
-import { formatUnits, isAddress, pad, parseUnits, stringToHex } from 'viem'
+import { isAddress, pad, parseUnits, stringToHex } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { useDemoContext } from '../../../DemoContext'
@@ -76,9 +76,9 @@ export function PayWithIssuedToken(props: DemoStepProps) {
     return Boolean(
       address &&
         alphaBalance &&
-        alphaBalance > 0n &&
+        alphaBalance.amount > 0n &&
         feeTokenBalance &&
-        feeTokenBalance > 0n &&
+        feeTokenBalance.amount > 0n &&
         pool &&
         pool.reserveValidatorToken > 0n,
     )
@@ -121,15 +121,13 @@ export function PayWithIssuedToken(props: DemoStepProps) {
               <div className="flex flex-col gap-1.5">
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">Payment Token: AlphaUSD</span>
-                  <span className="text-gray12">balance: {formatUnits(alphaBalance ?? 0n, 6)}</span>
+                  <span className="text-gray12">balance: {alphaBalance?.formatted ?? '0'}</span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">
                     {`Fee Token: ${feeTokenMetadata ? feeTokenMetadata.name : ''}`}
                   </span>
-                  <span className="text-gray12">
-                    balance: {formatUnits(feeTokenBalance ?? 0n, 6)}
-                  </span>
+                  <span className="text-gray12">balance: {feeTokenBalance?.formatted ?? '0'}</span>
                 </div>
               </div>
             </div>

--- a/src/components/guides/steps/payments/SendParallelPayments.tsx
+++ b/src/components/guides/steps/payments/SendParallelPayments.tsx
@@ -146,7 +146,7 @@ export function SendParallelPayments(props: DemoStepProps) {
   return (
     <Step
       active={
-        Boolean(address && balance && balance >= parseUnits('100', 6)) &&
+        Boolean(address && balance && balance.amount >= parseUnits('100', 6)) &&
         (last ? true : !bothSucceeded)
       }
       completed={bothSucceeded}
@@ -163,13 +163,13 @@ export function SendParallelPayments(props: DemoStepProps) {
         ) : (
           <Button
             variant={
-              address && balance && balance >= parseUnits('100', 6)
+              address && balance && balance.amount >= parseUnits('100', 6)
                 ? bothSucceeded
                   ? 'default'
                   : 'accent'
                 : 'default'
             }
-            disabled={!(address && balance && balance >= parseUnits('100', 6))}
+            disabled={!(address && balance && balance.amount >= parseUnits('100', 6))}
             onClick={() => setExpanded(true)}
             type="button"
             className="font-normal text-[14px] -tracking-[2%]"
@@ -220,9 +220,13 @@ export function SendParallelPayments(props: DemoStepProps) {
               <div className="flex items-start">
                 <Button
                   variant={
-                    address && balance && balance >= parseUnits('100', 6) ? 'accent' : 'default'
+                    address && balance && balance.amount >= parseUnits('100', 6)
+                      ? 'accent'
+                      : 'default'
                   }
-                  disabled={!(address && balance && balance >= parseUnits('100', 6)) || isSending}
+                  disabled={
+                    !(address && balance && balance.amount >= parseUnits('100', 6)) || isSending
+                  }
                   onClick={handleSendParallel}
                   type="button"
                   className="font-normal text-[14px] -tracking-[2%]"

--- a/src/components/guides/steps/payments/SendPayment.tsx
+++ b/src/components/guides/steps/payments/SendPayment.tsx
@@ -61,7 +61,9 @@ export function SendPayment(props: DemoStepProps) {
 
   return (
     <Step
-      active={Boolean(address && balance && balance > 0n) && (last ? true : !sendPayment.isSuccess)}
+      active={
+        Boolean(address && balance && balance.amount > 0n) && (last ? true : !sendPayment.isSuccess)
+      }
       completed={sendPayment.isSuccess}
       actions={
         expanded ? (
@@ -76,13 +78,13 @@ export function SendPayment(props: DemoStepProps) {
         ) : (
           <Button
             variant={
-              address && balance && balance > 0n
+              address && balance && balance.amount > 0n
                 ? sendPayment.isSuccess
                   ? 'default'
                   : 'accent'
                 : 'default'
             }
-            disabled={!(address && balance && balance > 0n)}
+            disabled={!(address && balance && balance.amount > 0n)}
             onClick={() => setExpanded(true)}
             type="button"
             className="font-normal text-[14px] -tracking-[2%]"
@@ -130,11 +132,13 @@ export function SendPayment(props: DemoStepProps) {
               </div>
               <Button
                 variant={
-                  address && balance && balance > 0n && isValidRecipient && !memoError
+                  address && balance && balance.amount > 0n && isValidRecipient && !memoError
                     ? 'accent'
                     : 'default'
                 }
-                disabled={!(address && balance && balance > 0n && isValidRecipient) || !!memoError}
+                disabled={
+                  !(address && balance && balance.amount > 0n && isValidRecipient) || !!memoError
+                }
                 onClick={handleTransfer}
                 type="button"
                 className="font-normal text-[14px] -tracking-[2%]"

--- a/src/components/guides/steps/payments/SendPaymentWithMemo.tsx
+++ b/src/components/guides/steps/payments/SendPaymentWithMemo.tsx
@@ -102,7 +102,9 @@ export function SendPaymentWithMemo(props: DemoStepProps) {
 
   return (
     <Step
-      active={Boolean(address && balance && balance > 0n) && (last ? true : !sendPayment.isSuccess)}
+      active={
+        Boolean(address && balance && balance.amount > 0n) && (last ? true : !sendPayment.isSuccess)
+      }
       completed={sendPayment.isSuccess}
       actions={
         expanded ? (
@@ -117,13 +119,13 @@ export function SendPaymentWithMemo(props: DemoStepProps) {
         ) : (
           <Button
             variant={
-              address && balance && balance > 0n
+              address && balance && balance.amount > 0n
                 ? sendPayment.isSuccess
                   ? 'default'
                   : 'accent'
                 : 'default'
             }
-            disabled={!(address && balance && balance > 0n)}
+            disabled={!(address && balance && balance.amount > 0n)}
             onClick={() => setExpanded(true)}
             type="button"
             className="font-normal text-[14px] -tracking-[2%]"
@@ -175,7 +177,7 @@ export function SendPaymentWithMemo(props: DemoStepProps) {
                   variant={
                     address &&
                     balance &&
-                    balance > 0n &&
+                    balance.amount > 0n &&
                     isValidRecipient &&
                     !memoError &&
                     memo.trim()
@@ -183,8 +185,13 @@ export function SendPaymentWithMemo(props: DemoStepProps) {
                       : 'default'
                   }
                   disabled={
-                    !(address && balance && balance > 0n && isValidRecipient && memo.trim()) ||
-                    !!memoError
+                    !(
+                      address &&
+                      balance &&
+                      balance.amount > 0n &&
+                      isValidRecipient &&
+                      memo.trim()
+                    ) || !!memoError
                   }
                   onClick={handleTransfer}
                   type="button"

--- a/src/components/guides/steps/payments/SponsorUserFees.tsx
+++ b/src/components/guides/steps/payments/SponsorUserFees.tsx
@@ -1,6 +1,6 @@
 'use client'
 import * as React from 'react'
-import { formatUnits, isAddress, pad, parseUnits, stringToHex } from 'viem'
+import { isAddress, pad, parseUnits, stringToHex } from 'viem'
 import { useConnection, useConnectionEffect } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
 import { Button, ExplorerLink, FAKE_RECIPIENT, Step } from '../../Demo'
@@ -48,7 +48,7 @@ export function SendRelayerSponsoredPayment(props: DemoStepProps) {
   }
 
   const active = React.useMemo(() => {
-    return Boolean(address && userBalance && userBalance > 0n)
+    return Boolean(address && userBalance && userBalance.amount > 0n)
   }, [address, userBalance])
 
   return (
@@ -87,7 +87,7 @@ export function SendRelayerSponsoredPayment(props: DemoStepProps) {
               <div className="flex flex-col gap-1.5">
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-gray10">Payment Token: AlphaUSD</span>
-                  <span className="text-gray12">balance: {formatUnits(userBalance ?? 0n, 6)}</span>
+                  <span className="text-gray12">balance: {userBalance?.formatted ?? '0'}</span>
                 </div>
               </div>
               <div className="mt-2 border-gray4 border-t pt-2 text-[12px] text-gray9">

--- a/src/components/guides/steps/rewards/ClaimReward.tsx
+++ b/src/components/guides/steps/rewards/ClaimReward.tsx
@@ -55,7 +55,7 @@ export function ClaimReward(props: DemoStepProps) {
 
   const active = React.useMemo(() => {
     const activeWithBalance = Boolean(
-      address && balance && balance > 0n && tokenAddress && flowDependenciesMet,
+      address && balance && balance.amount > 0n && tokenAddress && flowDependenciesMet,
     )
     if (last) return activeWithBalance
     return activeWithBalance && !isSuccess

--- a/src/components/guides/steps/rewards/OptInToRewards.tsx
+++ b/src/components/guides/steps/rewards/OptInToRewards.tsx
@@ -52,7 +52,7 @@ export function OptInToRewards(props: DemoStepProps) {
   })
 
   const active = React.useMemo(() => {
-    const activeWithBalance = Boolean(address && balance && balance > 0n && tokenAddress)
+    const activeWithBalance = Boolean(address && balance && balance.amount > 0n && tokenAddress)
     if (last) return activeWithBalance
     return activeWithBalance && !isSuccess
   }, [address, balance, tokenAddress, isSuccess, last])

--- a/src/components/guides/steps/rewards/StartReward.tsx
+++ b/src/components/guides/steps/rewards/StartReward.tsx
@@ -64,7 +64,7 @@ export function StartReward(props: DemoStepProps) {
     const activeWithBalance = Boolean(
       address &&
         balance &&
-        balance > 0n &&
+        balance.amount > 0n &&
         tokenAddress &&
         metadata &&
         (rewardOptedIn || (!!rewardInfo && rewardInfo.rewardRecipient !== REWARD_RECIPIENT_UNSET)),

--- a/src/components/guides/steps/wallet/AddFundsToWallet.tsx
+++ b/src/components/guides/steps/wallet/AddFundsToWallet.tsx
@@ -32,7 +32,7 @@ export function AddFundsToWallet(props: DemoStepProps) {
   })
   const { data: blockNumber } = useBlockNumber({
     query: {
-      enabled: Boolean(hasNonWebAuthnWallet && (!balance || balance < 0)),
+      enabled: Boolean(hasNonWebAuthnWallet && (!balance || balance.amount < 0)),
       refetchInterval: 1_500,
     },
   })
@@ -72,7 +72,7 @@ export function AddFundsToWallet(props: DemoStepProps) {
   }, [hasNonWebAuthnWallet, balance, last])
 
   const actions = React.useMemo(() => {
-    if (balance && balance > 0n)
+    if (balance && balance.amount > 0n)
       return (
         <Button
           disabled={!hasNonWebAuthnWallet || fundAccount.isPending}
@@ -100,7 +100,7 @@ export function AddFundsToWallet(props: DemoStepProps) {
   return (
     <Step
       active={active}
-      completed={Boolean(hasNonWebAuthnWallet && balance && balance > 0n)}
+      completed={Boolean(hasNonWebAuthnWallet && balance && balance.amount > 0n)}
       actions={actions}
       error={fundAccount.error}
       number={stepNumber}

--- a/src/components/guides/steps/wallet/SetFeeToken.tsx
+++ b/src/components/guides/steps/wallet/SetFeeToken.tsx
@@ -61,7 +61,7 @@ export function SetFeeToken(props: DemoStepProps) {
   const isFeeTokenValid = selectedOption.value !== 'other' || isAddress(customFeeToken)
   const defaultChainId = chainId ?? config?.chains?.[0]?.id
 
-  const hasBalance = Boolean(balance && balance > 0n)
+  const hasBalance = Boolean(balance && balance.amount > 0n)
   const hasUserToken = Boolean(userToken.data?.address)
 
   const canSubmit = Boolean(

--- a/src/components/guides/zones/DepositToZone.tsx
+++ b/src/components/guides/zones/DepositToZone.tsx
@@ -26,7 +26,10 @@ type DepositMode = 'plaintext' | 'encrypted'
 
 type ZoneClientLike = {
   token: {
-    getBalance: (parameters: { account: Hex; token: Hex }) => Promise<bigint>
+    getBalance: (parameters: {
+      account: Hex
+      token: Hex
+    }) => Promise<{ amount: bigint; decimals: number; formatted: string }>
   }
   zone: ZoneAuthClientLike['zone']
 }
@@ -173,6 +176,7 @@ function ConnectedZoneFlow(props: { address: Hex; mode: DepositMode }) {
           account: address,
           token: pathUsd,
         })
+        .then(({ amount }) => amount)
         .catch(() => 0n)
 
       const creditedAmount = getNetZoneDepositAmount(
@@ -243,10 +247,11 @@ function ConnectedZoneFlow(props: { address: Hex; mode: DepositMode }) {
       if (!zoneClient) throw new Error('zone client not ready')
 
       try {
-        return await zoneClient.token.getBalance({
+        const { amount } = await zoneClient.token.getBalance({
           account: address,
           token: pathUsd,
         })
+        return amount
       } catch {
         return null
       }
@@ -263,7 +268,7 @@ function ConnectedZoneFlow(props: { address: Hex; mode: DepositMode }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(rootBalance && rootBalance.amount > 0n)
   const zoneDepositProcessed = Boolean(
     targetZoneBalance !== undefined &&
       typeof zoneBalanceQuery.data === 'bigint' &&

--- a/src/components/guides/zones/SendTokensAcrossZones.tsx
+++ b/src/components/guides/zones/SendTokensAcrossZones.tsx
@@ -50,7 +50,10 @@ const targetDepositEvent = parseAbiItem(
 
 type ZoneClientLike = {
   token: {
-    getBalance: (parameters: { account: Hex; token: Hex }) => Promise<bigint>
+    getBalance: (parameters: {
+      account: Hex
+      token: Hex
+    }) => Promise<{ amount: bigint; decimals: number; formatted: string }>
   }
   zone: {
     getAuthorizationTokenInfo: ZoneAuthClientLike['zone']['getAuthorizationTokenInfo']
@@ -159,10 +162,11 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     queryFn: async () => {
       if (!sourceZoneClient) throw new Error('Zone A client not ready')
 
-      return sourceZoneClient.token.getBalance({
+      const { amount } = await sourceZoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
+      return amount
     },
     staleTime: 30_000,
   })
@@ -267,7 +271,7 @@ function ConnectedZoneFlow(props: { address: Hex }) {
       if (!rootWebAuthnAccount) throw new Error('root account not ready')
       if (!transferPrereqsQuery.data) throw new Error('Send prerequisites are not ready')
 
-      const currentSourceBalance = await sourceZoneClient.token.getBalance({
+      const { amount: currentSourceBalance } = await sourceZoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
@@ -374,10 +378,11 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     queryFn: async () => {
       if (!targetZoneClient) throw new Error('Zone B client not ready')
 
-      return targetZoneClient.token.getBalance({
+      const { amount } = await targetZoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
+      return amount
     },
     staleTime: 30_000,
     refetchOnReconnect: false,
@@ -385,7 +390,7 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(rootBalance && rootBalance.amount > 0n)
   const topUpReceipt = topUpMutation.data?.receipt
   const routedSendReceipt = sendMutation.data?.receipt
   const settlementTxHash = settlementQuery.data?.txHash

--- a/src/components/guides/zones/SendTokensWithinZone.tsx
+++ b/src/components/guides/zones/SendTokensWithinZone.tsx
@@ -25,7 +25,10 @@ const ZONE_GAS_BUFFER = parseUnits('1', 6)
 
 type ZoneClientLike = {
   token: {
-    getBalance: (parameters: { account: Hex; token: Hex }) => Promise<bigint>
+    getBalance: (parameters: {
+      account: Hex
+      token: Hex
+    }) => Promise<{ amount: bigint; decimals: number; formatted: string }>
   }
   zone: ZoneAuthClientLike['zone']
 }
@@ -104,10 +107,11 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     queryFn: async () => {
       if (!zoneClient) throw new Error('zone client not ready')
 
-      return zoneClient.token.getBalance({
+      const { amount } = await zoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
+      return amount
     },
     staleTime: 30_000,
   })
@@ -162,7 +166,7 @@ function ConnectedZoneFlow(props: { address: Hex }) {
       if (!zoneClient) throw new Error('zone client not ready')
       if (!rootWebAuthnAccount) throw new Error('root account not ready')
 
-      const currentZoneBalance = await zoneClient.token.getBalance({
+      const { amount: currentZoneBalance } = await zoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
@@ -196,10 +200,11 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     queryFn: async () => {
       if (!zoneClient) throw new Error('zone client not ready')
 
-      return zoneClient.token.getBalance({
+      const { amount } = await zoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
+      return amount
     },
     refetchInterval: (query) => {
       if (query.state.error) return false
@@ -219,7 +224,7 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(rootBalance && rootBalance.amount > 0n)
   const topUpReceipt = topUpMutation.data?.receipt
   const expectedMaxZoneBalance = transferMutation.data?.startingZoneBalance
     ? transferMutation.data.startingZoneBalance - TRANSFER_AMOUNT

--- a/src/components/guides/zones/SwapAcrossZones.tsx
+++ b/src/components/guides/zones/SwapAcrossZones.tsx
@@ -69,8 +69,15 @@ const targetDepositEvent = parseAbiItem(
 
 type ZoneClientLike = {
   token: {
-    getAllowance: (parameters: { account: Hex; spender: Hex; token: Hex }) => Promise<bigint>
-    getBalance: (parameters: { account: Hex; token: Hex }) => Promise<bigint>
+    getAllowance: (parameters: {
+      account: Hex
+      spender: Hex
+      token: Hex
+    }) => Promise<{ amount: bigint; decimals: number; formatted: string }>
+    getBalance: (parameters: {
+      account: Hex
+      token: Hex
+    }) => Promise<{ amount: bigint; decimals: number; formatted: string }>
   }
   zone: {
     getAuthorizationTokenInfo: ZoneAuthClientLike['zone']['getAuthorizationTokenInfo']
@@ -179,10 +186,11 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     queryFn: async () => {
       if (!sourceZoneClient) throw new Error('Zone A client not ready')
 
-      return sourceZoneClient.token.getBalance({
+      const { amount } = await sourceZoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
+      return amount
     },
     staleTime: 30_000,
   })
@@ -322,7 +330,7 @@ function ConnectedZoneFlow(props: { address: Hex }) {
       if (!rootWebAuthnAccount) throw new Error('root account not ready')
       if (!swapPrereqsQuery.data) throw new Error('Swap prerequisites are not ready')
 
-      const currentSourceBalance = await sourceZoneClient.token.getBalance({
+      const { amount: currentSourceBalance } = await sourceZoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
@@ -433,10 +441,11 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     queryFn: async () => {
       if (!targetZoneClient) throw new Error('Zone B client not ready')
 
-      return targetZoneClient.token.getBalance({
+      const { amount } = await targetZoneClient.token.getBalance({
         account: address,
         token: betaUsd,
       })
+      return amount
     },
     staleTime: 30_000,
     refetchOnReconnect: false,
@@ -444,7 +453,7 @@ function ConnectedZoneFlow(props: { address: Hex }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(rootBalance && rootBalance.amount > 0n)
   const topUpReceipt = topUpMutation.data?.receipt
   const routedSwapReceipt = swapMutation.data?.receipt
   const settlementTxHash = settlementQuery.data?.txHash

--- a/src/components/guides/zones/WithdrawFromZone.tsx
+++ b/src/components/guides/zones/WithdrawFromZone.tsx
@@ -35,7 +35,10 @@ type WithdrawalMode = 'standard' | 'authenticated'
 
 type ZoneClientLike = {
   token: {
-    getBalance: (parameters: { account: Hex; token: Hex }) => Promise<bigint>
+    getBalance: (parameters: {
+      account: Hex
+      token: Hex
+    }) => Promise<{ amount: bigint; decimals: number; formatted: string }>
   }
   zone: {
     requestVerifiableWithdrawalSync: (parameters: {
@@ -150,10 +153,11 @@ function ConnectedZoneFlow(props: { address: Hex; mode: WithdrawalMode }) {
     queryFn: async () => {
       if (!zoneClient) throw new Error('zone client not ready')
 
-      return zoneClient.token.getBalance({
+      const { amount } = await zoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
+      return amount
     },
     staleTime: 30_000,
   })
@@ -217,11 +221,14 @@ function ConnectedZoneFlow(props: { address: Hex; mode: WithdrawalMode }) {
       if (!rootWebAuthnAccount) throw new Error('root account not ready')
       if (withdrawalFeeQuery.data === undefined) throw new Error('withdrawal fee not ready')
 
-      const currentRootBalance = await Actions.token.getBalance(connectorClient as never, {
-        account: address,
-        token: pathUsd,
-      })
-      const currentZoneBalance = await zoneClient.token.getBalance({
+      const { amount: currentRootBalance } = await Actions.token.getBalance(
+        connectorClient as never,
+        {
+          account: address,
+          token: pathUsd,
+        },
+      )
+      const { amount: currentZoneBalance } = await zoneClient.token.getBalance({
         account: address,
         token: pathUsd,
       })
@@ -295,14 +302,18 @@ function ConnectedZoneFlow(props: { address: Hex; mode: WithdrawalMode }) {
           : 0n
 
       const [currentRootBalance, currentZoneBalance, latest] = await Promise.all([
-        Actions.token.getBalance(connectorClient as never, {
-          account: address,
-          token: pathUsd,
-        }),
-        zoneClient.token.getBalance({
-          account: address,
-          token: pathUsd,
-        }),
+        Actions.token
+          .getBalance(connectorClient as never, {
+            account: address,
+            token: pathUsd,
+          })
+          .then(({ amount }) => amount),
+        zoneClient.token
+          .getBalance({
+            account: address,
+            token: pathUsd,
+          })
+          .then(({ amount }) => amount),
         publicClient.getBlockNumber(),
       ])
 
@@ -334,7 +345,7 @@ function ConnectedZoneFlow(props: { address: Hex; mode: WithdrawalMode }) {
     retry: false,
   })
 
-  const hasRootBalance = Boolean(rootBalance && rootBalance > 0n)
+  const hasRootBalance = Boolean(rootBalance && rootBalance.amount > 0n)
   const settlementTxHash = withdrawalConfirmationQuery.data?.txHash
   const withdrawalConfirmed = Boolean(settlementTxHash)
   const topUpReceipt = topUpMutation.data?.receipt

--- a/src/pages/docs/guide/payments/accept-a-payment.mdx
+++ b/src/pages/docs/guide/payments/accept-a-payment.mdx
@@ -40,11 +40,11 @@ Check if a payment has been received by querying the token balance or listening 
     import { client } from './viem.config'
 
     const balance = await client.token.getBalance({
+      account: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
       token: '0x20c0000000000000000000000000000000000001', // AlphaUSD
-      address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb',
     })
 
-    console.log('Balance:', balance)
+    console.log('Balance:', balance.formatted)
     ```
 
     ```ts [viem.config.ts]

--- a/src/pages/docs/quickstart/wallet-developers.mdx
+++ b/src/pages/docs/quickstart/wallet-developers.mdx
@@ -172,6 +172,7 @@ const balance = await client.token.getBalance({
   account: userAddress,
   token: tokenAddress
 })
+// ^? { amount: bigint; decimals: number; formatted: string }
 ```
 
 See [`getBalance`](https://viem.sh/tempo/actions/token.getBalance) for full documentation.


### PR DESCRIPTION
Updates viem `2.53.1` → `2.54.6` and migrates for the breaking change in [viem#4767](https://github.com/wevm/viem/pull/4767): `token.getBalance` and `token.getAllowance` now return `Amount` objects (`{ amount: bigint; decimals: number; formatted: string }`) instead of `bigint`.

## Changes

- **Guide demo components**: unwrap `.amount` for comparisons/arithmetic; use `.formatted` for balance display in place of `formatUnits(balance, decimals)` (identical output — `formatted` is `formatUnits(amount, decimals)` with the token's real decimals).
- **Zone guides** (`src/components/guides/zones/`): these hand-declare `ZoneClientLike` with `getBalance: … => Promise<bigint>`, so the compiler couldn't catch the change. Updated the declared types to the `Amount` shape and unwrapped `.amount` at fetch points (queryFns, mutations), keeping all downstream bigint logic (`typeof === 'bigint'` guards, arithmetic, casts) unchanged.
- **Docs pages**: `wallet-developers.mdx` shows the new return shape; `accept-a-payment.mdx` logs `balance.formatted` and fixes a pre-existing param bug (`address:` → `account:`).

## Not affected

- `Actions.token.approve.call({...})` usages: the `.call` client-first change keeps the args-only overload.
- ERC-20 symbol resolution change: all token constants here are hex addresses.
- wagmi 3.6.20 / @wagmi/core 3.5.4 resolve viem 2.54.6 as peer — hook types picked up the new shape without a wagmi bump.

## Verification

- `tsgo --build` clean (note: `pnpm check:types` runs `--noEmit` against the solution-style tsconfig and checks nothing — it passed even before the migration with ~50 real type errors present; worth fixing separately)
- `biome check` clean (pre-existing warnings only)
- `vitest`: 79/79 pass
