### PR TITLE
[codex] fix mobile docs sidebar

### DIFF
--- a/src/components/DocsHeader.test.ts
+++ b/src/components/DocsHeader.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeDocsPath, resolveSidebarItems } from './DocsHeader'
+
+const sidebar = {
+  '/docs': [{ text: 'Start Here' }],
+  '/docs/protocol': [{ text: 'Tempo Protocol' }],
+  '/docs/tools': [{ text: 'Tools & SDKs' }],
+}
+
+describe('normalizeDocsPath', () => {
+  it.each([
+    ['/developers/docs/protocol', '/docs/protocol'],
+    ['/developers/docs/protocol/tip20/overview', '/docs/protocol/tip20/overview'],
+    ['/developers', '/'],
+    ['/docs/tools', '/docs/tools'],
+    ['', '/'],
+  ])('normalizes %s to %s', (pathname, expected) => {
+    expect(normalizeDocsPath(pathname)).toBe(expected)
+  })
+})
+
+describe('resolveSidebarItems', () => {
+  it('uses the current docs section when served from the developers mount', () => {
+    const items = resolveSidebarItems(sidebar, '/developers/docs/protocol')
+
+    expect(items[0]?.text).toBe('Tempo Protocol')
+  })
+
+  it('uses the longest matching sidebar key', () => {
+    const items = resolveSidebarItems(sidebar, '/docs/protocol/tip20/overview')
+
+    expect(items[0]?.text).toBe('Tempo Protocol')
+  })
+})

--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useConfig } from 'vocs'
+import { useRouter } from 'waku'
 import { DOCS_SEARCH_PARAM } from '../lib/docs-search'
 import { AmpLogo, ClaudeLogo, CodexLogo } from './AgentLogos'
 
@@ -36,8 +37,13 @@ function isExternal(href: string) {
   return !href.startsWith('/') && !href.startsWith('#')
 }
 
-function normalizePath(pathname: string) {
-  return pathname || '/'
+export function normalizeDocsPath(pathname: string) {
+  const path = pathname || '/'
+  if (path === DEVELOPERS_BASE_PATH) return '/'
+  if (path.startsWith(`${DEVELOPERS_BASE_PATH}/`)) {
+    return path.slice(DEVELOPERS_BASE_PATH.length) || '/'
+  }
+  return path
 }
 
 function pathMatches(pathname: string, href: string) {
@@ -45,10 +51,11 @@ function pathMatches(pathname: string, href: string) {
 }
 
 export function usePathname() {
-  const [pathname, setPathname] = useState('/')
+  const { path } = useRouter()
+  const [pathname, setPathname] = useState(() => normalizeDocsPath(path ?? '/'))
 
   useLayoutEffect(() => {
-    const update = () => setPathname(normalizePath(window.location.pathname))
+    const update = () => setPathname(normalizeDocsPath(window.location.pathname))
     update()
     window.addEventListener('popstate', update)
     window.addEventListener('hashchange', update)
@@ -57,6 +64,10 @@ export function usePathname() {
       window.removeEventListener('hashchange', update)
     }
   }, [])
+
+  useEffect(() => {
+    if (path) setPathname(normalizeDocsPath(path))
+  }, [path])
 
   return pathname
 }
@@ -882,10 +893,11 @@ export function resolveSidebarItems(sidebar: unknown, pathname: string): Sidebar
   if (Array.isArray(sidebar)) return sidebar as SidebarNode[]
   if (typeof sidebar !== 'object') return []
 
+  const path = normalizeDocsPath(pathname)
   const entries = sidebar as Record<string, SidebarNode[] | { items?: SidebarNode[] }>
   let bestKey: string | null = null
   for (const key of Object.keys(entries)) {
-    if (pathname === key || pathname.startsWith(key === '/' ? '/' : `${key}/`)) {
+    if (path === key || path.startsWith(key === '/' ? '/' : `${key}/`)) {
       if (bestKey === null || key.length > bestKey.length) bestKey = key
     }
   }


### PR DESCRIPTION
## Summary

Fixes the mobile docs sidebar drawer so it resolves the sidebar for the current docs section when the site is served from the production `/developers` mount.

## Root Cause

The custom docs pathname helper read the raw browser path, so production URLs such as `/developers/docs/protocol` did not match the `/docs/protocol` sidebar key and fell back to the `/docs` Start Here sidebar.

## Changes

- Normalize `/developers/...` paths before resolving docs sidebar items.
- Sync the custom pathname hook with Waku route state so client-side route changes keep the drawer in step.
- Add regression tests for production mount paths and longest-prefix sidebar matching.

## Validation

- `VITE_USE_HTTP=true ./node_modules/.bin/vitest run --dir src src/components/DocsHeader.test.ts`
- `VITE_USE_HTTP=true ./node_modules/.bin/tsgo --project tsconfig.json --noEmit`
- `./node_modules/.bin/biome check --write src/components/DocsHeader.tsx src/components/DocsHeader.test.ts`
- Mobile browser check on `/docs/protocol`: drawer shows Protocol/TIP-20 items, not Start Here