### PR TITLE
docs: add planned T8 upgrade page

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -1420,6 +1420,7 @@ body {
   box-shadow: none;
 }
 
+[data-v-sidebar] a[data-v-sidebar-item][href$="/protocol/upgrades/t8"] [data-v-sidebar-item-badge],
 [data-v-sidebar] a[data-v-sidebar-item][href$="/protocol/upgrades/t7"] [data-v-sidebar-item-badge] {
   background: var(--color-gray4);
 }

--- a/src/pages/docs/guide/issuance/distribute-rewards.mdx
+++ b/src/pages/docs/guide/issuance/distribute-rewards.mdx
@@ -17,9 +17,13 @@ import { Cards, Card } from 'vocs'
 
 # Distribute Rewards
 
-Distribute rewards to token holders using TIP-20's built-in reward distribution mechanism. Rewards allow parties to incentivize holders of a token by distributing tokens proportionally based on their balance.
+This guide documents TIP-20's built-in reward distribution mechanism for existing integrations and already-accrued rewards.
 
-Rewards can be distributed by anyone on any TIP-20 token, and claimed by any holder who has opted in. This guide covers both the reward distributor and token holder use cases. While the demo below uses a token you create, the same principles apply to any token.
+:::warning[Deprecated in T7]
+Do not build new rewards flows on this surface. The [T7 network upgrade](/docs/protocol/upgrades/t7) deprecates new TIP-20 reward opt-ins and reward distributions; already-accrued rewards remain claimable.
+:::
+
+Before T7, rewards could be distributed by anyone on any TIP-20 token, and claimed by any holder who had opted in. The demo below is kept as reference material for existing integrations.
 
 ## Rewards distribution demo
 

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,6 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
+| v1.10.2 | Planned: Jul 19, 2026 | Testnet + Mainnet | Planned required release for T8; includes native multisig accounts, current committee state, FeeAMM TIP-403 policy exemptions, and versioned Stablecoin DEX order storage. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.9.0](https://github.com/tempoxyz/tempo/releases/tag/v1.9.0) | Jun 15, 2026 | Testnet + Mainnet | Required for T6; adds account-level receive policies for safer TIP-20 deposits and admin access keys for smoother passkey, device, and delegated-key management. Operators were required to run this release before the T6 activation timestamp on each network. | <Badge variant="red">Required</Badge> |
@@ -34,6 +35,22 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | [v1.4.0](https://github.com/tempoxyz/tempo/releases/tag/v1.4.0) | Mar 5, 2026 | Moderato + Mainnet | Required for T1C; introduces keychain signature migration so only V2 signatures and hashes are accepted after activation | <Badge variant="red">Required</Badge> |
 | [v1.3.1](https://github.com/tempoxyz/tempo/releases/tag/v1.3.1) | Feb 22, 2026 | Testnet + Mainnet | Fixes high-load issues and finalizes T1A/T1B hardening for expiring nonce replay protection and keychain precompile gas handling | <Badge variant="red">Required</Badge> |
 | [v1.2.0](https://github.com/tempoxyz/tempo/releases/tag/v1.2.0) | Feb 13, 2026 | Mainnet only | Fixes validation bug rejecting transactions with gas limits above ~16.7M, blocking large contract deployments | <Badge variant="red">Required</Badge> |
+
+## T8
+
+| | |
+|---|---|
+| **Scope** | Native multisig accounts; current committee state; FeeAMM TIP-403 policy exemptions; versioned Stablecoin DEX order storage |
+| **TIPs** | [TIP-1061: Native Multisig](https://tips.sh/1061-1), [TIP-1070: Current Committee State](https://github.com/tempoxyz/tempo/pull/5215), [TIP-1042: FeeAMM TIP-403 Policy Exemptions](https://github.com/tempoxyz/tempo/pull/3425), [TIP-1062: Versioned DEX Order Storage](https://tips.sh/1062) |
+| **Details** | [T8 network upgrade](/docs/protocol/upgrades/t8) |
+| **Planned release date** | July 19, 2026 |
+| **Testnet** | Planned: July 23, 2026 |
+| **Mainnet** | Planned: July 29, 2026 |
+| **Priority** | <Badge variant="red">Required</Badge> |
+
+T8 is planned. Node operators should wait for the T8 release announcement, then upgrade before the activation timestamp on each network.
+
+---
 
 ## T7
 

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -187,7 +187,7 @@ See the [T3 network upgrade](/docs/protocol/upgrades/t3) page for breaking chang
 | | |
 |---|---|
 | **Scope** | Mainnet-ready gas economics, expiring nonces, and security hardening |
-| **TIPs** | [TIP-1000: State Creation Cost Increase](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md), [TIP-1009: Expiring Nonces](https://tips.sh/1009), [TIP-1010: Mainnet Gas Parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md) |
+| **TIPs** | [TIP-1000: State Creation Cost Increase](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md), [TIP-1009: Expiring Nonces](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1009.md), [TIP-1010: Mainnet Gas Parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md) |
 | **Testnet** | Feb 5, 2026 15:00 UTC (unix: 1770303600) — Release: [v1.1.0](https://github.com/tempoxyz/tempo/releases/tag/v1.1.0) |
 | **Mainnet** | Feb 12, 2026 15:00 UTC (unix: 1770908400) — Release: [v1.1.1](https://github.com/tempoxyz/tempo/releases/tag/v1.1.1) |
 | **Priority** | <Badge variant="red">Required</Badge> |

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.10.2 | Planned: Jul 19, 2026 | Testnet + Mainnet | Planned required release for T8; includes native multisig accounts, current committee state, FeeAMM TIP-403 policy exemptions, and versioned Stablecoin DEX order storage. | <Badge variant="red">Required</Badge> |
+| v1.10.2 | Planned: Jul 19, 2026 | Testnet + Mainnet | Planned required release for T8; includes current committee state, FeeAMM policy exemptions, versioned Stablecoin DEX order storage, and DEX V2Order support. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.9.0](https://github.com/tempoxyz/tempo/releases/tag/v1.9.0) | Jun 15, 2026 | Testnet + Mainnet | Required for T6; adds account-level receive policies for safer TIP-20 deposits and admin access keys for smoother passkey, device, and delegated-key management. Operators were required to run this release before the T6 activation timestamp on each network. | <Badge variant="red">Required</Badge> |
@@ -40,8 +40,8 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | | |
 |---|---|
-| **Scope** | Native multisig accounts; current committee state; FeeAMM TIP-403 policy exemptions; versioned Stablecoin DEX order storage |
-| **TIPs** | [TIP-1061: Native Multisig](https://tips.sh/1061-1), [TIP-1070: Current Committee State](https://github.com/tempoxyz/tempo/pull/5215), [TIP-1042: FeeAMM TIP-403 Policy Exemptions](https://github.com/tempoxyz/tempo/pull/3425), [TIP-1062: Versioned DEX Order Storage](https://tips.sh/1062) |
+| **Scope** | current committee state; FeeAMM policy exemptions; versioned Stablecoin DEX order storage; DEX V2Order support |
+| **References** | [current committee state specification](https://github.com/tempoxyz/tempo/pull/5215), [current committee state implementation](https://github.com/tempoxyz/tempo/pull/6209), [FeeAMM policy exemptions specification](https://github.com/tempoxyz/tempo/pull/6604), [FeeAMM policy exemptions implementation](https://github.com/tempoxyz/tempo/pull/6605), [versioned DEX order storage specification](https://github.com/tempoxyz/tempo/pull/4075), [versioned DEX order storage implementation](https://github.com/tempoxyz/tempo/pull/6546), [DEX V2Order implementation](https://github.com/tempoxyz/tempo/pull/6691) |
 | **Details** | [T8 network upgrade](/docs/protocol/upgrades/t8) |
 | **Planned release date** | July 19, 2026 |
 | **Testnet** | Planned: July 23, 2026 |
@@ -187,7 +187,7 @@ See the [T3 network upgrade](/docs/protocol/upgrades/t3) page for breaking chang
 | | |
 |---|---|
 | **Scope** | Mainnet-ready gas economics, expiring nonces, and security hardening |
-| **TIPs** | [TIP-1000: State Creation Cost Increase](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md), [TIP-1009: Expiring Nonces](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1009.md), [TIP-1010: Mainnet Gas Parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md) |
+| **TIPs** | [TIP-1000: State Creation Cost Increase](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md), [TIP-1009: Expiring Nonces](https://tips.sh/1009), [TIP-1010: Mainnet Gas Parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md) |
 | **Testnet** | Feb 5, 2026 15:00 UTC (unix: 1770303600) — Release: [v1.1.0](https://github.com/tempoxyz/tempo/releases/tag/v1.1.0) |
 | **Mainnet** | Feb 12, 2026 15:00 UTC (unix: 1770908400) — Release: [v1.1.1](https://github.com/tempoxyz/tempo/releases/tag/v1.1.1) |
 | **Priority** | <Badge variant="red">Required</Badge> |

--- a/src/pages/docs/protocol/index.mdx
+++ b/src/pages/docs/protocol/index.mdx
@@ -64,7 +64,7 @@ If you are building an app, start with the guides in **Build on Tempo** and come
   <Card
     title="Network Upgrades"
     description="Track upgrade specifications, migration notes, and release-level protocol changes."
-    to="/docs/protocol/upgrades/t7"
+    to="/docs/protocol/upgrades/t8"
     icon="lucide:arrow-up-circle"
   />
 </Cards>

--- a/src/pages/docs/protocol/tip20-rewards/overview.mdx
+++ b/src/pages/docs/protocol/tip20-rewards/overview.mdx
@@ -9,7 +9,11 @@ import { Cards, Card } from 'vocs'
 
 Tempo Token Rewards is a built-in mechanism that allows for efficient distribution of rewards to opted-in token holders proportional to their holdings, while maintaining low gas costs at scale and complying with [TIP-403 transfer policies](/docs/protocol/tip403/spec).
 
-Traditional reward mechanisms require tokens to be staked in separate contracts, which fragments user holdings and adds complexity to wallet implementations. Tempo Token Rewards solves this by:
+:::warning[Deprecated in T7]
+Do not build new rewards flows on this surface. The [T7 network upgrade](/docs/protocol/upgrades/t7) deprecates new TIP-20 reward opt-ins and reward distributions; already-accrued rewards remain claimable.
+:::
+
+Traditional reward mechanisms require tokens to be staked in separate contracts, which fragments user holdings and adds complexity to wallet implementations. Before deprecation, Tempo Token Rewards solved this by:
 
 - **Built-in Distribution**: Rewards are integrated directly into the token contract, no separate staking required
 - **Opt-in Participation**: Users choose whether to participate by setting a reward recipient

--- a/src/pages/docs/protocol/tip20-rewards/spec.mdx
+++ b/src/pages/docs/protocol/tip20-rewards/spec.mdx
@@ -5,6 +5,10 @@ description: Technical specification for Tempo Token Rewards using reward-per-to
 
 # Tempo Token Rewards Specification
 
+:::warning[Deprecated in T7]
+Do not build new rewards flows on this surface. The [T7 network upgrade](/docs/protocol/upgrades/t7) deprecates new TIP-20 reward opt-ins and reward distributions; already-accrued rewards remain claimable.
+:::
+
 ## Abstract
 An opt-in, scalable, pro-rata reward distribution mechanism built into TIP-20 tokens. The system uses a "reward-per-token" accumulator pattern to distribute rewards proportionally to opted-in holders without requiring staking or per-holder iteration. Rewards are distributed instantly; time-based streaming distributions are planned for a future upgrade.
 

--- a/src/pages/docs/protocol/tip20/overview.mdx
+++ b/src/pages/docs/protocol/tip20/overview.mdx
@@ -43,7 +43,7 @@ Below are some of the key benefits and features of TIP-20 tokens:
     title="Transfer Memos"
   />
   <Card
-    description="Opt-in reward distribution system for issuing rewards to token holders."
+    description="Deprecated reward distribution reference for already-accrued rewards."
     to="#reward-distribution"
     icon="lucide:gift"
     title="Reward Distribution"
@@ -133,7 +133,7 @@ TIP-20 tokens also have **pause/unpause** commands, which provide emergency cont
 
 ### Reward Distribution
 
-TIP-20 supports an opt-in [reward distribution system](/docs/protocol/tip20-rewards/overview) that allows issuers to distribute rewards to token holders. Rewards can be claimed by holders or automatically forwarded to designated recipient addresses.
+TIP-20 includes a deprecated [reward distribution system](/docs/protocol/tip20-rewards/overview). New reward opt-ins and distributions are deprecated by the [T7 network upgrade](/docs/protocol/upgrades/t7), while already-accrued rewards remain claimable.
 
 ### Currency Declaration
 

--- a/src/pages/docs/protocol/upgrades/t7.mdx
+++ b/src/pages/docs/protocol/upgrades/t7.mdx
@@ -5,10 +5,10 @@ description: Partner-focused overview and rollout dates for the T7 network upgra
 
 # T7 Network Upgrade
 
-T7 gives partners a clearer fee model for high-volume payment and exchange flows. It adds storage credits for reusable DEX order and TIP-20 channel state, makes the base fee move down when network usage is below the target threshold, and deprecates new TIP-20 rewards.
+T7 is a network upgrade focused on fee behavior and reward accounting for high-volume payment and exchange flows. It adds storage credits for reusable DEX order and TIP-20 channel state, lets the base fee move down when network usage is below the target threshold, and deprecates new TIP-20 rewards.
 
 :::info[T7 status]
-Release [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) is required for T7. See the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
+T7 is live on testnet. Mainnet rollout is planned for July 9, 2026. Release [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) is required for T7; see the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
 :::
 
 ## Timeline
@@ -25,38 +25,30 @@ Node operators should upgrade to [v1.10.1](https://github.com/tempoxyz/tempo/rel
 T7 focuses on three partner needs:
 
 - **Lower fees for reusable protocol state.** Storage credits reduce fees when previously freed protocol storage can be reused, including DEX order storage and TIP-20 channel storage.
-- **A more responsive base fee.** Dynamic base fee behavior lowers the base fee when gas usage is below the target threshold.
-- **A simpler TIP-20 rewards model.** Deprecating new TIP-20 rewards simplifies reward-related accounting and user-facing balances.
+- **A more responsive base fee.** The base fee can decrease when gas usage is below the target threshold.
+- **A simpler TIP-20 rewards model.** New TIP-20 reward opt-ins and reward distributions are deprecated, while already-accrued rewards remain claimable.
 
-These changes are designed to make costs easier to reason about for partners building high-throughput payment, liquidity, and exchange experiences. Storage credits and dynamic base fee behavior affect fee calculations, while existing TIP-20 transfer behavior and claims for already-accrued rewards continue to work.
+These changes make fee behavior easier to reason about for partners building payment, liquidity, and exchange experiences. Existing TIP-20 transfer behavior continues to work.
 
 ## Features
 
 ### Storage credits for reusable protocol state
 
-Storage credits lower fees for protocol surfaces where deleted storage can later be reused. This helps reduce the cost of flows where the network can account for reusable state separately from net-new long-lived state.
+Storage credits reduce the cost of workflows that delete and later recreate the same protocol-owned state. T7 applies this to DEX order storage and TIP-20 channel storage, so repeat flows can reuse prior storage instead of paying as though every write is net-new.
 
-| TIP | Scope |
-|-----|-------|
-| [TIP-1060: Storage Credits](https://tips.sh/1060) | Core storage credits primitive |
-| [TIP-1064: StablecoinDEX Order Storage Credits](https://tips.sh/1064) | Storage credits for DEX order storage |
-| [TIP-1066: TIP-20 Channel Storage Credits](https://tips.sh/1066) | Storage credits for TIP-20 channel state |
+Read the specifications for [storage credits](https://tips.sh/1060), [DEX order storage credits](https://tips.sh/1064), and [TIP-20 channel storage credits](https://tips.sh/1066).
 
 ### Dynamic base fee
 
-Dynamic base fee behavior lets the base fee move down when gas usage is below the target threshold. This gives wallets, apps, and infrastructure a fee model that can respond to lower network usage instead of assuming a fixed base fee.
+Dynamic base fee behavior lets the base fee move down when gas usage is below the target threshold. This gives wallets, apps, and infrastructure a fee model that can reflect quieter network periods.
 
-| TIP | Scope |
-|-----|-------|
-| [TIP-1067: Dynamic Base Fee](https://tips.sh/1067-1) | Dynamic base fee behavior |
+Read the specification for [dynamic base fee behavior](https://tips.sh/1067-1).
 
-### Deprecate TIP-20 rewards
+### TIP-20 rewards deprecation
 
-T7 deprecates new TIP-20 reward opt-ins and reward distributions so partners do not need to model new reward accrual after the upgrade. Already-accrued rewards remain claimable, so historical rewards data should remain separate from post-T7 payment and balance reporting.
+T7 deprecates new TIP-20 reward opt-ins and reward distributions. Already-accrued rewards remain claimable, so historical rewards should remain separate from post-T7 payment and balance reporting.
 
-| TIP | Scope |
-|-----|-------|
-| [TIP-1075: Deprecate TIP-20 Rewards](https://github.com/tempoxyz/tempo/pull/5380) | Deprecate new TIP-20 rewards and preserve claims for already-accrued rewards |
+Read the specification for [TIP-20 rewards deprecation](https://github.com/tempoxyz/tempo/pull/5380).
 
 ## Compatible releases
 
@@ -70,20 +62,22 @@ Release notes and binaries are available in the [v1.10.1 release](https://github
 
 ## What operators and integrators should know
 
-T7 changes fee and reward behavior. Node operators, integrators, indexers, wallets, and partner infrastructure should review the notes below before testnet and mainnet rollout.
+T7 changes fee and rewards behavior. Node operators, integrators, indexers, wallets, and partner infrastructure should review the notes below while validating testnet behavior and before mainnet rollout.
 
-### For storage credits
+### For node operators
 
-Partners using DEX or TIP-20 channel flows should review fee assumptions once the T7-compatible release is available.
+- Run [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) for T7.
+- Testnet operators should already be upgraded.
+- Mainnet operators should upgrade before the July 9, 2026 activation timestamp.
 
-- Storage credits are included for the core primitive, DEX order storage, and TIP-20 channel storage.
-- Wallets and apps that estimate fees should validate their fee displays against T7 behavior on testnet.
-- Indexers and analytics systems should keep pre-T7 fee assumptions separate from post-T7 fee data.
+### For wallets, apps, and indexers
 
-### For TIP-20 rewards deprecation
+- Validate fee estimates against T7 behavior on testnet.
+- Keep pre-T7 fee assumptions separate from post-T7 fee data.
+- If you read raw DEX order or TIP-20 channel storage, account for storage-credit behavior.
 
-Apps that show TIP-20 reward information should stop presenting new rewards as accruing from post-T7 reward distributions.
+### For TIP-20 rewards displays
 
-- Wallets and dashboards should separate already-accrued rewards from post-T7 balances.
-- Accounting and reporting systems should check whether any reward-specific assumptions remain.
-- Partner support teams should be ready to explain that TIP-20 transfers and claims for already-accrued rewards continue to work, while new reward opt-ins and distributions are deprecated.
+- Stop presenting new TIP-20 rewards as accruing after T7.
+- Keep already-accrued rewards separate from post-T7 balances.
+- Continue to support claims for already-accrued rewards.

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -1,0 +1,131 @@
+---
+title: T8 Network Upgrade
+description: Planned T8 network upgrade overview covering native multisig accounts, current committee state, FeeAMM policy behavior, and DEX order storage.
+---
+
+# T8 Network Upgrade
+
+T8 is a planned network upgrade focused on native multisig accounts, clearer validator committee reads, FeeAMM policy behavior, and DEX order storage. It is expected to improve partner and operator ergonomics across account tooling, validator tooling, FeeAMM integrations, and DEX infrastructure.
+
+:::info[T8 status]
+T8 is planned. The planned release date is July 19, 2026.
+:::
+
+## Timeline
+
+| Milestone | Planned date |
+|-----------|--------------|
+| Planned release date | July 19, 2026 |
+| Testnet rollout | July 23, 2026 |
+| Mainnet rollout | July 29, 2026 |
+
+Node operators should wait for the T8 release announcement, then upgrade before the activation timestamp on each network. Exact activation timestamps will be added when the release is cut.
+
+## Overview
+
+T8 focuses on four partner needs:
+
+- **Native multisig accounts.** Teams can use accounts controlled by multiple owners, with owner weights and a threshold for transaction approval.
+- **Canonical current committee reads.** Contracts and offchain tools can query the committee that consensus is actually using for the current epoch.
+- **Cleaner fee collection behavior.** Fee collection avoids a redundant FeeManager policy check while public AMM actions remain covered by TIP-403 controls.
+- **More compact DEX order storage.** New DEX orders use a versioned storage layout, while existing orders remain readable.
+
+These changes are mostly infrastructure-facing. Wallets, relayers, indexers, validators, DEX frontends, token issuers, and FeeAMM tooling should review the notes below before the testnet rollout.
+
+## Features
+
+### Native multisig accounts
+
+Native multisig accounts let teams, treasuries, validators, and institutional operators use a Tempo account that cannot be controlled by one private key alone.
+
+T8 adds a native multisig account type. In plain terms, a multisig account has an owner list, a weight for each owner, and a threshold that must be met before the account can send a transaction. The new design:
+
+- supports flat M-of-N setups by giving every owner weight `1` and setting the threshold to `M`;
+- supports weighted setups, where some owners can count more than others;
+- derives a stable account address from the initial owner config and a caller-chosen salt; and
+- keeps the normal transaction payload shape unchanged by carrying multisig approval data inside the signature.
+
+The first transaction from a native multisig account bootstraps the account config. After that, transactions from the account must use the multisig signature path and satisfy the current owner threshold.
+
+Read the technical specification at [TIP-1061](https://tips.sh/1061-1).
+
+### Current committee state
+
+T8 adds execution-layer state for the current effective validator committee. In plain terms, this is the committee that consensus is actually using for the current epoch, based on the DKG outcome.
+
+This matters because `ValidatorConfigV2.getActiveValidators()` returns the configured validator registry, not necessarily the committee currently active in consensus. Registry changes can happen before they become part of the effective committee, and a failed DKG round can leave the prior committee in place.
+
+The new `getCommitteeMembers()` query gives contracts and offchain tools a canonical source for current committee membership, without requiring them to reconstruct it from consensus data or epoch-boundary block data.
+
+Read the technical specification at [TIP-1070](https://github.com/tempoxyz/tempo/pull/5215).
+
+### FeeAMM TIP-403 policy exemptions
+
+The FeeAMM and FeeManager help users pay transaction fees in one token while validators receive another. T8 adjusts where TIP-403 policy checks happen in that flow.
+
+During protocol fee collection, the FeeManager address is no longer checked as a TIP-403 recipient. The fee payer is still checked as an authorized sender. This keeps fee collection simpler for block builders and avoids repeating a policy check on every transaction.
+
+Public AMM operations remain policy-controlled. `mint`, `burn`, `rebalanceSwap`, and `distributeFees` continue to enforce TIP-403, and `mint` / `burn` gain extra checks that tie authorization to the liquidity provider across the lifecycle of a pool position.
+
+Token issuers still control whether their token participates in FeeAMM liquidity by authorizing the FeeManager address where required.
+
+Read the technical specification at [TIP-1042](https://github.com/tempoxyz/tempo/pull/3425).
+
+### Versioned DEX order storage
+
+T8 introduces a versioned Stablecoin DEX order storage layout. Existing orders stay in the legacy layout and remain readable. New orders use the versioned layout, which stores the same active order state with fewer storage slots.
+
+The public `getOrder(uint128)` shape stays compatible. Indexers that reconstruct DEX state from events should not need to change for this storage layout. Tools that read raw DEX storage directly must decode orders by version.
+
+Read the technical specification at [TIP-1062](https://tips.sh/1062).
+
+## Compatible releases
+
+The T8-compatible release is not published yet.
+
+| Ecosystem | T8-compatible releases |
+|-----------|------------------------|
+| Node operators | Planned for July 19, 2026; exact version TBD |
+
+Release notes and binaries will be linked here when the T8 release is cut.
+
+## What operators and integrators should know
+
+T8 is a hardfork upgrade. Node operators, integrators, indexers, wallets, relayers, token issuers, DEX frontends, and partner infrastructure should review the notes below before testnet and mainnet rollout.
+
+### For node operators
+
+- Watch for the T8 release planned for July 19, 2026.
+- Upgrade testnet nodes before the planned July 23, 2026 rollout.
+- Upgrade mainnet nodes before the planned July 29, 2026 rollout.
+- Treat the exact activation timestamps from the release announcement as the source of truth.
+
+### For wallets, custody tools, and transaction builders
+
+- Native multisig accounts use a new multisig signature type.
+- A multisig account address is derived from its initial owner config and salt.
+- The first transaction from a native multisig account must include the initial multisig config.
+- Later transactions must be authorized by owner signatures whose configured weights meet the threshold.
+- Native multisig accounts do not support access keys.
+
+### For validators, monitoring, and contracts
+
+- Use `getCommitteeMembers()` when you need the committee consensus is using now.
+- Keep using `ValidatorConfigV2` when you need the configured validator registry.
+- Do not treat `getActiveValidators()` as the current effective committee.
+- After activation, wait for the first epoch-boundary committee update before relying on the new query.
+
+### For FeeAMM, token issuer, and validator tooling
+
+- Fee collection no longer checks the FeeManager address as a TIP-403 recipient.
+- The fee payer is still checked as an authorized sender.
+- AMM actions remain policy-controlled.
+- `mint` and `burn` have extra checks that prevent blocked accounts from using liquidity positions to bypass token policies.
+- If a token does not authorize the FeeManager where required, some fees or liquidity flows may be unavailable or stranded; validator and issuer tooling should surface that clearly.
+
+### For DEX frontends and indexers
+
+- Event-driven order indexing should continue to work.
+- `getOrder(uint128)` remains ABI-compatible.
+- Raw storage readers must support both legacy version `0` orders and new version `1` orders.
+- Mixed-version order lists are expected, so storage tooling should update each order according to that order's own version.

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -1,11 +1,11 @@
 ---
 title: T8 Network Upgrade
-description: Planned T8 network upgrade overview covering native multisig accounts, current committee state, FeeAMM policy behavior, and DEX order storage.
+description: Planned T8 network upgrade overview covering current committee state, FeeAMM policy behavior, and DEX order storage.
 ---
 
 # T8 Network Upgrade
 
-T8 is a planned network upgrade focused on native multisig accounts, clearer validator committee reads, FeeAMM policy behavior, and DEX order storage. It is expected to improve partner and operator ergonomics across account tooling, validator tooling, FeeAMM integrations, and DEX infrastructure.
+T8 is a planned network upgrade focused on clearer validator committee reads, FeeAMM policy behavior, and DEX order storage.
 
 :::info[T8 status]
 T8 is planned. The planned release date is July 19, 2026.
@@ -23,31 +23,14 @@ Node operators should wait for the T8 release announcement, then upgrade before 
 
 ## Overview
 
-T8 focuses on four partner needs:
+T8 focuses on four infrastructure-facing changes:
 
-- **Native multisig accounts.** Teams can use accounts controlled by multiple owners, with owner weights and a threshold for transaction approval.
 - **Canonical current committee reads.** Contracts and offchain tools can query the committee that consensus is actually using for the current epoch.
-- **Cleaner fee collection behavior.** Fee collection avoids a redundant FeeManager policy check while public AMM actions remain covered by TIP-403 controls.
+- **Cleaner fee collection behavior.** Fee collection avoids a redundant FeeManager policy check while public AMM actions remain policy-controlled.
 - **More compact DEX order storage.** New DEX orders use a versioned storage layout, while existing orders remain readable.
-
-These changes are mostly infrastructure-facing. Wallets, relayers, indexers, validators, DEX frontends, token issuers, and FeeAMM tooling should review the notes below before the testnet rollout.
+- **DEX V2Order support.** The Stablecoin DEX adds support for a compact V2Order layout.
 
 ## Features
-
-### Native multisig accounts
-
-Native multisig accounts let teams, treasuries, validators, and institutional operators use a Tempo account that cannot be controlled by one private key alone.
-
-T8 adds a native multisig account type. In plain terms, a multisig account has an owner list, a weight for each owner, and a threshold that must be met before the account can send a transaction. The new design:
-
-- supports flat M-of-N setups by giving every owner weight `1` and setting the threshold to `M`;
-- supports weighted setups, where some owners can count more than others;
-- derives a stable account address from the initial owner config and a caller-chosen salt; and
-- keeps the normal transaction payload shape unchanged by carrying multisig approval data inside the signature.
-
-The first transaction from a native multisig account bootstraps the account config. After that, transactions from the account must use the multisig signature path and satisfy the current owner threshold.
-
-Read the technical specification at [TIP-1061](https://tips.sh/1061-1).
 
 ### Current committee state
 
@@ -57,19 +40,19 @@ This matters because `ValidatorConfigV2.getActiveValidators()` returns the confi
 
 The new `getCommitteeMembers()` query gives contracts and offchain tools a canonical source for current committee membership, without requiring them to reconstruct it from consensus data or epoch-boundary block data.
 
-Read the technical specification at [TIP-1070](https://github.com/tempoxyz/tempo/pull/5215).
+Read the specification [here](https://github.com/tempoxyz/tempo/pull/5215). Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6209).
 
-### FeeAMM TIP-403 policy exemptions
+### FeeAMM policy exemptions
 
-The FeeAMM and FeeManager help users pay transaction fees in one token while validators receive another. T8 adjusts where TIP-403 policy checks happen in that flow.
+The FeeAMM and FeeManager help users pay transaction fees in one token while validators receive another. T8 adjusts where token policy checks happen in that flow.
 
-During protocol fee collection, the FeeManager address is no longer checked as a TIP-403 recipient. The fee payer is still checked as an authorized sender. This keeps fee collection simpler for block builders and avoids repeating a policy check on every transaction.
+During protocol fee collection, the FeeManager address is no longer checked as the recipient. The fee payer is still checked as an authorized sender. This keeps fee collection simpler for block builders and avoids repeating a recipient check on every transaction.
 
-Public AMM operations remain policy-controlled. `mint`, `burn`, `rebalanceSwap`, and `distributeFees` continue to enforce TIP-403, and `mint` / `burn` gain extra checks that tie authorization to the liquidity provider across the lifecycle of a pool position.
+Public AMM operations remain policy-controlled. `mint`, `burn`, `rebalanceSwap`, and `distributeFees` continue to enforce the relevant token policies, and `mint` / `burn` gain extra checks that tie authorization to the liquidity provider across the lifecycle of a pool position.
 
 Token issuers still control whether their token participates in FeeAMM liquidity by authorizing the FeeManager address where required.
 
-Read the technical specification at [TIP-1042](https://github.com/tempoxyz/tempo/pull/3425).
+Read the specification [here](https://github.com/tempoxyz/tempo/pull/6604). Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6605).
 
 ### Versioned DEX order storage
 
@@ -77,7 +60,13 @@ T8 introduces a versioned Stablecoin DEX order storage layout. Existing orders s
 
 The public `getOrder(uint128)` shape stays compatible. Indexers that reconstruct DEX state from events should not need to change for this storage layout. Tools that read raw DEX storage directly must decode orders by version.
 
-Read the technical specification at [TIP-1062](https://tips.sh/1062).
+Read the specification [here](https://github.com/tempoxyz/tempo/pull/4075). Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6546).
+
+### DEX V2Order support
+
+T8 adds support for a compact Stablecoin DEX V2Order layout. The implementation stores an orderbook index instead of repeating the full book key on each order.
+
+Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6691).
 
 ## Compatible releases
 
@@ -85,13 +74,13 @@ The T8-compatible release is not published yet.
 
 | Ecosystem | T8-compatible releases |
 |-----------|------------------------|
-| Node operators | Planned for July 19, 2026; exact version TBD |
+| Node operators | v1.10.2 planned for July 19, 2026 |
 
-Release notes and binaries will be linked here when the T8 release is cut.
+Release notes and binaries will be linked here when v1.10.2 is cut.
 
 ## What operators and integrators should know
 
-T8 is a hardfork upgrade. Node operators, integrators, indexers, wallets, relayers, token issuers, DEX frontends, and partner infrastructure should review the notes below before testnet and mainnet rollout.
+T8 is a hardfork upgrade. Node operators should watch for the planned release and activation details before updating testnet and mainnet nodes. Teams that depend on committee reads, FeeAMM behavior, or DEX order data should review the relevant notes before rollout.
 
 ### For node operators
 
@@ -99,14 +88,6 @@ T8 is a hardfork upgrade. Node operators, integrators, indexers, wallets, relaye
 - Upgrade testnet nodes before the planned July 23, 2026 rollout.
 - Upgrade mainnet nodes before the planned July 29, 2026 rollout.
 - Treat the exact activation timestamps from the release announcement as the source of truth.
-
-### For wallets, custody tools, and transaction builders
-
-- Native multisig accounts use a new multisig signature type.
-- A multisig account address is derived from its initial owner config and salt.
-- The first transaction from a native multisig account must include the initial multisig config.
-- Later transactions must be authorized by owner signatures whose configured weights meet the threshold.
-- Native multisig accounts do not support access keys.
 
 ### For validators, monitoring, and contracts
 
@@ -117,7 +98,7 @@ T8 is a hardfork upgrade. Node operators, integrators, indexers, wallets, relaye
 
 ### For FeeAMM, token issuer, and validator tooling
 
-- Fee collection no longer checks the FeeManager address as a TIP-403 recipient.
+- Fee collection no longer checks the FeeManager address as the recipient.
 - The fee payer is still checked as an authorized sender.
 - AMM actions remain policy-controlled.
 - `mint` and `burn` have extra checks that prevent blocked accounts from using liquidity positions to bypass token policies.
@@ -129,3 +110,4 @@ T8 is a hardfork upgrade. Node operators, integrators, indexers, wallets, relaye
 - `getOrder(uint128)` remains ABI-compatible.
 - Raw storage readers must support both legacy version `0` orders and new version `1` orders.
 - Mixed-version order lists are expected, so storage tooling should update each order according to that order's own version.
+- Tooling that reads raw DEX storage should also account for V2Order support.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -806,6 +806,11 @@ export default defineConfig({
             collapsed: false,
             items: [
               {
+                text: 'T8',
+                badge: { text: 'Planned', variant: 'note' },
+                link: '/docs/protocol/upgrades/t8',
+              },
+              {
                 text: 'T7',
                 badge: { text: 'Next', variant: 'note' },
                 link: '/docs/protocol/upgrades/t7',


### PR DESCRIPTION
## Summary
- add the planned T8 network upgrade page
- add T8 to the network upgrades page and release table with planned July dates
- tighten the T7 upgrade page to match the T8 tone and link specifications without TIP tables
- add T7 deprecation notices to TIP-20 rewards docs and mark the rewards guide as reference material

## Testing
- remote readback confirmed updated T7 and rewards docs on `docs/t8-planned-upgrade-final`
- previous local `pnpm run check:types` passed for the same T7/rewards content