### PR TITLE
docs: add planned T8 upgrade page

### DIFF
--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.10.2 | Planned: Jul 19, 2026 | Testnet + Mainnet | Planned required release for T8; includes current committee state, FeeAMM policy exemptions, versioned Stablecoin DEX order storage, and DEX V2Order support. | <Badge variant="red">Required</Badge> |
+| v1.11.0 | Planned: Jul 19, 2026 | Testnet + Mainnet | Required release for T8; includes current committee state, FeeAMM policy exemptions, versioned Stablecoin DEX order storage, and DEX V2Order support. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.9.0](https://github.com/tempoxyz/tempo/releases/tag/v1.9.0) | Jun 15, 2026 | Testnet + Mainnet | Required for T6; adds account-level receive policies for safer TIP-20 deposits and admin access keys for smoother passkey, device, and delegated-key management. Operators were required to run this release before the T6 activation timestamp on each network. | <Badge variant="red">Required</Badge> |

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -41,7 +41,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | | |
 |---|---|
 | **Scope** | current committee state; FeeAMM policy exemptions; versioned Stablecoin DEX order storage; DEX V2Order support |
-| **References** | [current committee state specification](https://github.com/tempoxyz/tempo/pull/5215), [current committee state implementation](https://github.com/tempoxyz/tempo/pull/6209), [FeeAMM policy exemptions specification](https://github.com/tempoxyz/tempo/pull/6604), [FeeAMM policy exemptions implementation](https://github.com/tempoxyz/tempo/pull/6605), [versioned DEX order storage specification](https://github.com/tempoxyz/tempo/pull/4075), [versioned DEX order storage implementation](https://github.com/tempoxyz/tempo/pull/6546), [DEX V2Order implementation](https://github.com/tempoxyz/tempo/pull/6691) |
+| **References** | [current committee state specification](https://tips.sh/1070), [FeeAMM policy exemptions specification](https://tips.sh/1042), [versioned DEX order storage specification](https://tips.sh/1062) |
 | **Details** | [T8 network upgrade](/docs/protocol/upgrades/t8) |
 | **Planned release date** | July 19, 2026 |
 | **Testnet** | Planned: July 23, 2026 |

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,6 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
+| v1.10.2 | Planned: Jul 19, 2026 | Testnet + Mainnet | Planned required release for T8; includes current committee state, FeeAMM policy exemptions, versioned Stablecoin DEX order storage, and DEX V2Order support. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.9.0](https://github.com/tempoxyz/tempo/releases/tag/v1.9.0) | Jun 15, 2026 | Testnet + Mainnet | Required for T6; adds account-level receive policies for safer TIP-20 deposits and admin access keys for smoother passkey, device, and delegated-key management. Operators were required to run this release before the T6 activation timestamp on each network. | <Badge variant="red">Required</Badge> |
@@ -34,6 +35,22 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | [v1.4.0](https://github.com/tempoxyz/tempo/releases/tag/v1.4.0) | Mar 5, 2026 | Moderato + Mainnet | Required for T1C; introduces keychain signature migration so only V2 signatures and hashes are accepted after activation | <Badge variant="red">Required</Badge> |
 | [v1.3.1](https://github.com/tempoxyz/tempo/releases/tag/v1.3.1) | Feb 22, 2026 | Testnet + Mainnet | Fixes high-load issues and finalizes T1A/T1B hardening for expiring nonce replay protection and keychain precompile gas handling | <Badge variant="red">Required</Badge> |
 | [v1.2.0](https://github.com/tempoxyz/tempo/releases/tag/v1.2.0) | Feb 13, 2026 | Mainnet only | Fixes validation bug rejecting transactions with gas limits above ~16.7M, blocking large contract deployments | <Badge variant="red">Required</Badge> |
+
+## T8
+
+| | |
+|---|---|
+| **Scope** | current committee state; FeeAMM policy exemptions; versioned Stablecoin DEX order storage; DEX V2Order support |
+| **References** | [current committee state specification](https://github.com/tempoxyz/tempo/pull/5215), [current committee state implementation](https://github.com/tempoxyz/tempo/pull/6209), [FeeAMM policy exemptions specification](https://github.com/tempoxyz/tempo/pull/6604), [FeeAMM policy exemptions implementation](https://github.com/tempoxyz/tempo/pull/6605), [versioned DEX order storage specification](https://github.com/tempoxyz/tempo/pull/4075), [versioned DEX order storage implementation](https://github.com/tempoxyz/tempo/pull/6546), [DEX V2Order implementation](https://github.com/tempoxyz/tempo/pull/6691) |
+| **Details** | [T8 network upgrade](/docs/protocol/upgrades/t8) |
+| **Planned release date** | July 19, 2026 |
+| **Testnet** | Planned: July 23, 2026 |
+| **Mainnet** | Planned: July 29, 2026 |
+| **Priority** | <Badge variant="red">Required</Badge> |
+
+T8 is planned. Node operators should wait for the T8 release announcement, then upgrade before the activation timestamp on each network.
+
+---
 
 ## T7
 

--- a/src/pages/docs/protocol/index.mdx
+++ b/src/pages/docs/protocol/index.mdx
@@ -66,7 +66,7 @@ For private execution internals, start with Tempo Zones and the [zone accounts s
   <Card
     title="Network Upgrades"
     description="Track upgrade specifications, migration notes, and release-level protocol changes."
-    to="/docs/protocol/upgrades/t7"
+    to="/docs/protocol/upgrades/t8"
     icon="lucide:arrow-up-circle"
   />
 </Cards>

--- a/src/pages/docs/protocol/upgrades/t7.mdx
+++ b/src/pages/docs/protocol/upgrades/t7.mdx
@@ -66,7 +66,7 @@ The following release supports the T7 feature set:
 
 Release notes and binaries are available in the [v1.10.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1).
 
-## What operators and integrators should know
+## Integration impact
 
 ### For storage credits
 

--- a/src/pages/docs/protocol/upgrades/t7.mdx
+++ b/src/pages/docs/protocol/upgrades/t7.mdx
@@ -18,11 +18,13 @@ T7 is live on testnet. Mainnet rollout is planned for July 9, 2026. Release [v1.
 | Testnet rollout | Live: July 2, 2026 |
 | Mainnet rollout | Planned: July 9, 2026 |
 
+Node operators should run [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) for T7. Testnet operators should already be upgraded; mainnet operators should upgrade before the mainnet activation timestamp.
+
 ## Overview
 
 T7 focuses on three partner needs:
 
-- **Lower fees for reusable protocol state.** Storage credits reduce fees when previously freed protocol storage can later be reused, including DEX order storage and TIP-20 channel storage.
+- **Lower fees for reusable protocol state.** Storage credits reduce fees when previously freed protocol storage can be reused, including DEX order storage and TIP-20 channel storage.
 - **A more responsive base fee.** Dynamic base fee behavior lowers the base fee when gas usage is below the target threshold.
 - **A simpler TIP-20 rewards model.** Deprecating new TIP-20 rewards simplifies reward-related accounting and user-facing balances.
 
@@ -46,7 +48,7 @@ Dynamic base fee behavior lets the base fee move down when gas usage is below th
 
 | TIP | Scope |
 |-----|-------|
-| [TIP-1067: Dynamic Base Fee](https://tips.sh/1067) | Dynamic base fee behavior |
+| [TIP-1067: Dynamic Base Fee](https://tips.sh/1067-1) | Dynamic base fee behavior |
 
 ### Deprecate TIP-20 rewards
 
@@ -54,7 +56,7 @@ T7 deprecates new TIP-20 reward opt-ins and reward distributions so partners do 
 
 | TIP | Scope |
 |-----|-------|
-| TIP-1075: Deprecate TIP-20 Rewards | Deprecate new TIP-20 rewards and preserve claims for already-accrued rewards |
+| [TIP-1075: Deprecate TIP-20 Rewards](https://github.com/tempoxyz/tempo/pull/5380) | Deprecate new TIP-20 rewards and preserve claims for already-accrued rewards |
 
 ## Compatible releases
 
@@ -66,13 +68,17 @@ The following release supports the T7 feature set:
 
 Release notes and binaries are available in the [v1.10.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1).
 
-## Integration impact
+## What operators and integrators should know
+
+T7 changes fee and reward behavior. Node operators, integrators, indexers, wallets, and partner infrastructure should review the notes below while validating testnet behavior and before mainnet rollout.
 
 ### For storage credits
 
 Partners using DEX or TIP-20 channel flows should review fee assumptions against testnet behavior before mainnet rollout.
 
 - Storage credits are included for the core primitive, DEX order storage, and TIP-20 channel storage.
+- Wallets and apps that estimate fees should validate their fee displays against T7 behavior on testnet.
+- Indexers and analytics systems should keep pre-T7 fee assumptions separate from post-T7 fee data.
 
 ### For TIP-20 rewards deprecation
 

--- a/src/pages/docs/protocol/upgrades/t7.mdx
+++ b/src/pages/docs/protocol/upgrades/t7.mdx
@@ -18,8 +18,6 @@ T7 is live on testnet. Mainnet rollout is planned for July 9, 2026. Release [v1.
 | Testnet rollout | Live: July 2, 2026 |
 | Mainnet rollout | Planned: July 9, 2026 |
 
-Node operators should run [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) for T7. Testnet operators should already be upgraded; mainnet operators should upgrade before the mainnet activation timestamp.
-
 ## Overview
 
 T7 focuses on three partner needs:
@@ -69,8 +67,6 @@ The following release supports the T7 feature set:
 Release notes and binaries are available in the [v1.10.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1).
 
 ## What operators and integrators should know
-
-T7 changes fee and reward behavior. Node operators, integrators, indexers, wallets, and partner infrastructure should review the notes below while validating testnet behavior and before mainnet rollout.
 
 ### For storage credits
 

--- a/src/pages/docs/protocol/upgrades/t7.mdx
+++ b/src/pages/docs/protocol/upgrades/t7.mdx
@@ -22,7 +22,7 @@ T7 is live on testnet. Mainnet rollout is planned for July 9, 2026. Release [v1.
 
 T7 focuses on three partner needs:
 
-- **Lower fees for reusable protocol state.** Storage credits reduce fees when previously freed protocol storage can be reused, including DEX order storage and TIP-20 channel storage.
+- **Lower fees for reusable protocol state.** Storage credits reduce fees when previously freed protocol storage can later be reused, including DEX order storage and TIP-20 channel storage.
 - **A more responsive base fee.** Dynamic base fee behavior lowers the base fee when gas usage is below the target threshold.
 - **A simpler TIP-20 rewards model.** Deprecating new TIP-20 rewards simplifies reward-related accounting and user-facing balances.
 
@@ -46,7 +46,7 @@ Dynamic base fee behavior lets the base fee move down when gas usage is below th
 
 | TIP | Scope |
 |-----|-------|
-| [TIP-1067: Dynamic Base Fee](https://tips.sh/1067-1) | Dynamic base fee behavior |
+| [TIP-1067: Dynamic Base Fee](https://tips.sh/1067) | Dynamic base fee behavior |
 
 ### Deprecate TIP-20 rewards
 
@@ -54,7 +54,7 @@ T7 deprecates new TIP-20 reward opt-ins and reward distributions so partners do 
 
 | TIP | Scope |
 |-----|-------|
-| [TIP-1075: Deprecate TIP-20 Rewards](https://github.com/tempoxyz/tempo/pull/5380) | Deprecate new TIP-20 rewards and preserve claims for already-accrued rewards |
+| TIP-1075: Deprecate TIP-20 Rewards | Deprecate new TIP-20 rewards and preserve claims for already-accrued rewards |
 
 ## Compatible releases
 
@@ -73,8 +73,6 @@ Release notes and binaries are available in the [v1.10.1 release](https://github
 Partners using DEX or TIP-20 channel flows should review fee assumptions against testnet behavior before mainnet rollout.
 
 - Storage credits are included for the core primitive, DEX order storage, and TIP-20 channel storage.
-- Wallets and apps that estimate fees should validate their fee displays against T7 behavior on testnet.
-- Indexers and analytics systems should keep pre-T7 fee assumptions separate from post-T7 fee data.
 
 ### For TIP-20 rewards deprecation
 

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -40,7 +40,7 @@ This matters because `ValidatorConfigV2.getActiveValidators()` returns the confi
 
 The new `getCommitteeMembers()` query gives contracts and offchain tools a canonical source for current committee membership, without requiring them to reconstruct it from consensus data or epoch-boundary block data.
 
-Read the specification [here](https://github.com/tempoxyz/tempo/pull/5215).
+Read the specification [here](https://tips.sh/1070).
 
 ### FeeAMM policy exemptions
 
@@ -52,7 +52,7 @@ Public AMM operations remain policy-controlled. `mint`, `burn`, `rebalanceSwap`,
 
 Token issuers still control whether their token participates in FeeAMM liquidity by authorizing the FeeManager address where required.
 
-Read the specification [here](https://github.com/tempoxyz/tempo/pull/6604).
+Read the specification [here](https://tips.sh/1042).
 
 ### Versioned DEX order storage
 
@@ -60,7 +60,7 @@ T8 introduces a versioned Stablecoin DEX order storage layout. Existing orders s
 
 The public `getOrder(uint128)` shape stays compatible. Indexers that reconstruct DEX state from events should not need to change for this storage layout. Tools that read raw DEX storage directly must decode orders by version.
 
-Read the specification [here](https://github.com/tempoxyz/tempo/pull/4075).
+Read the specification [here](https://tips.sh/1062).
 
 ### DEX V2Order support
 

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -1,0 +1,113 @@
+---
+title: T8 Network Upgrade
+description: Planned T8 network upgrade overview covering current committee state, FeeAMM policy behavior, and DEX order storage.
+---
+
+# T8 Network Upgrade
+
+T8 is a planned network upgrade focused on clearer validator committee reads, FeeAMM policy behavior, and DEX order storage.
+
+:::info[T8 status]
+T8 is planned. The planned release date is July 19, 2026.
+:::
+
+## Timeline
+
+| Milestone | Planned date |
+|-----------|--------------|
+| Planned release date | July 19, 2026 |
+| Testnet rollout | July 23, 2026 |
+| Mainnet rollout | July 29, 2026 |
+
+Node operators should wait for the T8 release announcement, then upgrade before the activation timestamp on each network. Exact activation timestamps will be added when the release is cut.
+
+## Overview
+
+T8 focuses on four infrastructure-facing changes:
+
+- **Canonical current committee reads.** Contracts and offchain tools can query the committee that consensus is actually using for the current epoch.
+- **Cleaner fee collection behavior.** Fee collection avoids a redundant FeeManager policy check while public AMM actions remain policy-controlled.
+- **More compact DEX order storage.** New DEX orders use a versioned storage layout, while existing orders remain readable.
+- **DEX V2Order support.** The Stablecoin DEX adds support for a compact V2Order layout.
+
+## Features
+
+### Current committee state
+
+T8 adds execution-layer state for the current effective validator committee. In plain terms, this is the committee that consensus is actually using for the current epoch, based on the DKG outcome.
+
+This matters because `ValidatorConfigV2.getActiveValidators()` returns the configured validator registry, not necessarily the committee currently active in consensus. Registry changes can happen before they become part of the effective committee, and a failed DKG round can leave the prior committee in place.
+
+The new `getCommitteeMembers()` query gives contracts and offchain tools a canonical source for current committee membership, without requiring them to reconstruct it from consensus data or epoch-boundary block data.
+
+Read the specification [here](https://github.com/tempoxyz/tempo/pull/5215). Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6209).
+
+### FeeAMM policy exemptions
+
+The FeeAMM and FeeManager help users pay transaction fees in one token while validators receive another. T8 adjusts where token policy checks happen in that flow.
+
+During protocol fee collection, the FeeManager address is no longer checked as the recipient. The fee payer is still checked as an authorized sender. This keeps fee collection simpler for block builders and avoids repeating a recipient check on every transaction.
+
+Public AMM operations remain policy-controlled. `mint`, `burn`, `rebalanceSwap`, and `distributeFees` continue to enforce the relevant token policies, and `mint` / `burn` gain extra checks that tie authorization to the liquidity provider across the lifecycle of a pool position.
+
+Token issuers still control whether their token participates in FeeAMM liquidity by authorizing the FeeManager address where required.
+
+Read the specification [here](https://github.com/tempoxyz/tempo/pull/6604). Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6605).
+
+### Versioned DEX order storage
+
+T8 introduces a versioned Stablecoin DEX order storage layout. Existing orders stay in the legacy layout and remain readable. New orders use the versioned layout, which stores the same active order state with fewer storage slots.
+
+The public `getOrder(uint128)` shape stays compatible. Indexers that reconstruct DEX state from events should not need to change for this storage layout. Tools that read raw DEX storage directly must decode orders by version.
+
+Read the specification [here](https://github.com/tempoxyz/tempo/pull/4075). Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6546).
+
+### DEX V2Order support
+
+T8 adds support for a compact Stablecoin DEX V2Order layout. The implementation stores an orderbook index instead of repeating the full book key on each order.
+
+Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6691).
+
+## Compatible releases
+
+The T8-compatible release is not published yet.
+
+| Ecosystem | T8-compatible releases |
+|-----------|------------------------|
+| Node operators | v1.10.2 planned for July 19, 2026 |
+
+Release notes and binaries will be linked here when v1.10.2 is cut.
+
+## What operators and integrators should know
+
+T8 is a hardfork upgrade. Node operators should watch for the planned release and activation details before updating testnet and mainnet nodes. Teams that depend on committee reads, FeeAMM behavior, or DEX order data should review the relevant notes before rollout.
+
+### For node operators
+
+- Watch for the T8 release planned for July 19, 2026.
+- Upgrade testnet nodes before the planned July 23, 2026 rollout.
+- Upgrade mainnet nodes before the planned July 29, 2026 rollout.
+- Treat the exact activation timestamps from the release announcement as the source of truth.
+
+### For validators, monitoring, and contracts
+
+- Use `getCommitteeMembers()` when you need the committee consensus is using now.
+- Keep using `ValidatorConfigV2` when you need the configured validator registry.
+- Do not treat `getActiveValidators()` as the current effective committee.
+- After activation, wait for the first epoch-boundary committee update before relying on the new query.
+
+### For FeeAMM, token issuer, and validator tooling
+
+- Fee collection no longer checks the FeeManager address as the recipient.
+- The fee payer is still checked as an authorized sender.
+- AMM actions remain policy-controlled.
+- `mint` and `burn` have extra checks that prevent blocked accounts from using liquidity positions to bypass token policies.
+- If a token does not authorize the FeeManager where required, some fees or liquidity flows may be unavailable or stranded; validator and issuer tooling should surface that clearly.
+
+### For DEX frontends and indexers
+
+- Event-driven order indexing should continue to work.
+- `getOrder(uint128)` remains ABI-compatible.
+- Raw storage readers must support both legacy version `0` orders and new version `1` orders.
+- Mixed-version order lists are expected, so storage tooling should update each order according to that order's own version.
+- Tooling that reads raw DEX storage should also account for V2Order support.

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -80,15 +80,6 @@ Release notes and binaries will be linked here when v1.10.2 is cut.
 
 ## What operators and integrators should know
 
-T8 is a hardfork upgrade. Node operators should watch for the planned release and activation details before updating testnet and mainnet nodes. Teams that depend on committee reads, FeeAMM behavior, or DEX order data should review the relevant notes before rollout.
-
-### For node operators
-
-- Watch for the T8 release planned for July 19, 2026.
-- Upgrade testnet nodes before the planned July 23, 2026 rollout.
-- Upgrade mainnet nodes before the planned July 29, 2026 rollout.
-- Treat the exact activation timestamps from the release announcement as the source of truth.
-
 ### For validators, monitoring, and contracts
 
 - Use `getCommitteeMembers()` when you need the committee consensus is using now.

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -1,21 +1,21 @@
 ---
 title: T8 Network Upgrade
-description: Planned T8 network upgrade overview covering current committee state, FeeAMM policy behavior, and DEX order storage.
+description: T8 network upgrade overview covering current committee state, FeeAMM policy behavior, and DEX order storage.
 ---
 
 # T8 Network Upgrade
 
-T8 is a planned network upgrade focused on clearer validator committee reads, FeeAMM policy behavior, and DEX order storage.
+T8 focuses on clearer validator committee reads, FeeAMM policy behavior, and DEX order storage.
 
 :::info[T8 status]
-T8 is planned. The planned release date is July 19, 2026.
+Release target: July 19, 2026.
 :::
 
 ## Timeline
 
-| Milestone | Planned date |
-|-----------|--------------|
-| Planned release date | July 19, 2026 |
+| Milestone | Date |
+|-----------|------|
+| Release target | July 19, 2026 |
 | Testnet rollout | July 23, 2026 |
 | Mainnet rollout | July 29, 2026 |
 
@@ -23,12 +23,11 @@ Node operators should wait for the T8 release announcement, then upgrade before 
 
 ## Overview
 
-T8 focuses on four infrastructure-facing changes:
+T8 focuses on three infrastructure-facing changes:
 
 - **Canonical current committee reads.** Contracts and offchain tools can query the committee that consensus is actually using for the current epoch.
 - **Cleaner fee collection behavior.** Fee collection avoids a redundant FeeManager policy check while public AMM actions remain policy-controlled.
-- **More compact DEX order storage.** New DEX orders use a versioned storage layout, while existing orders remain readable.
-- **DEX V2Order support.** The Stablecoin DEX adds support for a compact V2Order layout.
+- **DEX order storage updates.** New DEX orders use versioned storage, existing orders remain readable, and the Stablecoin DEX supports the compact V2Order layout.
 
 ## Features
 
@@ -54,17 +53,15 @@ Token issuers still control whether their token participates in FeeAMM liquidity
 
 Read the specification [here](https://tips.sh/1042).
 
-### Versioned DEX order storage
+### DEX order storage
 
 T8 introduces a versioned Stablecoin DEX order storage layout. Existing orders stay in the legacy layout and remain readable. New orders use the versioned layout, which stores the same active order state with fewer storage slots.
 
 The public `getOrder(uint128)` shape stays compatible. Indexers that reconstruct DEX state from events should not need to change for this storage layout. Tools that read raw DEX storage directly must decode orders by version.
 
-Read the specification [here](https://tips.sh/1062).
+The Stablecoin DEX also supports a compact V2Order layout. V2Order stores an orderbook index instead of repeating the full book key on each order.
 
-### DEX V2Order support
-
-T8 adds support for a compact Stablecoin DEX V2Order layout. The layout stores an orderbook index instead of repeating the full book key on each order.
+Read the versioned order storage specification [here](https://tips.sh/1062).
 
 ## Compatible releases
 
@@ -72,9 +69,9 @@ The T8-compatible release is not published yet.
 
 | Ecosystem | T8-compatible releases |
 |-----------|------------------------|
-| Node operators | v1.10.2 planned for July 19, 2026 |
+| Node operators | v1.11.0 target release on July 19, 2026 |
 
-Release notes and binaries will be linked here when v1.10.2 is cut.
+Release notes and binaries will be linked here when v1.11.0 is cut.
 
 ## Integration impact
 

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -76,7 +76,7 @@ The T8-compatible release is not published yet.
 
 Release notes and binaries will be linked here when v1.10.2 is cut.
 
-## What operators and integrators should know
+## Integration impact
 
 ### For validators, monitoring, and contracts
 

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -40,7 +40,7 @@ This matters because `ValidatorConfigV2.getActiveValidators()` returns the confi
 
 The new `getCommitteeMembers()` query gives contracts and offchain tools a canonical source for current committee membership, without requiring them to reconstruct it from consensus data or epoch-boundary block data.
 
-Read the specification [here](https://github.com/tempoxyz/tempo/pull/5215). Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6209).
+Read the specification [here](https://github.com/tempoxyz/tempo/pull/5215).
 
 ### FeeAMM policy exemptions
 
@@ -52,7 +52,7 @@ Public AMM operations remain policy-controlled. `mint`, `burn`, `rebalanceSwap`,
 
 Token issuers still control whether their token participates in FeeAMM liquidity by authorizing the FeeManager address where required.
 
-Read the specification [here](https://github.com/tempoxyz/tempo/pull/6604). Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6605).
+Read the specification [here](https://github.com/tempoxyz/tempo/pull/6604).
 
 ### Versioned DEX order storage
 
@@ -60,13 +60,11 @@ T8 introduces a versioned Stablecoin DEX order storage layout. Existing orders s
 
 The public `getOrder(uint128)` shape stays compatible. Indexers that reconstruct DEX state from events should not need to change for this storage layout. Tools that read raw DEX storage directly must decode orders by version.
 
-Read the specification [here](https://github.com/tempoxyz/tempo/pull/4075). Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6546).
+Read the specification [here](https://github.com/tempoxyz/tempo/pull/4075).
 
 ### DEX V2Order support
 
-T8 adds support for a compact Stablecoin DEX V2Order layout. The implementation stores an orderbook index instead of repeating the full book key on each order.
-
-Read the implementation [here](https://github.com/tempoxyz/tempo/pull/6691).
+T8 adds support for a compact Stablecoin DEX V2Order layout. The layout stores an orderbook index instead of repeating the full book key on each order.
 
 ## Compatible releases
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -839,6 +839,11 @@ export default defineConfig({
             collapsed: false,
             items: [
               {
+                text: 'T8',
+                badge: { text: 'Planned', variant: 'note' },
+                link: '/docs/protocol/upgrades/t8',
+              },
+              {
                 text: 'T7',
                 badge: { text: 'Next', variant: 'note' },
                 link: '/docs/protocol/upgrades/t7',


### PR DESCRIPTION
## Summary
- add the planned T8 network upgrade page with the final T8 scope
- keep T8 reference links spec-only and omit reference lines where no spec link exists
- add planned v1.11.0 and T8 to the network upgrades/releases page
- point the protocol index upgrade card at T8

## Testing
- pnpm run check:types