### PR TITLE
Update docs SEO metadata

### DIFF
--- a/e2e/seo-head.test.ts
+++ b/e2e/seo-head.test.ts
@@ -67,8 +67,15 @@ const cases: {
     ogImageIncludes: 'section=PERFORMANCE',
   },
   {
+    path: '/docs',
+    title: 'Tempo Documentation ⋅ Tempo Docs',
+    ogTitle: 'Tempo Documentation',
+    descriptionIncludes: 'Tempo docs for integration paths',
+    ogImageIncludes: '/og-docs.png',
+  },
+  {
     path: '/docs/guide/payments/send-a-payment',
-    title: 'Send a Payment ⋅ Tempo',
+    title: 'Send a Payment ⋅ Tempo Docs',
     ogTitle: 'Send a Payment',
     descriptionIncludes: 'stablecoin payments between accounts',
     ogImageIncludes: 'subsection=PAYMENTS',
@@ -85,6 +92,11 @@ for (const c of cases) {
     expect(metaContent(head, 'og:description')).toContain(c.descriptionIncludes)
     expect(metaContent(head, 'og:image')).toContain(c.ogImageIncludes)
     expect(metaContent(head, 'twitter:title')).toBe(c.ogTitle)
+
+    if (c.path.startsWith('/docs')) {
+      expect(metaContent(head, 'article:published_time')).toBeUndefined()
+      expect(metaContent(head, 'article:modified_time')).toBeUndefined()
+    }
   })
 }
 

--- a/patches/vocs@2.3.3.patch
+++ b/patches/vocs@2.3.3.patch
@@ -1,0 +1,54 @@
+diff --git a/dist/react/Head.js b/dist/react/Head.js
+index 14b82a21ac7f3f1f1cd8871d7cd1d5e73775ad71..c7cad127018aa38ee9d83fe818e91a6a51405744 100644
+--- a/dist/react/Head.js
++++ b/dist/react/Head.js
+@@ -10,7 +10,12 @@ export function Head() {
+     const { basePath, baseUrl, colorScheme, iconUrl, logoUrl, ogImageUrl, renderStrategy } = config;
+     const staticScheme = colorScheme !== 'light dark';
+     const title = frontmatter?.title ?? config.title;
+-    const titleTemplate = title.includes(config.title) ? undefined : config.titleTemplate;
++    const isDocsPath = pathname === '/docs' || pathname.startsWith('/docs/');
++    const titleTemplate = isDocsPath
++        ? '%s ⋅ Tempo Docs'
++        : title.includes(config.title)
++            ? undefined
++            : config.titleTemplate;
+     const fullTitle = titleTemplate ? titleTemplate.replace('%s', title) : title;
+     const description = frontmatter?.description ?? config.description;
+     const fullPathname = basePath && basePath !== '/' ? `${basePath}${pathname}` : pathname;
+@@ -34,7 +39,7 @@ export function Head() {
+                 // biome-ignore lint/security/noDangerouslySetInnerHtml: blocking script to prevent FOUC
+                 dangerouslySetInnerHTML: {
+                     __html: `(function(){try{var e=document.documentElement;var s=function(t){e.setAttribute('data-vocs-theme',t);e.style.colorScheme=t};var t=localStorage.getItem('vocs-theme');if(t==='light'||t==='dark'){s(t)}else if(window.matchMedia('(prefers-color-scheme:dark)').matches){s('dark')}else if(window.matchMedia('(prefers-color-scheme:light)').matches){s('light')}else{s('dark')}}catch(e){}})()`,
+-                } })), _jsx("meta", { name: "color-scheme", content: colorScheme }), _jsx("meta", { name: "robots", content: frontmatter?.robots ?? (import.meta.env.PROD ? 'index, follow' : 'noindex, nofollow') }), fullTitle && _jsx("title", { children: fullTitle }, "title"), description && _jsx("meta", { name: "description", content: description }), baseUrl && _jsx("base", { href: baseUrl }), canonicalUrl && _jsx("link", { rel: "canonical", href: canonicalUrl }), iconUrl && typeof iconUrl === 'string' && (_jsx("link", { rel: "icon", href: iconUrl, type: getIconType(iconUrl) })), iconUrl && typeof iconUrl !== 'string' && (_jsx("link", { rel: "icon", href: iconUrl.light, type: getIconType(iconUrl.light) })), iconUrl && typeof iconUrl !== 'string' && (_jsx("link", { rel: "icon", href: iconUrl.dark, type: getIconType(iconUrl.dark), media: "(prefers-color-scheme: dark)" })), frontmatter?.author && _jsx("meta", { name: "author", content: frontmatter.author }), _jsx("meta", { property: "og:type", content: "website" }), title && _jsx("meta", { property: "og:title", content: title }), config.title && _jsx("meta", { property: "og:site_name", content: config.title }), baseUrl && _jsx("meta", { property: "og:url", content: canonicalUrl ?? baseUrl }), description && _jsx("meta", { property: "og:description", content: description }), ogImage && _jsx("meta", { property: "og:image", content: ogImage }), frontmatter?.author && _jsx("meta", { property: "article:author", content: frontmatter.author }), frontmatter?.lastModified && (_jsx("meta", { property: "article:modified_time", content: frontmatter.lastModified })), _jsx("meta", { name: "twitter:card", content: "summary_large_image" }), title && _jsx("meta", { name: "twitter:title", content: title }), description && _jsx("meta", { name: "twitter:description", content: description }), ogImage && _jsx("meta", { property: "twitter:image", content: ogImage })] }));
++                } })), _jsx("meta", { name: "color-scheme", content: colorScheme }), _jsx("meta", { name: "robots", content: frontmatter?.robots ?? (import.meta.env.PROD ? 'index, follow' : 'noindex, nofollow') }), fullTitle && _jsx("title", { children: fullTitle }, "title"), description && _jsx("meta", { name: "description", content: description }), baseUrl && _jsx("base", { href: baseUrl }), canonicalUrl && _jsx("link", { rel: "canonical", href: canonicalUrl }), iconUrl && typeof iconUrl === 'string' && (_jsx("link", { rel: "icon", href: iconUrl, type: getIconType(iconUrl) })), iconUrl && typeof iconUrl !== 'string' && (_jsx("link", { rel: "icon", href: iconUrl.light, type: getIconType(iconUrl.light) })), iconUrl && typeof iconUrl !== 'string' && (_jsx("link", { rel: "icon", href: iconUrl.dark, type: getIconType(iconUrl.dark), media: "(prefers-color-scheme: dark)" })), frontmatter?.author && _jsx("meta", { name: "author", content: frontmatter.author }), _jsx("meta", { property: "og:type", content: "website" }), title && _jsx("meta", { property: "og:title", content: title }), config.title && _jsx("meta", { property: "og:site_name", content: config.title }), baseUrl && _jsx("meta", { property: "og:url", content: canonicalUrl ?? baseUrl }), description && _jsx("meta", { property: "og:description", content: description }), ogImage && _jsx("meta", { property: "og:image", content: ogImage }), frontmatter?.author && _jsx("meta", { property: "article:author", content: frontmatter.author }), frontmatter?.lastModified && !isDocsPath && (_jsx("meta", { property: "article:modified_time", content: frontmatter.lastModified })), _jsx("meta", { name: "twitter:card", content: "summary_large_image" }), title && _jsx("meta", { name: "twitter:title", content: title }), description && _jsx("meta", { name: "twitter:description", content: description }), ogImage && _jsx("meta", { property: "twitter:image", content: ogImage })] }));
+ }
+ function getIconType(iconUrl) {
+     if (iconUrl.endsWith('.svg'))
+diff --git a/src/react/Head.tsx b/src/react/Head.tsx
+index b24b581509a3a65acd46983b0a83a6f92a01f693..6c8b7d7e9f4175d04c1818c69f411e1c3e4db266 100644
+--- a/src/react/Head.tsx
++++ b/src/react/Head.tsx
+@@ -14,7 +14,12 @@ export function Head() {
+   const staticScheme = colorScheme !== 'light dark'
+ 
+   const title = frontmatter?.title ?? config.title
+-  const titleTemplate = title.includes(config.title) ? undefined : config.titleTemplate
++  const isDocsPath = pathname === '/docs' || pathname.startsWith('/docs/')
++  const titleTemplate = isDocsPath
++    ? '%s ⋅ Tempo Docs'
++    : title.includes(config.title)
++      ? undefined
++      : config.titleTemplate
+   const fullTitle = titleTemplate ? titleTemplate.replace('%s', title) : title
+ 
+   const description = frontmatter?.description ?? config.description
+@@ -100,7 +105,7 @@ export function Head() {
+ 
+       {/* Article metadata */}
+       {frontmatter?.author && <meta property="article:author" content={frontmatter.author} />}
+-      {frontmatter?.lastModified && (
++      {frontmatter?.lastModified && !isDocsPath && (
+         <meta property="article:modified_time" content={frontmatter.lastModified} />
+       )}
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ patchedDependencies:
   dayjs@1.11.20:
     hash: 47bfcf62e3c84ba85d881815422a02e23f372df46bddb9b022eb3705361fd165
     path: patches/dayjs@1.11.20.patch
+  vocs@2.3.3:
+    hash: 8991bff2794fafa19ccdb2e23b03cdeaab5e9aa09b652f976ac56e8d8c3a55e2
+    path: patches/vocs@2.3.3.patch
 
 importers:
 
@@ -137,7 +140,7 @@ importers:
         version: 2.54.6(typescript@6.0.3)(zod@4.4.3)
       vocs:
         specifier: ^2.3.3
-        version: 2.3.3(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 2.3.3(patch_hash=8991bff2794fafa19ccdb2e23b03cdeaab5e9aa09b652f976ac56e8d8c3a55e2)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       wagmi:
         specifier: 3.6.20
         version: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
@@ -9764,7 +9767,7 @@ snapshots:
       ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
       tidx.ts: 0.1.1(typescript@6.0.3)
       viem: 2.51.3(typescript@6.0.3)(zod@4.4.3)
-      vocs: 2.3.3(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vocs: 2.3.3(patch_hash=8991bff2794fafa19ccdb2e23b03cdeaab5e9aa09b652f976ac56e8d8c3a55e2)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -10181,7 +10184,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@2.3.3(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vocs@2.3.3(patch_hash=8991bff2794fafa19ccdb2e23b03cdeaab5e9aa09b652f976ac56e8d8c3a55e2)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ overrides:
 patchedDependencies:
   '@braintree/sanitize-url@7.1.2': patches/@braintree__sanitize-url@7.1.2.patch
   dayjs@1.11.20: patches/dayjs@1.11.20.patch
+  vocs@2.3.3: patches/vocs@2.3.3.patch
 
 strictDepBuilds: true
 

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Get Started
-description: Start building on Tempo with integration paths, payment guides, protocol references, SDKs, hosted services, node operations, AI resources, and partners.
+title: Tempo Documentation
+description: Tempo docs for integration paths, payment guides, protocol references, SDKs, hosted services, node operations, AI resources, and partners.
 ---
 
 import { Cards, Card } from 'vocs'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -217,6 +217,7 @@ function llmsFeedbackPreamble(): Plugin {
 
       await Promise.all(candidates.map(prependFeedbackNotice))
       await removeTemplateRoutesFromSitemap(path.join(publicDir, 'sitemap.xml'))
+      await removeDocsLastmodFromSitemap(path.join(publicDir, 'sitemap.xml'))
     },
   }
 }
@@ -254,6 +255,19 @@ async function removeTemplateRoutesFromSitemap(filePath: string) {
     const filtered = content.replaceAll(
       /<url>\s*<loc>[^<]*\/\[[^\]]+\][^<]*<\/loc>[\s\S]*?<\/url>\s*/g,
       '',
+    )
+    if (filtered !== content) await fs.writeFile(filePath, filtered, 'utf-8')
+  } catch {
+    return
+  }
+}
+
+async function removeDocsLastmodFromSitemap(filePath: string) {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8')
+    const filtered = content.replace(
+      /<url>([\s\S]*?<loc>[^<]*\/docs(?:\/[^<]*)?<\/loc>[\s\S]*?)<\/url>/g,
+      (entry) => entry.replace(/\s*<lastmod>[^<]*<\/lastmod>/g, ''),
     )
     if (filtered !== content) await fs.writeFile(filePath, filtered, 'utf-8')
   } catch {


### PR DESCRIPTION
## Summary
- Update the docs landing page title to `Tempo Documentation` and add `docs` to the meta description.
- Override docs page `<title>` tags so `/developers/docs...` pages end in `⋅ Tempo Docs` instead of `⋅ Tempo`.
- Remove `<lastmod>` entries for docs URLs from the generated sitemap so evergreen docs pages do not advertise freshness dates to crawlers.
- Add SEO regression coverage for the docs landing page, docs title suffixes, and absence of article time metadata on docs pages.

## Verification
- `pnpm exec biome check --write --unsafe src/pages/docs/_layout.tsx e2e/seo-head.test.ts`
- `pnpm check:types`
- Local sitemap regex probe for docs `<lastmod>` removal
- `pnpm build` blocked after TypeScript by Vocs remote OpenAPI fetch timeout from `https://api.tempo.xyz/openapi.json`

Prompted by: @juandolealt