### PR TITLE
docs: fix Zones specification link

### DIFF
--- a/src/pages/docs/protocol/zones/index.mdx
+++ b/src/pages/docs/protocol/zones/index.mdx
@@ -43,9 +43,9 @@ Validity proofs guarantee correct state transitions. Sequencers order transactio
 
 Tempo Zones are interoperable with Tempo Mainnet and with each other. Deposits and withdrawals settle in seconds. A Tempo Zone can withdraw tokens, swap them on the Stablecoin DEX, and deposit the result into another Tempo Zone in a single operation. The [bridging specification](/docs/protocol/zones/bridging) covers deposits, withdrawals, encrypted deposits for private on-ramps, and composable withdrawal callbacks for cross-zone transfers.
 
-### Github and Specifications
+### GitHub and Specifications
 
-The zones repository is available on [github](https://github.com/tempoxyz/zones), which also includes the full Tempo Zones [specifications](https://github.com/tempoxyz/zones/blob/main/docs/specs/zone_spec.md).
+The zones repository is available on [GitHub](https://github.com/tempoxyz/zones), which also includes the full Tempo Zones [specification](https://github.com/tempoxyz/zones/blob/main/specs/spec.md).
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- Fix the broken Tempo Zones specification link on the Zones protocol page
- Normalize GitHub capitalization in the same section

## Validation
- pnpm check:types

Prompted by: @snario