### PR TITLE
Add T7 network upgrade blog

### DIFF
--- a/blogs/t7-network-upgrade.md
+++ b/blogs/t7-network-upgrade.md
@@ -55,10 +55,10 @@ See the [v1.10.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1
 ## Resources
 
 - [T7 upgrade docs](/docs/protocol/upgrades/t7)
-- [TIP-1067: Dynamic Base Fee](https://tips.sh/1067)
-- [TIP-1060: Storage Credits](https://tips.sh/1060)
-- [TIP-1064: StablecoinDEX Order Storage Credits](https://tips.sh/1064)
-- [TIP-1066: TIP-20 Channel Storage Credits](https://tips.sh/1066)
+- [Dynamic base fee](https://tips.sh/1067)
+- [Storage credits](https://tips.sh/1060)
+- [StablecoinDEX order storage credits](https://tips.sh/1064)
+- [TIP-20 channel storage credits](https://tips.sh/1066)
 - [Accept pay-as-you-go payments](/docs/guide/machine-payments/pay-as-you-go)
 - [v1.10.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1)
 - [Tempo on GitHub](https://github.com/tempoxyz)

--- a/blogs/t7-network-upgrade.md
+++ b/blogs/t7-network-upgrade.md
@@ -11,7 +11,15 @@ category: network-upgrades
 
 T7 replaces Tempo's fixed base fee with a bounded dynamic base fee. The new cap is 40% lower than the current fixed fee, and when block gas usage is below target, the fee can fall toward a floor set at one twentieth of the cap. The fee never exceeds the cap, so integrators keep a hard ceiling on per-transaction costs while gaining the upside of cheaper quiet periods.
 
+![A diagram comparing today's fixed fee, the T7 cap, and the T7 floor for a 50,000 gas TIP-20 transfer.](/blog/t7-dynamic-base-fee-range.svg)
+
+*T7 keeps a hard cap on the base fee while allowing lower fees during quiet periods.*
+
 As an example, the typical gas for a TIP-20 token transfer between two existing users (~50,000 gas) now costs about $0.0006 at the new cap and about $0.00003 at the quiet-period floor, compared to $0.001 today. At the floor, that transfer is therefore about 33x cheaper than today's fixed fee.
+
+![A diagram showing the base fee falling when block usage is below target and rising back toward the cap as usage increases.](/blog/t7-dynamic-base-fee-response.svg)
+
+*The cap and floor are fixed bounds. The live base fee moves inside that range as block usage changes.*
 
 The base fee starts at the cap at activation and moves with block usage. For wallets, checkout flows, and infrastructure that display fees, this means expecting the base fee to move rather than stay fixed, and comparing pre-T7 fixed-fee periods separately from post-T7 dynamic-fee periods in fee analytics.
 

--- a/blogs/t7-network-upgrade.md
+++ b/blogs/t7-network-upgrade.md
@@ -1,0 +1,65 @@
+---
+title: "T7 network upgrade: Lower fees, storage credits, and more"
+excerpt: "The T7 network upgrade lowers fees on Tempo with capped dynamic fees and new storage credits that make repeated onchain workflows cheaper."
+date: 2026-07-09
+category: network-upgrades
+---
+
+**The T7 network upgrade lowers fees on Tempo. T7 introduces capped dynamic fees: the base fee cap is 40% below today's fixed fee and can fall a further 20x during off-peak periods. New storage credits make repeated onchain workflows cheaper, from user contracts to StablecoinDEX orders and MPP payment channels.** [Read the T7 docs to start integrating →](/docs/protocol/upgrades/t7)
+
+## Dynamic base fee
+
+T7 replaces Tempo's fixed base fee with a bounded dynamic base fee. The new cap is 40% lower than the current fixed fee, and when block gas usage is below target, the fee can fall toward a floor set at one twentieth of the cap. The fee never exceeds the cap, so integrators keep a hard ceiling on per-transaction costs while gaining the upside of cheaper quiet periods.
+
+As an example, the typical gas for a TIP-20 token transfer between two existing users (~50,000 gas) now costs about $0.0006 at the new cap and about $0.00003 at the quiet-period floor, compared to $0.001 today. At the floor, that transfer is therefore about 33x cheaper than today's fixed fee.
+
+The base fee starts at the cap at activation and moves with block usage. For wallets, checkout flows, and infrastructure that display fees, this means expecting the base fee to move rather than stay fixed, and comparing pre-T7 fixed-fee periods separately from post-T7 dynamic-fee periods in fee analytics.
+
+Read the specification for [dynamic base fees](https://tips.sh/1067).
+
+## Storage credits
+
+Many payment and liquidity workflows follow the same lifecycle: create state, clear it, then create more state in the same transaction. Order placement and cancellation on DEXes follow this pattern, as do MPP channel opens and closes and escrow creation and release. Before T7, each creation paid the full storage-creation cost, so, for example, in the flow above, the contract would be charged for two state creations even though it created only one net piece of state.
+
+Storage credits change that. When a contract clears eligible storage, it earns a credit, and when it later creates eligible storage, the credit offsets roughly 98% of the cost.
+
+The savings are targeted rather than a blanket gas discount: they apply where a workflow repeatedly creates and clears temporary state. For apps with repeat contract workflows, this means meaningful gas savings can be passed to returning users.
+
+Read the specification for [storage credits](https://tips.sh/1060).
+
+## Per-user credits for DEX orders and payment channels
+
+Shared contracts introduce an attribution problem. If a contract earns credits from many users' activity, the next storage write spends those credits regardless of who earned them, and the savings land on the wrong users. T7 solves this with per-user accounting in the two places where the lifecycle pattern shows up most: credits stay with the user who earned them.
+
+On the StablecoinDEX, credits are tracked per maker. When a maker cancels or fully fills an eligible order, the savings stay attached to that maker and apply the next time they place an eligible order. Active makers pay less on repeat order placement, and no one can spend savings another maker earned.
+
+On MPP payment channels, credits are tracked per payer through the TIP20ChannelReserve precompile. When a payer closes or withdraws a finished channel, the reserve records a credit for that payer and applies it when the same payer opens their next channel. Per-request vouchers already stay off-chain, so per-payment costs do not change. The savings apply to the channel lifecycle itself, which means repeated pay-as-you-go sessions from the same payer cost less to run.
+
+The same pattern is available to any shared contract: track which user earned credits and spend them only for that user. If you build shared systems with temporary state, the main integration decision is whether to allocate credits per user, payer, maker, or account rather than pooling them globally.
+
+Read the specifications:
+
+- [StablecoinDEX Order Storage Credits](https://tips.sh/1064)
+- [TIP-20 Channel Storage Credits](https://tips.sh/1066)
+
+For the MPP session flow, see [Accept pay-as-you-go payments](/docs/guide/machine-payments/pay-as-you-go) in the docs.
+
+## What integrators should know
+
+T7 went live on testnet on July 2 and rolls out to mainnet on July 9. Node operators should run the [v1.10.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) to stay in sync with mainnet. The full set of changes and gas benchmarks are in the release notes, and the current node-operator release status is in the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates).
+
+For contract developers, the main opportunity is to identify workflows with temporary state and decide how storage-credit savings should be allocated: per user, payer, maker, or account. Avoid global credit pools in shared contracts when savings should stay attached to the party who earned them.
+
+See the [v1.10.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) and the [T7 upgrade docs](/docs/protocol/upgrades/t7).
+
+## Resources
+
+- [T7 upgrade docs](/docs/protocol/upgrades/t7)
+- [TIP-1067: Dynamic Base Fee](https://tips.sh/1067)
+- [TIP-1060: Storage Credits](https://tips.sh/1060)
+- [TIP-1064: StablecoinDEX Order Storage Credits](https://tips.sh/1064)
+- [TIP-1066: TIP-20 Channel Storage Credits](https://tips.sh/1066)
+- [Accept pay-as-you-go payments](/docs/guide/machine-payments/pay-as-you-go)
+- [v1.10.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1)
+- [Tempo on GitHub](https://github.com/tempoxyz)
+- [All TIPs](/docs/protocol/tips)

--- a/blogs/t7-network-upgrade.md
+++ b/blogs/t7-network-upgrade.md
@@ -13,7 +13,7 @@ T7 replaces Tempo's fixed base fee with a bounded dynamic base fee. The new cap 
 
 ![A diagram comparing today's fixed fee, the T7 cap, and the T7 floor for a 50,000 gas TIP-20 transfer.](/blog/t7-dynamic-base-fee-range.svg)
 
-*T7 keeps a hard cap on the base fee while allowing lower fees during quiet periods.*
+*T7 keeps a hard cap on the base fee while allowing lower fees during off-peak periods.*
 
 As an example, the typical gas for a TIP-20 token transfer between two existing users (~50,000 gas) now costs about $0.0006 at the new cap and about $0.00003 at the quiet-period floor, compared to $0.001 today. At the floor, that transfer is therefore about 33x cheaper than today's fixed fee.
 

--- a/public/blog/t7-dynamic-base-fee-range.svg
+++ b/public/blog/t7-dynamic-base-fee-range.svg
@@ -39,6 +39,4 @@
   <line x1="424" y1="159.2" x2="448" y2="159.2" stroke="#58b88a" stroke-width="2"/>
   <line x1="424" y1="243.56" x2="448" y2="243.56" stroke="#58b88a" stroke-width="2"/>
   <text x="400" y="145.2" font-size="7.6" fill="#58b88a" opacity="0.85" letter-spacing="0.14em" text-anchor="middle">BOUNDED RANGE</text>
-
-  <text x="260" y="310" font-size="7.6" fill="var(--foreground)" opacity="0.48" letter-spacing="0.14em" text-anchor="middle">THE CAP STAYS HARD. QUIET PERIODS CAN PRICE LOWER.</text>
 </svg>

--- a/public/blog/t7-dynamic-base-fee-range.svg
+++ b/public/blog/t7-dynamic-base-fee-range.svg
@@ -1,0 +1,44 @@
+<svg width="840" height="517" viewBox="0 0 520 320" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="var(--font-jetbrains-mono), ui-monospace, monospace">
+  <rect width="520" height="320" fill="var(--surface-shell)"/>
+
+  <text x="24" y="34" font-size="10.5" fill="var(--foreground)" opacity="0.9" letter-spacing="0.16em">DYNAMIC BASE FEE RANGE</text>
+  <text x="24" y="52" font-size="7.8" fill="var(--foreground)" opacity="0.42" letter-spacing="0.14em">50K GAS TIP-20 TRANSFER COST</text>
+
+  <g opacity="0.55" stroke="var(--line-strong)">
+    <line x1="54" y1="86" x2="420" y2="86"/>
+    <line x1="54" y1="166" x2="420" y2="166"/>
+    <line x1="54" y1="248" x2="420" y2="248"/>
+  </g>
+  <text x="24" y="90" font-size="7.2" fill="var(--foreground)" opacity="0.36" letter-spacing="0.12em">TODAY</text>
+  <text x="24" y="252" font-size="7.2" fill="var(--foreground)" opacity="0.36" letter-spacing="0.12em">FLOOR</text>
+
+  <g opacity="0.58">
+    <text x="109" y="88" font-size="8.8" fill="var(--foreground)" opacity="0.48" letter-spacing="0.08em" text-anchor="middle">$0.001</text>
+    <rect x="70" y="100" width="78" height="148" fill="var(--surface-block)" stroke="var(--line-strong)"/>
+    <text x="109" y="271" font-size="8.2" fill="var(--foreground)" opacity="0.68" letter-spacing="0.12em" text-anchor="middle">TODAY</text>
+    <text x="109" y="287" font-size="6.8" fill="var(--foreground)" opacity="0.38" letter-spacing="0.1em" text-anchor="middle">FIXED FEE</text>
+  </g>
+
+  <g>
+    <text x="229" y="147.2" font-size="8.8" fill="#58b88a" opacity="0.92" letter-spacing="0.08em" text-anchor="middle">$0.0006</text>
+    <rect x="190" y="159.2" width="78" height="88.8" fill="#58b88a" opacity="0.22" stroke="#58b88a"/>
+    <rect x="190" y="159.2" width="78" height="4" fill="#58b88a"/>
+    <text x="229" y="271" font-size="8.2" fill="var(--foreground)" opacity="0.68" letter-spacing="0.12em" text-anchor="middle">T7 CAP</text>
+    <text x="229" y="287" font-size="6.8" fill="var(--foreground)" opacity="0.38" letter-spacing="0.1em" text-anchor="middle">40% LOWER</text>
+  </g>
+
+  <g>
+    <text x="349" y="231.56" font-size="8.8" fill="#cde769" opacity="0.92" letter-spacing="0.08em" text-anchor="middle">$0.00003</text>
+    <rect x="310" y="243.56" width="78" height="4.44" fill="#cde769" opacity="0.22" stroke="#cde769"/>
+    <rect x="310" y="243.56" width="78" height="4" fill="#cde769"/>
+    <text x="349" y="271" font-size="8.2" fill="var(--foreground)" opacity="0.68" letter-spacing="0.12em" text-anchor="middle">T7 FLOOR</text>
+    <text x="349" y="287" font-size="6.8" fill="var(--foreground)" opacity="0.38" letter-spacing="0.1em" text-anchor="middle">20X BELOW CAP</text>
+  </g>
+
+  <path d="M436 159.2V243.56" stroke="#58b88a" stroke-width="2"/>
+  <line x1="424" y1="159.2" x2="448" y2="159.2" stroke="#58b88a" stroke-width="2"/>
+  <line x1="424" y1="243.56" x2="448" y2="243.56" stroke="#58b88a" stroke-width="2"/>
+  <text x="400" y="145.2" font-size="7.6" fill="#58b88a" opacity="0.85" letter-spacing="0.14em" text-anchor="middle">BOUNDED RANGE</text>
+
+  <text x="260" y="310" font-size="7.6" fill="var(--foreground)" opacity="0.48" letter-spacing="0.14em" text-anchor="middle">THE CAP STAYS HARD. QUIET PERIODS CAN PRICE LOWER.</text>
+</svg>

--- a/public/blog/t7-dynamic-base-fee-response.svg
+++ b/public/blog/t7-dynamic-base-fee-response.svg
@@ -62,6 +62,4 @@
     <rect x="445" y="244" width="22" height="3" fill="#5d88ff"/>
     <text x="456" y="304" font-size="6.6" fill="var(--foreground)" opacity="0.54" letter-spacing="0.1em" text-anchor="middle">FULL</text>
   </g>
-
-  <text x="260" y="314" font-size="7.6" fill="var(--foreground)" opacity="0.48" letter-spacing="0.14em" text-anchor="middle">LOW BLOCK USAGE PULLS FEES DOWN. BUSIER BLOCKS MOVE FEES BACK UP.</text>
 </svg>

--- a/public/blog/t7-dynamic-base-fee-response.svg
+++ b/public/blog/t7-dynamic-base-fee-response.svg
@@ -1,0 +1,67 @@
+<svg width="840" height="517" viewBox="0 0 520 320" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="var(--font-jetbrains-mono), ui-monospace, monospace">
+  <rect width="520" height="320" fill="var(--surface-shell)"/>
+
+  <text x="24" y="34" font-size="10.5" fill="var(--foreground)" opacity="0.9" letter-spacing="0.16em">BASE FEE RESPONDS TO BLOCK USE</text>
+  <text x="24" y="52" font-size="7.8" fill="var(--foreground)" opacity="0.42" letter-spacing="0.14em">THE LIVE FEE MOVES BETWEEN THE T7 CAP AND FLOOR</text>
+  <text x="174" y="76" font-size="7.3" fill="var(--foreground)" opacity="0.48" letter-spacing="0.17em" text-anchor="middle">BELOW TARGET</text>
+  <text x="370" y="76" font-size="7.3" fill="var(--foreground)" opacity="0.48" letter-spacing="0.17em" text-anchor="middle">USAGE RISES</text>
+
+  <line x1="58" y1="100" x2="456" y2="100" stroke="var(--line-strong)"/>
+  <line x1="58" y1="226" x2="456" y2="226" stroke="var(--line-strong)" stroke-dasharray="4 4" opacity="0.65"/>
+  <text x="24" y="104" font-size="7.2" fill="var(--foreground)" opacity="0.38" letter-spacing="0.12em">CAP</text>
+  <text x="24" y="230" font-size="7.2" fill="var(--foreground)" opacity="0.38" letter-spacing="0.12em">FLOOR</text>
+
+  <path class="diagram-flow" d="M58 100L157.5 145.36L257 219.7L356.5 157.96L456 100" stroke="#58b88a" stroke-width="2.5" fill="none"/>
+
+  <g>
+    <circle cx="58" cy="100" r="4" fill="#5d88ff"/>
+    <text x="58" y="87" font-size="6.6" fill="var(--foreground)" opacity="0.55" letter-spacing="0.12em" text-anchor="middle">AT CAP</text>
+  </g>
+  <g>
+    <circle cx="157.5" cy="145.36" r="4" fill="#58b88a"/>
+    <text x="157.5" y="132.36" font-size="6.6" fill="var(--foreground)" opacity="0.55" letter-spacing="0.12em" text-anchor="middle">FALLS</text>
+  </g>
+  <g>
+    <circle cx="257" cy="219.7" r="4" fill="#cde769"/>
+    <text x="257" y="206.7" font-size="6.6" fill="var(--foreground)" opacity="0.55" letter-spacing="0.12em" text-anchor="middle">NEAR FLOOR</text>
+  </g>
+  <g>
+    <circle cx="356.5" cy="157.96" r="4" fill="#58b88a"/>
+    <text x="356.5" y="144.96" font-size="6.6" fill="var(--foreground)" opacity="0.55" letter-spacing="0.12em" text-anchor="middle">RISES</text>
+  </g>
+  <g>
+    <circle cx="456" cy="100" r="4" fill="#5d88ff"/>
+    <text x="456" y="87" font-size="6.6" fill="var(--foreground)" opacity="0.55" letter-spacing="0.12em" text-anchor="middle">AT CAP</text>
+  </g>
+
+  <line x1="58" y1="262" x2="456" y2="262" stroke="var(--line-strong)" stroke-dasharray="3 3" opacity="0.45"/>
+  <text x="466" y="265" font-size="6.7" fill="var(--foreground)" opacity="0.36" letter-spacing="0.12em">TARGET</text>
+
+  <g>
+    <rect x="47" y="253.36" width="22" height="32.64" fill="#5d88ff" opacity="0.2"/>
+    <rect x="47" y="253.36" width="22" height="3" fill="#5d88ff"/>
+    <text x="58" y="304" font-size="6.6" fill="var(--foreground)" opacity="0.54" letter-spacing="0.1em" text-anchor="middle">START</text>
+  </g>
+  <g>
+    <rect x="146.5" y="271.36" width="22" height="14.64" fill="#58b88a" opacity="0.2"/>
+    <rect x="146.5" y="271.36" width="22" height="3" fill="#58b88a"/>
+    <text x="157.5" y="304" font-size="6.6" fill="var(--foreground)" opacity="0.54" letter-spacing="0.1em" text-anchor="middle">LOW</text>
+  </g>
+  <g>
+    <rect x="246" y="275.68" width="22" height="10.32" fill="#cde769" opacity="0.2"/>
+    <rect x="246" y="275.68" width="22" height="3" fill="#cde769"/>
+    <text x="257" y="304" font-size="6.6" fill="var(--foreground)" opacity="0.54" letter-spacing="0.1em" text-anchor="middle">QUIET</text>
+  </g>
+  <g>
+    <rect x="345.5" y="254.8" width="22" height="31.2" fill="#58b88a" opacity="0.2"/>
+    <rect x="345.5" y="254.8" width="22" height="3" fill="#58b88a"/>
+    <text x="356.5" y="304" font-size="6.6" fill="var(--foreground)" opacity="0.54" letter-spacing="0.1em" text-anchor="middle">BUSY</text>
+  </g>
+  <g>
+    <rect x="445" y="244" width="22" height="42" fill="#5d88ff" opacity="0.2"/>
+    <rect x="445" y="244" width="22" height="3" fill="#5d88ff"/>
+    <text x="456" y="304" font-size="6.6" fill="var(--foreground)" opacity="0.54" letter-spacing="0.1em" text-anchor="middle">FULL</text>
+  </g>
+
+  <text x="260" y="314" font-size="7.6" fill="var(--foreground)" opacity="0.48" letter-spacing="0.14em" text-anchor="middle">LOW BLOCK USAGE PULLS FEES DOWN. BUSIER BLOCKS MOVE FEES BACK UP.</text>
+</svg>

--- a/src/marketing/app/diagrams/_components/FeatureDiagram.tsx
+++ b/src/marketing/app/diagrams/_components/FeatureDiagram.tsx
@@ -11,6 +11,8 @@ import {
   type FeatureDiagramSpec,
   type FeeAmmSpec,
   type FeeAmmToken,
+  type FeeRangeSpec,
+  type FeeResponseSpec,
   type ForwardSpec,
   type GateSpec,
   type HubSpec,
@@ -27,6 +29,7 @@ const markPath =
   'M5.03996 14.8395H1.03534L4.74694 3.36361H0L1.03534 0H14.2604L13.225 3.36361H8.73202L5.03996 14.8395Z'
 
 const color = (accent: number) => PALETTE[accent % PALETTE.length]
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1)
 
 function NodeCard({
   x,
@@ -1071,6 +1074,278 @@ function FeeAmmShape({ spec }: { spec: FeeAmmSpec }) {
   )
 }
 
+// ── fee range ───────────────────────────────────────────────────────────────
+// T7's base fee is bounded: the cap is lower than the previous fixed fee, and
+// the live base fee can fall toward the floor when the network is quiet.
+const FR_CHART_X = 54
+const FR_CHART_TOP = 86
+const FR_BASE_Y = 248
+const FR_BAR_MAX_H = 148
+const FR_BAR_W = 78
+const FR_BAR_START_X = 70
+const FR_BAR_STEP = 120
+function FeeRangeShape({ spec }: { spec: FeeRangeSpec }) {
+  const pointForRatio = (ratio: number) => FR_BASE_Y - FR_BAR_MAX_H * clamp01(ratio)
+  const capY = pointForRatio(spec.markers[1]?.ratio ?? 0.6)
+  const floorY = pointForRatio(spec.markers[2]?.ratio ?? 0.03)
+  const rangeX = 436
+  return (
+    <>
+      <Label x={24} y={34} size={10.5} tracking={0.16} opacity={0.9}>
+        {spec.title}
+      </Label>
+      <Label x={24} y={52} size={7.8} tracking={0.14} opacity={0.42}>
+        {spec.subtitle}
+      </Label>
+
+      <g opacity="0.55">
+        <line
+          x1={FR_CHART_X}
+          y1={FR_CHART_TOP}
+          x2="420"
+          y2={FR_CHART_TOP}
+          stroke="var(--line-strong)"
+        />
+        <line x1={FR_CHART_X} y1={166} x2="420" y2={166} stroke="var(--line-strong)" />
+        <line x1={FR_CHART_X} y1={FR_BASE_Y} x2="420" y2={FR_BASE_Y} stroke="var(--line-strong)" />
+      </g>
+      <Label x={24} y={FR_CHART_TOP + 4} size={7.2} tracking={0.12} opacity={0.36}>
+        TODAY
+      </Label>
+      <Label x={24} y={FR_BASE_Y + 4} size={7.2} tracking={0.12} opacity={0.36}>
+        FLOOR
+      </Label>
+
+      {spec.markers.map((marker, i) => {
+        const x = FR_BAR_START_X + i * FR_BAR_STEP
+        const h = Math.max(4, FR_BAR_MAX_H * clamp01(marker.ratio))
+        const y = FR_BASE_Y - h
+        const cx = x + FR_BAR_W / 2
+        const fill = marker.muted ? 'var(--surface-block)' : color(marker.accent)
+        return (
+          <g key={marker.label} opacity={marker.muted ? 0.58 : 1}>
+            <Label
+              x={cx}
+              y={y - 12}
+              size={8.8}
+              tracking={0.08}
+              opacity={marker.muted ? 0.48 : 0.92}
+              fill={marker.muted ? 'var(--foreground)' : color(marker.accent)}
+              anchor="middle"
+            >
+              {marker.value}
+            </Label>
+            <rect
+              x={x}
+              y={y}
+              width={FR_BAR_W}
+              height={h}
+              fill={fill}
+              opacity={marker.muted ? 1 : 0.22}
+              stroke={marker.muted ? 'var(--line-strong)' : color(marker.accent)}
+            />
+            {!marker.muted && (
+              <rect x={x} y={y} width={FR_BAR_W} height="4" fill={color(marker.accent)} />
+            )}
+            <Label
+              x={cx}
+              y={FR_BASE_Y + 23}
+              size={8.2}
+              tracking={0.12}
+              opacity={0.68}
+              anchor="middle"
+            >
+              {marker.label}
+            </Label>
+            <Label
+              x={cx}
+              y={FR_BASE_Y + 39}
+              size={6.8}
+              tracking={0.1}
+              opacity={0.38}
+              anchor="middle"
+            >
+              {marker.detail}
+            </Label>
+          </g>
+        )
+      })}
+
+      <path
+        d={`M${rangeX} ${capY}V${floorY}`}
+        stroke={color(spec.rangeAccent)}
+        strokeWidth="2"
+        fill="none"
+      />
+      <line
+        x1={rangeX - 12}
+        y1={capY}
+        x2={rangeX + 12}
+        y2={capY}
+        stroke={color(spec.rangeAccent)}
+        strokeWidth="2"
+      />
+      <line
+        x1={rangeX - 12}
+        y1={floorY}
+        x2={rangeX + 12}
+        y2={floorY}
+        stroke={color(spec.rangeAccent)}
+        strokeWidth="2"
+      />
+      <Label
+        x={400}
+        y={capY - 14}
+        size={7.6}
+        tracking={0.14}
+        opacity={0.85}
+        fill={color(spec.rangeAccent)}
+        anchor="middle"
+      >
+        {spec.rangeLabel}
+      </Label>
+      <Label x={260} y={310} size={7.6} tracking={0.14} opacity={0.48} anchor="middle">
+        {spec.caption}
+      </Label>
+    </>
+  )
+}
+
+// ── fee response ────────────────────────────────────────────────────────────
+// Block usage controls the live base fee inside the bounded T7 range. Low usage
+// pushes the fee lower; rising usage moves it back toward the cap.
+const FEE_RESP_X = 58
+const FEE_RESP_W = 398
+const FEE_RESP_CAP_Y = 100
+const FEE_RESP_FLOOR_Y = 226
+function FeeResponseShape({ spec }: { spec: FeeResponseSpec }) {
+  const steps = spec.steps
+  const points = steps.map((step, i) => {
+    const x = FEE_RESP_X + (FEE_RESP_W * i) / Math.max(1, steps.length - 1)
+    const y = FEE_RESP_CAP_Y + (1 - clamp01(step.feeRatio)) * (FEE_RESP_FLOOR_Y - FEE_RESP_CAP_Y)
+    return { ...step, x, y }
+  })
+  const feePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x} ${p.y}`).join('')
+  const usageBaseY = 286
+  const usageTargetY = usageBaseY - 24
+  return (
+    <>
+      <Label x={24} y={34} size={10.5} tracking={0.16} opacity={0.9}>
+        {spec.title}
+      </Label>
+      <Label x={24} y={52} size={7.8} tracking={0.14} opacity={0.42}>
+        {spec.subtitle}
+      </Label>
+      <Label x={174} y={76} size={7.3} tracking={0.17} opacity={0.48} anchor="middle">
+        {spec.quietLabel}
+      </Label>
+      <Label x={370} y={76} size={7.3} tracking={0.17} opacity={0.48} anchor="middle">
+        {spec.busyLabel}
+      </Label>
+
+      <line
+        x1={FEE_RESP_X}
+        y1={FEE_RESP_CAP_Y}
+        x2={FEE_RESP_X + FEE_RESP_W}
+        y2={FEE_RESP_CAP_Y}
+        stroke="var(--line-strong)"
+      />
+      <line
+        x1={FEE_RESP_X}
+        y1={FEE_RESP_FLOOR_Y}
+        x2={FEE_RESP_X + FEE_RESP_W}
+        y2={FEE_RESP_FLOOR_Y}
+        stroke="var(--line-strong)"
+        strokeDasharray="4 4"
+        opacity="0.65"
+      />
+      <Label x={24} y={FEE_RESP_CAP_Y + 4} size={7.2} tracking={0.12} opacity={0.38}>
+        {spec.capLabel}
+      </Label>
+      <Label x={24} y={FEE_RESP_FLOOR_Y + 4} size={7.2} tracking={0.12} opacity={0.38}>
+        {spec.floorLabel}
+      </Label>
+
+      <path
+        className="diagram-flow"
+        d={feePath}
+        stroke={color(spec.accent)}
+        strokeWidth="2.5"
+        fill="none"
+      />
+      {points.map((point) => (
+        <g key={point.label}>
+          <circle cx={point.x} cy={point.y} r="4" fill={color(point.accent)} />
+          <Label
+            x={point.x}
+            y={point.y - 13}
+            size={6.6}
+            tracking={0.12}
+            opacity={0.55}
+            anchor="middle"
+          >
+            {point.detail}
+          </Label>
+        </g>
+      ))}
+
+      <line
+        x1={FEE_RESP_X}
+        y1={usageTargetY}
+        x2={FEE_RESP_X + FEE_RESP_W}
+        y2={usageTargetY}
+        stroke="var(--line-strong)"
+        strokeDasharray="3 3"
+        opacity="0.45"
+      />
+      <Label
+        x={FEE_RESP_X + FEE_RESP_W + 10}
+        y={usageTargetY + 3}
+        size={6.7}
+        tracking={0.12}
+        opacity={0.36}
+      >
+        {spec.targetLabel}
+      </Label>
+      {points.map((point) => {
+        const h = 6 + clamp01(point.usageRatio) * 36
+        return (
+          <g key={`u${point.label}`}>
+            <rect
+              x={point.x - 11}
+              y={usageBaseY - h}
+              width="22"
+              height={h}
+              fill={color(point.accent)}
+              opacity="0.2"
+            />
+            <rect
+              x={point.x - 11}
+              y={usageBaseY - h}
+              width="22"
+              height="3"
+              fill={color(point.accent)}
+            />
+            <Label
+              x={point.x}
+              y={usageBaseY + 18}
+              size={6.6}
+              tracking={0.1}
+              opacity={0.54}
+              anchor="middle"
+            >
+              {point.label}
+            </Label>
+          </g>
+        )
+      })}
+      <Label x={260} y={314} size={7.6} tracking={0.14} opacity={0.48} anchor="middle">
+        {spec.caption}
+      </Label>
+    </>
+  )
+}
+
 // ── sponsor ──────────────────────────────────────────────────────────────────
 // Fee sponsorship. The app signs the user's transaction as fee payer, the user
 // sends it, and Tempo executes the action while debiting the fee payer balance.
@@ -1748,6 +2023,10 @@ export default function FeatureDiagram({
           <BlockspaceShape spec={spec} />
         ) : spec.kind === 'feeamm' ? (
           <FeeAmmShape spec={spec} />
+        ) : spec.kind === 'feeRange' ? (
+          <FeeRangeShape spec={spec} />
+        ) : spec.kind === 'feeResponse' ? (
+          <FeeResponseShape spec={spec} />
         ) : spec.kind === 'sponsor' ? (
           <SponsorShape spec={spec} />
         ) : spec.kind === 'batch' ? (

--- a/src/marketing/app/diagrams/_components/FeatureDiagram.tsx
+++ b/src/marketing/app/diagrams/_components/FeatureDiagram.tsx
@@ -1204,9 +1204,11 @@ function FeeRangeShape({ spec }: { spec: FeeRangeSpec }) {
       >
         {spec.rangeLabel}
       </Label>
-      <Label x={260} y={310} size={7.6} tracking={0.14} opacity={0.48} anchor="middle">
-        {spec.caption}
-      </Label>
+      {spec.caption && (
+        <Label x={260} y={310} size={7.6} tracking={0.14} opacity={0.48} anchor="middle">
+          {spec.caption}
+        </Label>
+      )}
     </>
   )
 }
@@ -1339,9 +1341,11 @@ function FeeResponseShape({ spec }: { spec: FeeResponseSpec }) {
           </g>
         )
       })}
-      <Label x={260} y={314} size={7.6} tracking={0.14} opacity={0.48} anchor="middle">
-        {spec.caption}
-      </Label>
+      {spec.caption && (
+        <Label x={260} y={314} size={7.6} tracking={0.14} opacity={0.48} anchor="middle">
+          {spec.caption}
+        </Label>
+      )}
     </>
   )
 }

--- a/src/marketing/app/diagrams/_lib/featureDiagram.ts
+++ b/src/marketing/app/diagrams/_lib/featureDiagram.ts
@@ -165,6 +165,55 @@ export type FeeAmmSpec = {
   validator: FeeAmmParty
 }
 
+// Dynamic base fee range. A fixed pre-upgrade fee is compared with the T7 cap
+// and floor for the same transaction shape, showing that the base fee now moves
+// inside a bounded range rather than sitting at one value.
+export type FeeRangeMarker = {
+  accent: number
+  label: string
+  value: string
+  detail: string
+  // Relative to the pre-upgrade fixed fee. 1 means "today's fee", 0.6 is the T7
+  // cap, 0.03 is the quiet-period floor in the T7 blog example.
+  ratio: number
+  muted?: boolean
+}
+
+export type FeeRangeSpec = {
+  kind: 'feeRange'
+  title: string
+  subtitle: string
+  markers: FeeRangeMarker[]
+  rangeAccent: number
+  rangeLabel: string
+  caption: string
+}
+
+// Dynamic base fee response. Block usage samples drive a fee path between the
+// configured cap and floor, making the feedback loop visible without implying
+// that the cap itself moves.
+export type FeeResponseStep = {
+  accent: number
+  label: string
+  detail: string
+  feeRatio: number
+  usageRatio: number
+}
+
+export type FeeResponseSpec = {
+  kind: 'feeResponse'
+  title: string
+  subtitle: string
+  capLabel: string
+  floorLabel: string
+  targetLabel: string
+  quietLabel: string
+  busyLabel: string
+  accent: number
+  steps: FeeResponseStep[]
+  caption: string
+}
+
 // Fee sponsorship. A single Tempo Transaction can carry a fee-payer signature
 // from the app. The user sends the transaction, Tempo executes the action, and
 // the protocol debits the fee from the fee payer balance.
@@ -266,6 +315,8 @@ export type FeatureDiagramSpec =
   | NoncesSpec
   | BlockspaceSpec
   | FeeAmmSpec
+  | FeeRangeSpec
+  | FeeResponseSpec
   | SponsorSpec
   | BatchSpec
   | MemoSpec

--- a/src/marketing/app/diagrams/_lib/t7BlogDiagrams.ts
+++ b/src/marketing/app/diagrams/_lib/t7BlogDiagrams.ts
@@ -30,7 +30,7 @@ export const t7DynamicBaseFeeRangeSpec: FeatureDiagramSpec = {
   ],
   rangeAccent: 2,
   rangeLabel: 'BOUNDED RANGE',
-  caption: 'THE CAP STAYS HARD. QUIET PERIODS CAN PRICE LOWER.',
+  caption: '',
 }
 
 export const t7DynamicBaseFeeResponseSpec: FeatureDiagramSpec = {
@@ -80,5 +80,5 @@ export const t7DynamicBaseFeeResponseSpec: FeatureDiagramSpec = {
       usageRatio: 1,
     },
   ],
-  caption: 'LOW BLOCK USAGE PULLS FEES DOWN. BUSIER BLOCKS MOVE FEES BACK UP.',
+  caption: '',
 }

--- a/src/marketing/app/diagrams/_lib/t7BlogDiagrams.ts
+++ b/src/marketing/app/diagrams/_lib/t7BlogDiagrams.ts
@@ -1,0 +1,84 @@
+import type { FeatureDiagramSpec } from './featureDiagram'
+
+export const t7DynamicBaseFeeRangeSpec: FeatureDiagramSpec = {
+  kind: 'feeRange',
+  title: 'DYNAMIC BASE FEE RANGE',
+  subtitle: '50K GAS TIP-20 TRANSFER COST',
+  markers: [
+    {
+      accent: 1,
+      label: 'TODAY',
+      value: '$0.001',
+      detail: 'FIXED FEE',
+      ratio: 1,
+      muted: true,
+    },
+    {
+      accent: 2,
+      label: 'T7 CAP',
+      value: '$0.0006',
+      detail: '40% LOWER',
+      ratio: 0.6,
+    },
+    {
+      accent: 3,
+      label: 'T7 FLOOR',
+      value: '$0.00003',
+      detail: '20X BELOW CAP',
+      ratio: 0.03,
+    },
+  ],
+  rangeAccent: 2,
+  rangeLabel: 'BOUNDED RANGE',
+  caption: 'THE CAP STAYS HARD. QUIET PERIODS CAN PRICE LOWER.',
+}
+
+export const t7DynamicBaseFeeResponseSpec: FeatureDiagramSpec = {
+  kind: 'feeResponse',
+  title: 'BASE FEE RESPONDS TO BLOCK USE',
+  subtitle: 'THE LIVE FEE MOVES BETWEEN THE T7 CAP AND FLOOR',
+  capLabel: 'CAP',
+  floorLabel: 'FLOOR',
+  targetLabel: 'TARGET',
+  quietLabel: 'BELOW TARGET',
+  busyLabel: 'USAGE RISES',
+  accent: 2,
+  steps: [
+    {
+      accent: 1,
+      label: 'START',
+      detail: 'AT CAP',
+      feeRatio: 1,
+      usageRatio: 0.74,
+    },
+    {
+      accent: 2,
+      label: 'LOW',
+      detail: 'FALLS',
+      feeRatio: 0.64,
+      usageRatio: 0.24,
+    },
+    {
+      accent: 3,
+      label: 'QUIET',
+      detail: 'NEAR FLOOR',
+      feeRatio: 0.05,
+      usageRatio: 0.12,
+    },
+    {
+      accent: 2,
+      label: 'BUSY',
+      detail: 'RISES',
+      feeRatio: 0.54,
+      usageRatio: 0.7,
+    },
+    {
+      accent: 1,
+      label: 'FULL',
+      detail: 'AT CAP',
+      feeRatio: 1,
+      usageRatio: 1,
+    },
+  ],
+  caption: 'LOW BLOCK USAGE PULLS FEES DOWN. BUSIER BLOCKS MOVE FEES BACK UP.',
+}


### PR DESCRIPTION
## Summary

Adds the T7 network upgrade developer blog as a published post under `blogs/t7-network-upgrade.md`, which renders at `/developers/blog/t7-network-upgrade` via the developer blog route.

The post uses the existing `network-upgrades` blog category, links to the T7 upgrade docs, TIP references, MPP pay-as-you-go docs, and the v1.10.1 release.

## Validation

- `pnpm check:types`
- `pnpm build`

Build output generated `dist/public/blog/t7-network-upgrade/index.html` and `dist/public/RSC/R/blog/t7-network-upgrade.txt`.