### PR TITLE
fix: blog client-side navigation links

### DIFF
--- a/src/marketing/app/_lib/developersPaths.ts
+++ b/src/marketing/app/_lib/developersPaths.ts
@@ -1,6 +1,7 @@
 export const DEVELOPERS_BASE_PATH = '/developers'
 
 export function developersPath(path: string): string {
+  if (import.meta.env.DEV && (path === '/blog' || path.startsWith('/blog/'))) return path
   if (path === '/') return DEVELOPERS_BASE_PATH
   return `${DEVELOPERS_BASE_PATH}${path.startsWith('/') ? path : `/${path}`}`
 }

--- a/src/marketing/next-shims.tsx
+++ b/src/marketing/next-shims.tsx
@@ -1,4 +1,11 @@
-import type { AnchorHTMLAttributes, ImgHTMLAttributes, ReactNode } from 'react'
+import {
+  type AnchorHTMLAttributes,
+  type ImgHTMLAttributes,
+  type ReactNode,
+  useContext,
+} from 'react'
+import { Link as WakuLink } from 'waku'
+import { unstable_RouterContext as WakuRouterContext } from 'waku/router/client'
 
 export type Metadata = Record<string, unknown>
 
@@ -21,7 +28,37 @@ function prefetchPath(href: string) {
   document.head.appendChild(link)
 }
 
+function isClientRoutedBlogHref(href: string) {
+  return (
+    href === '/blog' ||
+    href.startsWith('/blog/') ||
+    href === '/developers/blog' ||
+    href.startsWith('/developers/blog/')
+  )
+}
+
 export default function Link({ href, children, onFocus, onPointerEnter, ...props }: LinkProps) {
+  const router = useContext(WakuRouterContext)
+
+  if (router && isClientRoutedBlogHref(href)) {
+    return (
+      <WakuLink
+        {...props}
+        to={href}
+        onFocus={(event) => {
+          prefetchPath(href)
+          onFocus?.(event)
+        }}
+        onPointerEnter={(event) => {
+          prefetchPath(href)
+          onPointerEnter?.(event)
+        }}
+      >
+        {children}
+      </WakuLink>
+    )
+  }
+
   return (
     <a
       {...props}


### PR DESCRIPTION
Switches to client-side navigation for blog links instead of full page reload.

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/6e3956b8-8100-41cc-8980-23b900fd4e2e" controls width="400"></video> | <video src="https://github.com/user-attachments/assets/437dac81-cc8e-409f-8c2d-e563536c711c" controls width="400"></video> |



