### PR TITLE
Fix docs deploy after rewards page removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@10.28.1",
   "scripts": {
     "dev": "node --env-file-if-exists=.env --import=tsx node_modules/vite/bin/vite.js",
-    "build": "pnpm run check:types && vite build",
+    "build": "node scripts/guard-vocs-config.mjs && pnpm run check:types && vite build",
     "check": "biome check --write --unsafe .",
     "check:types": "tsgo --project tsconfig.json --noEmit",
     "preview": "node dist/preview.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@10.28.1",
   "scripts": {
     "dev": "node --env-file-if-exists=.env --import=tsx node_modules/vite/bin/vite.js",
-    "build": "tsgo --build && vite build",
+    "build": "pnpm run check:types && vite build",
     "check": "biome check --write --unsafe .",
     "check:types": "tsgo --project tsconfig.json --noEmit",
     "preview": "node dist/preview.js",

--- a/scripts/guard-vocs-config.mjs
+++ b/scripts/guard-vocs-config.mjs
@@ -1,0 +1,29 @@
+import { readFile, writeFile } from 'node:fs/promises'
+
+const configPath = new URL('../vocs.config.ts', import.meta.url)
+let config = await readFile(configPath, 'utf8')
+const original = config
+
+config = config
+  .replace(
+    "  titleTemplate: (path, { title }) => {\n    if (path === '/docs') return 'Tempo %s ⋅ Tempo Docs'\n    if (path === '/docs' || path.startsWith('/docs/')) return '%s ⋅ Tempo Docs'",
+    "  titleTemplate: (path, { title }) => {\n    const pagePath = typeof path === 'string' ? path : '/'\n    if (pagePath === '/docs') return 'Tempo %s ⋅ Tempo Docs'\n    if (pagePath === '/docs' || pagePath.startsWith('/docs/')) return '%s ⋅ Tempo Docs'",
+  )
+  .replace(
+    "  head(path) {\n    if (path === '/docs' || path.startsWith('/docs/'))",
+    "  head(path) {\n    const pagePath = typeof path === 'string' ? path : '/'\n    if (pagePath === '/docs' || pagePath.startsWith('/docs/'))",
+  )
+  .replace(
+    "    lastmod: (path, { lastmod }) => {\n      if (path === '/docs' || path.startsWith('/docs/')) return false",
+    "    lastmod: (path, { lastmod }) => {\n      const pagePath = typeof path === 'string' ? path : '/'\n      if (pagePath === '/docs' || pagePath.startsWith('/docs/')) return false",
+  )
+  .replace(
+    "    const docsPath = path.replace(/^\\/docs(?=\\/|$)/, '') || '/'",
+    "    const docsPath = String(path ?? '').replace(/^\\/docs(?=\\/|$)/, '') || '/'",
+  )
+  .replace(
+    "badge: { text: 'Planned', variant: 'note' },",
+    "badge: { text: 'Planned', variant: 'note' as const },",
+  )
+
+if (config !== original) await writeFile(configPath, config, 'utf8')

--- a/src/pages/docs/protocol/upgrades/t7.mdx
+++ b/src/pages/docs/protocol/upgrades/t7.mdx
@@ -88,7 +88,7 @@ At the quiet-period floor, the same transaction is 20x cheaper than the T7 cap a
 
 T7 deprecates new Tempo Token Rewards opt-ins and reward distributions so partners do not need to model new reward accrual after the upgrade. Already-accrued rewards remain claimable through the existing `claimRewards()` flow.
 
-Apps that show reward information should keep already-accrued rewards separate from post-T7 balances, and should stop presenting new rewards as accruing from post-T7 reward distributions. See [Tempo Token Rewards](/docs/protocol/tip20-rewards/overview) if your integration still uses rewards.
+Apps that show reward information should keep already-accrued rewards separate from post-T7 balances, and should stop presenting new rewards as accruing from post-T7 reward distributions.
 
 ## Technical references
 

--- a/src/types/vocs-config.d.ts
+++ b/src/types/vocs-config.d.ts
@@ -1,5 +1,0 @@
-import 'vocs/config'
-
-declare module 'vocs/config' {
-  export function defineConfig(config: unknown): Config
-}

--- a/src/types/vocs-config.d.ts
+++ b/src/types/vocs-config.d.ts
@@ -1,0 +1,3 @@
+declare module 'vocs/config' {
+  export function defineConfig(config: unknown): Config
+}

--- a/src/types/vocs-config.d.ts
+++ b/src/types/vocs-config.d.ts
@@ -1,3 +1,5 @@
+import 'vocs/config'
+
 declare module 'vocs/config' {
   export function defineConfig(config: unknown): Config
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -85,9 +85,10 @@ const publicDevelopersPath = (path) => {
   return developersPrefix + path;
 };
 const normalizeDevelopersRoute = (route) => {
-  if (route.path === '/developers') return { ...route, path: '/' };
-  if (route.path.startsWith('/developers/')) {
-    return { ...route, path: route.path.slice('/developers'.length) || '/' };
+  const routePath = typeof route.path === 'string' ? route.path : '/';
+  if (routePath === '/developers') return { ...route, path: '/' };
+  if (routePath.startsWith('/developers/')) {
+    return { ...route, path: routePath.slice('/developers'.length) || '/' };
   }
   return route;
 };


### PR DESCRIPTION
## Summary
- Remove the stale T7 link to the deleted TIP-20 rewards overview page.
- Guard `/developers` route normalization when the parsed route has no path, which matches the production `startsWith` crash.
- Run a small pre-build guard for Vocs config callbacks so missing route paths do not crash title/head/sitemap/OG handling, and narrow the T8 `Planned` sidebar badge during the build.

## Why
- Production did not pick up the merged T7/T8 docs because Vercel kept failing or serving a crashing build.
- The deleted rewards page left a stale T7 link behind.
- The preview showed `Cannot read properties of undefined (reading 'startsWith')`, so the route/config callbacks now tolerate a missing path.