### PR TITLE
docs: replace actionable TIP references

### DIFF
--- a/src/components/guides/VirtualAddressesFastDemo.tsx
+++ b/src/components/guides/VirtualAddressesFastDemo.tsx
@@ -500,13 +500,13 @@ export function VirtualAddressesFastDemo() {
             </div>
           ) : registerMutation.isPending ? (
             <div className="mt-2 text-[13px] text-gray9 -tracking-[1%]">
-              This tab skips live mining and submits a pre-mined valid TIP-1022 salt for a
-              docs-managed wallet so you can get to the forwarding flow immediately.
+              This tab skips live mining and submits a pre-mined salt for a valid virtual address
+              and docs-managed wallet so you can get to the forwarding flow immediately.
             </div>
           ) : (
             <div className="mt-2 text-[13px] text-gray9 -tracking-[1%]">
               Click <span className="text-primary">Prepare demo master</span> to use a shared
-              docs-managed wallet with pre-mined valid TIP-1022 salt.
+              docs-managed wallet with a pre-mined salt for a valid virtual address.
             </div>
           )}
         </div>

--- a/src/components/guides/VirtualAddressesLiveDemo.tsx
+++ b/src/components/guides/VirtualAddressesLiveDemo.tsx
@@ -251,7 +251,7 @@ export function VirtualAddressesLiveDemo() {
           start: randomHex(32),
         })
 
-        if (!result) throw new Error('Unable to find a valid TIP-1022 salt.')
+        if (!result) throw new Error('Unable to find a valid virtual-address salt.')
 
         setMinerState({
           status: 'found',
@@ -597,7 +597,7 @@ export function VirtualAddressesLiveDemo() {
               </div>
               <div className="col-span-full">
                 `VirtualMaster.mineSaltAsync` is searching for the 32-bit proof-of-work required by
-                TIP-1022 using parallel workers when the browser supports them.
+                creating a virtual address, using parallel workers when the browser supports them.
               </div>
             </div>
           ) : minerState.status === 'found' ? (

--- a/src/marketing/MarketingRoute.tsx
+++ b/src/marketing/MarketingRoute.tsx
@@ -17,8 +17,8 @@ const prefetchedPaths = new Set<string>()
 const ANALYTICS_DELAY_MS = 15_000
 const ANALYTICS_IDLE_TIMEOUT_MS = 20_000
 
-function prefetchPath(href: string) {
-  if (!href.startsWith('/') || prefetchedPaths.has(href)) return
+function prefetchPath(href: unknown) {
+  if (typeof href !== 'string' || !href.startsWith('/') || prefetchedPaths.has(href)) return
   prefetchedPaths.add(href)
 
   const link = document.createElement('link')

--- a/src/marketing/next-shims.tsx
+++ b/src/marketing/next-shims.tsx
@@ -16,9 +16,9 @@ type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
 
 const prefetchedPaths = new Set<string>()
 
-function prefetchPath(href: string) {
+function prefetchPath(href: unknown) {
   if (typeof document === 'undefined') return
-  if (!href.startsWith('/') || prefetchedPaths.has(href)) return
+  if (typeof href !== 'string' || !href.startsWith('/') || prefetchedPaths.has(href)) return
   prefetchedPaths.add(href)
 
   const link = document.createElement('link')
@@ -28,7 +28,8 @@ function prefetchPath(href: string) {
   document.head.appendChild(link)
 }
 
-function isClientRoutedBlogHref(href: string) {
+function isClientRoutedBlogHref(href: unknown) {
+  if (typeof href !== 'string') return false
   return (
     href === '/blog' ||
     href.startsWith('/blog/') ||

--- a/src/pages/docs/guide/issuance/create-a-stablecoin.mdx
+++ b/src/pages/docs/guide/issuance/create-a-stablecoin.mdx
@@ -152,7 +152,7 @@ Now that we have some input fields, we need to add some logic to handle the subm
 
 After this step, your users will be able to create a stablecoin by clicking the "Create" button!
 
-Tokens can also carry an optional on-chain `logoURI` ([TIP-1026](https://tips.sh/1026)) that wallets and explorers read directly from the token contract. It's set on the token contract and is independent of this creation flow; for the recommended format, use a square, rasterized PNG or WebP (max 256 bytes; `https`, `http`, `ipfs`, or `data` scheme).
+Tokens can also carry an optional on-chain [`logoURI`](/docs/protocol/tip20/spec#logo-uri) that wallets and explorers read directly from the token contract. It's set on the token contract and is independent of this creation flow; for the recommended format, use a square, rasterized PNG or WebP (max 256 bytes; `https`, `http`, `ipfs`, or `data` scheme).
 
 :::warning
 The `currency` field is **immutable** after token creation and affects fee payment eligibility, DEX routing, and quote token pairing. See [Currency Declaration](/docs/protocol/tip20/overview#currency-declaration) for guidelines on choosing the right value. **Only `USD` stablecoins can be used to pay transaction fees on Tempo.**

--- a/src/pages/docs/guide/issuance/manage-stablecoin.mdx
+++ b/src/pages/docs/guide/issuance/manage-stablecoin.mdx
@@ -293,7 +293,7 @@ export const config = createConfig({
 
 ### Set the stablecoin logo
 
-Set or update the token's on-chain `logoURI` so wallets and explorers can read the icon directly from the token contract via `logoURI()`. This requires the **`DEFAULT_ADMIN_ROLE`** and is done by calling `setLogoURI(string newLogoURI)` on the token ([TIP-1026](https://tips.sh/1026)). For the recommended format, use a square, rasterized PNG or WebP (max 256 bytes; `https`, `http`, `ipfs`, or `data` scheme).
+Set or update the token's on-chain [`logoURI`](/docs/protocol/tip20/spec#logo-uri) so wallets and explorers can read the icon directly from the token contract via `logoURI()`. This requires the **`DEFAULT_ADMIN_ROLE`** and is done by calling `setLogoURI(string newLogoURI)` on the token. For the recommended format, use a square, rasterized PNG or WebP (max 256 bytes; `https`, `http`, `ipfs`, or `data` scheme).
 
 ### Set the stablecoin supply cap
 

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -23,12 +23,12 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | [v1.8.1](https://github.com/tempoxyz/tempo/releases/tag/v1.8.1) | Jun 1, 2026 | Testnet + Mainnet | Required for T5; reverts builder prewarming and execution cache sharing defaults from v1.8.0 to avoid stale-state validation errors while retaining T5 compatibility. | <Badge variant="red">Required</Badge> |
 | [v1.8.0](https://github.com/tempoxyz/tempo/releases/tag/v1.8.0) | May 28, 2026 | Testnet + Mainnet | Required for T5; introduces the enshrined TIP-20 reserve channel precompile, payment lane classification, DEX flip-order improvements, multihop FeeAMM routing, optional on-chain TIP-20 `logoURI`, implicit approvals, and key authorization witnesses. Operators should use v1.8.2 for the latest patch fixes. | <Badge variant="red">Required</Badge> |
 | [v1.7.1](https://github.com/tempoxyz/tempo/releases/tag/v1.7.1) | May 21, 2026 | Moderato + Mainnet | Adds validator migration support for minimal snapshots, trustless RPC certificate checks on Moderato, and automatic pruning for finalized consensus blocks. | <Badge variant="yellow">Recommended</Badge> |
-| [v1.7.0](https://github.com/tempoxyz/tempo/releases/tag/v1.7.0) | Mon, May 11, 2026 | Moderato + Mainnet | Required for T4; embeds consensus context into the block header to unlock deferred verification (TIP-1031) and bundles T4 bug fixes and security hardening (TIP-1046). | <Badge variant="red">Required</Badge> |
-| [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) | Apr 16, 2026 | Moderato + Mainnet | Required for T3; implements enhanced access key permissions with periodic limits and call scoping (TIP-1011), the signature verification precompile (TIP-1020), and virtual addresses for TIP-20 deposit forwarding (TIP-1022). | <Badge variant="red">Required</Badge> |
+| [v1.7.0](https://github.com/tempoxyz/tempo/releases/tag/v1.7.0) | Mon, May 11, 2026 | Moderato + Mainnet | Required for T4; embeds consensus context into block headers to unlock deferred verification and bundles T4 bug fixes and security hardening. | <Badge variant="red">Required</Badge> |
+| [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) | Apr 16, 2026 | Moderato + Mainnet | Required for T3; implements enhanced access key permissions with periodic limits and call scoping, signature verification, and virtual addresses for TIP-20 deposit forwarding. | <Badge variant="red">Required</Badge> |
 | [v1.5.3](https://github.com/tempoxyz/tempo/releases/tag/v1.5.3) | Apr 9, 2026 | Moderato + Mainnet | Patch release that restores OTLP HTTPS telemetry and fixes an epoch-transition consensus race that could incorrectly block straggling peers. Validators that skipped v1.5.2 should upgrade directly to this release. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.5.2](https://github.com/tempoxyz/tempo/releases/tag/v1.5.2) | Apr 8, 2026 | Moderato + Mainnet | Maintenance release with the latest reth update, payload builder and RPC improvements, plus transaction validation and mempool hardening. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.5.1](https://github.com/tempoxyz/tempo/releases/tag/v1.5.1) | Mar 29, 2026 | Moderato + Mainnet | Security patch for RPC endpoints that accept `stateOverride`, including `eth_call` and `debug_traceCall`. This release is required for RPC providers and other public RPC nodes, and low priority for validators. | <Badge variant="amber">RPC only</Badge> |
-| [v1.5.0](https://github.com/tempoxyz/tempo/releases/tag/v1.5.0) | Mar 26, 2026 | Moderato + Mainnet | Required for T2; implements compound transfer policies (TIP-1015), permit support for TIP-20 (TIP-1004), ValidatorConfig V2 (TIP-1017), and 14 audit-driven bug fixes (TIP-1036) | <Badge variant="red">Required</Badge> |
+| [v1.5.0](https://github.com/tempoxyz/tempo/releases/tag/v1.5.0) | Mar 26, 2026 | Moderato + Mainnet | Required for T2; implements compound transfer policies, permit support for TIP-20, Validator Config V2, and 14 audit-driven bug fixes. | <Badge variant="red">Required</Badge> |
 | [v1.4.3](https://github.com/tempoxyz/tempo/releases/tag/v1.4.3) | Mar 18, 2026 | Moderato + Mainnet | Fixes gas price oracle poisoning that caused inflated fee estimates for wallet transactions | <Badge variant="yellow">Recommended</Badge> |
 | [v1.4.2](https://github.com/tempoxyz/tempo/releases/tag/v1.4.2) | Mar 16, 2026 | Moderato + Mainnet | Strict payment calldata validation in the transaction pool and block builder, rejecting malformed payment transactions earlier | <Badge variant="yellow">Recommended</Badge> |
 | [v1.4.1](https://github.com/tempoxyz/tempo/releases/tag/v1.4.1) | Mar 12, 2026 | Moderato + Mainnet | Transaction pool DoS-hardening, consensus resilience improvements (DKG recovery), hardfork-aware gas estimation, and payload builder enhancements | <Badge variant="yellow">Recommended</Badge> |
@@ -57,7 +57,7 @@ T8 is planned. Node operators should wait for the T8 release announcement, then 
 | | |
 |---|---|
 | **Scope** | Storage credits for DEX order storage and TIP-20 channel storage; lower the base fee when gas is below the target threshold; deprecate new TIP-20 rewards |
-| **TIPs** | [TIP-1060: Storage Credits](https://tips.sh/1060), [TIP-1064: StablecoinDEX Order Storage Credits](https://tips.sh/1064), [TIP-1066: TIP-20 Channel Storage Credits](https://tips.sh/1066), [TIP-1067: Dynamic Base Fee](https://tips.sh/1067), TIP-20 rewards deprecation |
+| **TIPs** | [Storage credits](https://tips.sh/1060), [StablecoinDEX order storage credits](https://tips.sh/1064), [TIP-20 channel storage credits](https://tips.sh/1066), [Dynamic base fee](https://tips.sh/1067), TIP-20 rewards deprecation |
 | **Details** | [T7 network upgrade](/docs/protocol/upgrades/t7) |
 | **Release** | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) |
 | **Testnet** | Live: July 2, 2026 |
@@ -73,7 +73,7 @@ T7 is active on testnet and mainnet and supported by [v1.10.1](https://github.co
 | | |
 |---|---|
 | **Scope** | Account-level receive policies for safer TIP-20 deposits; admin access keys for smoother passkey, device, and delegated-key management |
-| **TIPs** | [TIP-1028: Account-Level Receive Policies](https://tips.sh/1028), [TIP-1049: Admin Access Keys](https://tips.sh/1049) |
+| **TIPs** | [Receive policies](https://tips.sh/1028), [Admin access keys](https://tips.sh/1049) |
 | **Details** | [T6 network upgrade](/docs/protocol/upgrades/t6) |
 | **Release** | [v1.9.0](https://github.com/tempoxyz/tempo/releases/tag/v1.9.0) |
 | **Testnet** | June 18, 2026 4pm CEST (unix: 1781791200) |
@@ -93,7 +93,7 @@ Integrators, indexers, wallets, explorers, and SDK maintainers should review the
 | | |
 |---|---|
 | **Scope** | Enshrined TIP-20 reserve channel precompile; payment lane classification; DEX same-tick flip orders and persistent order IDs across flips; multihop FeeAMM routing; optional on-chain TIP-20 `logoURI`; implicit approvals; and key authorization witnesses |
-| **TIPs** | [TIP-1034: Enshrined TIP-20 Reserve Channel](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1034.md), [TIP-1045: Payment Lane Classification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1045.md), [TIP-1030: Allow Same-Tick Flip Orders](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1030.md), [TIP-1056: Keep Order IDs Across Flips](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1056.md), [TIP-1033: Multihop FeeAMM Routing](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1033.md), [TIP-1026: Optional logoURI Field in TIP-20](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1026.md), [TIP-1035: Implicit Approvals List](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1035.md), [TIP-1053: Witness Digest in Key Authorizations](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1053.md) |
+| **TIPs** | [Payment-channel reserve](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1034.md), [Payment lane classification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1045.md), [Same-tick flip orders](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1030.md), [Keep order IDs across flips](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1056.md), [Multihop FeeAMM routing](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1033.md), [Logo URI](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1026.md), [Implicit approvals](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1035.md), [Witnesses in key authorizations](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1053.md) |
 | **Details** | [T5 network upgrade](/docs/protocol/upgrades/t5) |
 | **Release** | [v1.8.1](https://github.com/tempoxyz/tempo/releases/tag/v1.8.1) |
 | **Testnet** | June 3, 2026 16:00 CEST (unix: 1780495200) |
@@ -113,7 +113,7 @@ Integrators, indexers, wallets, explorers, and SDK maintainers should review the
 | | |
 |---|---|
 | **Scope** | Embed consensus context into the block header to unlock deferred verification, plus T4 bug fixes and security hardening |
-| **TIPs** | [TIP-1031: Embed Consensus Context in the Block Header](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1031.md), [TIP-1046: T4 Hardfork Meta TIP](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1046.md) |
+| **TIPs** | [Consensus context in block headers](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1031.md), [T4 network upgrade](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1046.md) |
 | **Details** | [T4 network upgrade](/docs/protocol/upgrades/t4) |
 | **Release** | [v1.7.0](https://github.com/tempoxyz/tempo/releases/tag/v1.7.0) |
 | **Testnet** | Moderato: May 14, 2026 16:00 CEST (unix: 1778767200) |
@@ -122,9 +122,9 @@ Integrators, indexers, wallets, explorers, and SDK maintainers should review the
 
 ### Who is affected?
 
-All node operators needed to upgrade before the T4 activation timestamp. TIP-1031 changed how block headers are produced and verified; non-upgraded nodes have their proposals rejected and have fallen out of consensus.
+All node operators needed to upgrade before the T4 activation timestamp. Adding consensus context to block headers changed how blocks are produced and verified; non-upgraded nodes have their proposals rejected and have fallen out of consensus.
 
-Smart contract developers and integrators are not directly affected by TIP-1031, but should review [TIP-1046](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1046.md) for the bundled gas accounting changes and access-key scope validation updates that may affect transaction gas usage post-T4.
+Smart contract developers and integrators are not directly affected by consensus context in block headers, but should review the [T4 network upgrade specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1046.md) for bundled gas accounting changes and access-key scope validation updates that may affect transaction gas usage post-T4.
 
 ---
 
@@ -133,7 +133,7 @@ Smart contract developers and integrators are not directly affected by TIP-1031,
 | | |
 |---|---|
 | **Scope** | Enhanced access keys with periodic limits, call scoping, and an authorization ABI update; signature verification precompile; and virtual addresses for TIP-20 deposit forwarding |
-| **TIPs** | [TIP-1011: Enhanced Access Key Permissions](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1011.md), [TIP-1020: Signature Verification Precompile](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md), [TIP-1022: Virtual Addresses for TIP-20 Deposit Forwarding](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) |
+| **TIPs** | [Enhanced access key permissions](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1011.md), [Signature verification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md), [Virtual addresses](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) |
 | **Details** | [T3 network upgrade](/docs/protocol/upgrades/t3) |
 | **Release** | [v1.6.0](https://github.com/tempoxyz/tempo/releases/tag/v1.6.0) |
 | **Testnet** | Moderato: Apr 21, 2026 16:00 CEST (unix: 1776780000) |
@@ -149,7 +149,7 @@ See the [T3 network upgrade](/docs/protocol/upgrades/t3) page for breaking chang
 | | |
 |---|---|
 | **Scope** | Compound transfer policies, ValidatorConfig V2, and audit-driven bug fixes |
-| **TIPs** | [TIP-1015: Compound Transfer Policies](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1015.md), [TIP-1004: Permit for TIP-20](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1004.md), [TIP-1017: Validator Config V2](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1017.md), [TIP-1036: T2 Hardfork Bug Fixes](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1036.md) |
+| **TIPs** | [Compound transfer policies](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1015.md), [Permit](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1004.md), [Validator Config V2](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1017.md), [T2 network upgrade](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1036.md) |
 | **Release** | v1.5.0 |
 | **Testnet** | Moderato: Mar 26, 2026 16:00 CET (unix: 1774537200) |
 | **Mainnet** | Mar 31, 2026 16:00 CEST (unix: 1774965600) |
@@ -174,7 +174,7 @@ See the [T3 network upgrade](/docs/protocol/upgrades/t3) page for breaking chang
 | | |
 |---|---|
 | **Scope** | T1A removes the 16.7M per-transaction gas limit in favor of Tempo's 30M cap; T1B adds keychain precompile gas metering and expiring nonce replay-protection hardening |
-| **TIPs** | T1A: [TIP-1010: Mainnet Gas Parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md); T1B: upgrade hardening release |
+| **TIPs** | T1A: [Mainnet gas parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md); T1B: upgrade hardening release |
 | **Release** | [v1.3.1](https://github.com/tempoxyz/tempo/releases/tag/v1.3.1) |
 | **Testnet** | T1A + T1B: Feb 23, 2026 15:00 UTC (unix: 1771858800) |
 | **Mainnet** | T1A: Feb 12, 2026 15:00 UTC (unix: 1770908400); T1B: Feb 23, 2026 15:00 UTC (unix: 1771858800) |
@@ -187,7 +187,7 @@ See the [T3 network upgrade](/docs/protocol/upgrades/t3) page for breaking chang
 | | |
 |---|---|
 | **Scope** | Mainnet-ready gas economics, expiring nonces, and security hardening |
-| **TIPs** | [TIP-1000: State Creation Cost Increase](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md), [TIP-1009: Expiring Nonces](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1009.md), [TIP-1010: Mainnet Gas Parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md) |
+| **TIPs** | [State creation costs](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md), [Expiring nonces](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1009.md), [Mainnet gas parameters](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1010.md) |
 | **Testnet** | Feb 5, 2026 15:00 UTC (unix: 1770303600) — Release: [v1.1.0](https://github.com/tempoxyz/tempo/releases/tag/v1.1.0) |
 | **Mainnet** | Feb 12, 2026 15:00 UTC (unix: 1770908400) — Release: [v1.1.1](https://github.com/tempoxyz/tempo/releases/tag/v1.1.1) |
 | **Priority** | <Badge variant="red">Required</Badge> |

--- a/src/pages/docs/guide/node/validator-keys.mdx
+++ b/src/pages/docs/guide/node/validator-keys.mdx
@@ -137,7 +137,7 @@ If the signing share is lost â€” for example by deleting `<datadir>/consensus` â
 
 ## ValidatorConfig V2 precompile
 
-All key and identity operations are executed through the ValidatorConfig V2 precompile ([TIP-1017](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1017.md)):
+All key and identity operations are executed through the [Validator Config V2 precompile](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1017.md):
 
 ```solidity
 address constant VALIDATOR_CONFIG_V2 = 0xCCCCCCCC00000000000000000000000000000001;

--- a/src/pages/docs/guide/payments/configure-receive-policies.mdx
+++ b/src/pages/docs/guide/payments/configure-receive-policies.mdx
@@ -77,13 +77,13 @@ The recovery authority controls who may claim receipts for future blocked transf
 
 Changing the recovery authority affects future receipts only. Existing receipts keep the recovery authority captured when they were created.
 
-Nonzero recovery authorities cannot be `ReceivePolicyGuard`, [TIP-1022](https://tips.sh/1022) virtual addresses, or system precompile addresses that cannot initiate calls.
+Nonzero recovery authorities cannot be `ReceivePolicyGuard`, [virtual addresses](/docs/protocol/tip20/virtual-addresses), or system precompile addresses that cannot initiate calls.
 
 ### Set the receive policy
 
 Call `setReceivePolicy(senderPolicyId, tokenFilterId, recoveryAuthority)` from the address being configured.
 
-If the receiver is using TIP-1022 virtual addresses, configure the policy on the resolved master address. A virtual address must not call `setReceivePolicy(...)`.
+If the receiver is using virtual addresses, configure the policy on the resolved master address. A virtual address must not call `setReceivePolicy(...)`.
 
 :::::
 
@@ -136,7 +136,7 @@ Burn eligibility has additional policy checks. See the [protocol overview](/docs
 
 ## Virtual-address behavior
 
-If `to` is a TIP-1022 virtual address, it is resolved to its master address before checks run. Receive-policy checks use the master address.
+If `to` is a virtual address, it is resolved to its master address before checks run. Receive-policy checks use the master address.
 
 If resolution fails, the operation reverts as before. If the transfer or mint is blocked, the receipt is recorded for the master address and preserves the original `to` for attribution.
 
@@ -144,7 +144,7 @@ If resolution fails, the operation reverts as before. If the transfer or mint is
 
 <Cards>
   <Card
-    title="TIP-1028"
+    title="Receive policies specification"
     description="The approved specification for address-level receive policies."
     to="https://tips.sh/1028"
     icon="lucide:file-text"
@@ -163,7 +163,7 @@ If resolution fails, the operation reverts as before. If the transfer or mint is
   />
   <Card
     title="Use Virtual Addresses"
-    description="Understand how TIP-1022 virtual addresses affect deposit attribution."
+    description="Understand how virtual addresses affect deposit attribution."
     to="/docs/guide/payments/virtual-addresses"
     icon="lucide:route"
   />

--- a/src/pages/docs/guide/payments/send-a-payment.mdx
+++ b/src/pages/docs/guide/payments/send-a-payment.mdx
@@ -18,7 +18,7 @@ Send stablecoin payments between accounts on Tempo. Payments can include optiona
 :::warning[Confirm delivery, not just transaction success]
 On post-T6 networks, a blocked TIP-20 `transfer` / `transferFrom` still succeeds, but credits `ReceivePolicyGuard` at `0xB10C000000000000000000000000000000000000` instead of the intended receiver.
 
-- Before marking a payment, withdrawal, or deposit delivered, confirm the `Transfer` recipient is the intended receiver or its TIP-1022 master.
+- Before marking a payment, withdrawal, or deposit delivered, confirm the `Transfer` recipient is the intended receiver or the master wallet for its virtual address.
 - Index `ReceivePolicyGuard.TransferBlocked` so redirected funds can be surfaced and claimed later.
 
 See [Configure Receive Policies](/docs/guide/payments/configure-receive-policies).

--- a/src/pages/docs/guide/payments/virtual-addresses.mdx
+++ b/src/pages/docs/guide/payments/virtual-addresses.mdx
@@ -71,7 +71,7 @@ Use `VirtualMaster.mineSaltAsync` to register a master id for the passkey accoun
 <div className="h-4" />
 
 :::info
-Mining the TIP-1022 salt can take 30+ seconds depending on your browser, hardware, and available worker parallelism.
+Mining a virtual-address salt can take 30+ seconds depending on your browser, hardware, and available worker parallelism.
 :::
 
 <div className="h-6" />
@@ -132,7 +132,7 @@ A few things matter in production:
     icon="lucide:route"
   />
   <Card
-    title="TIP-1022 specification"
+    title="Virtual address specification"
     description="Read the full protocol definition, including derivation rules, transfer paths, and invariants."
     to="https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md"
     icon="lucide:file-text"

--- a/src/pages/docs/guide/stablecoin-dex/managing-fee-liquidity.mdx
+++ b/src/pages/docs/guide/stablecoin-dex/managing-fee-liquidity.mdx
@@ -17,7 +17,7 @@ import { MintFeeAmmLiquidity } from '../../../../components/guides/steps/amm/Min
 
 The Fee AMM converts transaction fees between stablecoins when users pay in a different token than the validator prefers. This guide shows you how to add and remove liquidity to enable fee conversions.
 
-The Fee AMM also supports multihop routing ([TIP-1033](https://tips.sh/1033)): one fee conversion can route through two pools when a direct pair between the user's fee token and the validator's payout token doesn't exist or has insufficient liquidity. The pool mechanics for adding and removing liquidity are the same either way, but a single conversion may reserve and consume liquidity from two pools you provide to instead of one.
+The Fee AMM also supports [multihop FeeAMM routing](https://tips.sh/1033): one fee conversion can route through two pools when a direct pair between the user's fee token and the validator's payout token doesn't exist or has insufficient liquidity. The pool mechanics for adding and removing liquidity are the same either way, but a single conversion may reserve and consume liquidity from two pools you provide to instead of one.
 
 Browse current pool reserves and route availability in the [FeeAMM explorer view](https://explore.tempo.xyz/fee-amm).
 

--- a/src/pages/docs/protocol/blockspace/payment-lane-specification.mdx
+++ b/src/pages/docs/protocol/blockspace/payment-lane-specification.mdx
@@ -38,7 +38,7 @@ A transaction is classified as a **payment transaction** when:
 
 This classification is performed entirely on the transaction payload, no account state is consulted.
 
-The payment call allow-list includes TIP-20 payment and mint/burn/approval calls, plus the `TIP20ChannelReserve` payment-channel precompile calls. Calls with unrecognized selectors, malformed ABI encoding, disallowed targets, non-empty auxiliary payloads, or dynamic calldata above the allow-list size bound are classified as non-payment transactions. See [TIP-1045](https://tips.sh/1045) for the complete selector table and ABI constraints.
+The payment call allow-list includes TIP-20 payment and mint/burn/approval calls, plus the `TIP20ChannelReserve` payment-channel precompile calls. Calls with unrecognized selectors, malformed ABI encoding, disallowed targets, non-empty auxiliary payloads, or dynamic calldata above the allow-list size bound are classified as non-payment transactions. See the [payment lane classification specification](https://tips.sh/1045) for the complete selector table and ABI constraints.
 
 ### 2. Ordering of Transactions
 

--- a/src/pages/docs/protocol/exchange/providing-liquidity.mdx
+++ b/src/pages/docs/protocol/exchange/providing-liquidity.mdx
@@ -197,4 +197,4 @@ You can only cancel your own orders. Attempting to cancel another user's order w
 
 - Do not assert that `flipTick != tick`; same-tick flips are valid
 
-See the [compatibility section of TIP-1056](https://tips.sh/1056#compatibility) for additional migration guidance.
+See the [compatibility section of the specification](https://tips.sh/1056#compatibility) for additional migration guidance on keeping order IDs across flips.

--- a/src/pages/docs/protocol/tip20/overview.mdx
+++ b/src/pages/docs/protocol/tip20/overview.mdx
@@ -10,7 +10,7 @@ import { Cards, Card } from 'vocs'
 TIP-20 tokens are Tempo's native token standard for stablecoins and payment tokens. They are designed for stablecoin payments, and are the foundation for many token-related functions on Tempo including transaction fees, payment lanes, DEX quote tokens, optimized routing for DEX liquidity, optional on-chain token `logoURI` metadata, implicit approvals for listed precompiles, and enshrined payment-channel reserve flows.
 
 :::info[Live with T6]
-The [T6 network upgrade](/docs/protocol/upgrades/t6) added account-level receive policies for TIP-20 transfers and mints ([TIP-1028](https://tips.sh/1028)). A receiver can choose which tokens and senders they accept, helping wallets and deposit addresses avoid unsupported assets, unwanted counterparties, and wrong-token deposits. If a receive policy blocks delivery, the transfer or mint still succeeds, but funds are redirected to `ReceivePolicyGuard` so they can be claimed later.
+The [T6 network upgrade](/docs/protocol/upgrades/t6) added [account-level receive policies](/docs/protocol/tip403/receive-policies) for TIP-20 transfers and mints. A receiver can choose which tokens and senders they accept, helping wallets and deposit addresses avoid unsupported assets, unwanted counterparties, and wrong-token deposits. If a receive policy blocks delivery, the transfer or mint still succeeds, but funds are redirected to `ReceivePolicyGuard` so they can be claimed later.
 
 See the [T5 → T6 migration appendix on the TIP-20 spec](/docs/protocol/tip20/spec#t5--t6-migration) for the TIP-20 surface area.
 :::

--- a/src/pages/docs/protocol/tip20/spec.mdx
+++ b/src/pages/docs/protocol/tip20/spec.mdx
@@ -224,7 +224,7 @@ interface ITIP20 {
     function setRoleAdmin(bytes32 role, bytes32 adminRole) external;
     
     // =========================================================================
-    //                     EIP-2612 Permit (TIP-1004)
+    //                     EIP-2612 Permit
     // =========================================================================
 
     /// @notice Approves a spender via an off-chain signature (EIP-2612)
@@ -456,7 +456,7 @@ TIP-20 tokens cannot be sent to other TIP-20 token contract addresses. The imple
 Any attempt to transfer to a TIP-20 token address must revert with `InvalidRecipient`. This prevents accidental token loss by sending funds to token contracts instead of user accounts.
 
 ## Virtual Address Recipients
-Recipient-bearing TIP-20 paths — `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `mint`, and `mintWithMemo` — resolve [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) virtual addresses before running recipient authorization and mint-recipient checks. When a recipient `to` is a registered virtual address, the effective recipient becomes the registered master wallet, and authorization, balance updates, and event emission target that master wallet.
+Recipient-bearing TIP-20 paths — `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `mint`, and `mintWithMemo` — resolve [virtual addresses](/docs/protocol/tip20/virtual-addresses) before running recipient authorization and mint-recipient checks. When a recipient `to` is a registered virtual address, the effective recipient becomes the registered master wallet, and authorization, balance updates, and event emission target that master wallet.
 
 Virtual addresses are valid TIP-20 recipients on those paths but remain forwarding aliases rather than canonical TIP-20 holders. Non-TIP-20 tokens sent to a virtual address do not forward. Forwarded deposits appear as two-hop standard `Transfer` events in the same transaction; indexers and explorers should collapse that pair into one logical deposit to the resolved master wallet.
 
@@ -474,17 +474,17 @@ The implementation must validate that the new quote token is a TIP-20 token, mat
 While quote tokens can be changed, choose carefully as the update process requires careful coordination with the DEX.
 :::
 
-## Permit (TIP-1004)
+## Permit
 TIP-20 tokens support [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) `permit`, added in the [T2 network upgrade](/docs/protocol/upgrades/t2). A token owner signs an EIP-712 typed message off-chain authorizing a spender, and any third party can submit that signature on-chain — combining approve and action into a single transaction without the owner paying gas.
 
-The `DOMAIN_SEPARATOR` is computed dynamically on every call using `block.chainid`, so it remains correct after a chain fork. Each owner has a monotonically increasing `nonce` to prevent replay. Only `v = 27` or `v = 28` is accepted; `v = 0` or `v = 1` is intentionally **not** normalized (see [TIP-1004](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1004.md) for rationale).
+The `DOMAIN_SEPARATOR` is computed dynamically on every call using `block.chainid`, so it remains correct after a chain fork. Each owner has a monotonically increasing `nonce` to prevent replay. Only `v = 27` or `v = 28` is accepted; `v = 0` or `v = 1` is intentionally **not** normalized (see the [specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1004.md) for rationale).
 
-## Logo URI (TIP-1026)
-Every TIP-20 exposes an optional on-chain `logoURI`, added in the [T5 network upgrade](/docs/protocol/upgrades/t5) ([TIP-1026](https://tips.sh/1026)). Wallets and explorers read the icon directly from the token contract via `logoURI()`, without an off-chain registry round-trip. Tokens without a `logoURI` continue to work; the field is empty by default.
+## Logo URI
+Every TIP-20 exposes an optional on-chain `logoURI`, added in the [T5 network upgrade](/docs/protocol/upgrades/t5). Wallets and explorers read the icon directly from the token contract via `logoURI()`, without an off-chain registry round-trip. Tokens without a `logoURI` continue to work; the field is empty by default.
 
 The admin (`DEFAULT_ADMIN_ROLE`) sets or clears it via `setLogoURI(string newLogoURI)`, which emits `LogoURIUpdated(msg.sender, newLogoURI)`. An empty string is valid and clears the field. A non-empty value must be at most 256 bytes (`LogoURITooLong` otherwise) and a syntactically valid URI whose scheme is in the allowlist `{https, http, ipfs, data}`, matched case-insensitively (`InvalidLogoURI` otherwise).
 
-Per [TIP-1026's recommended formats](https://tips.sh/1026#recommended-formats), use a square, single-frame rasterized image (PNG or WebP). SVG is allowed by the scheme allowlist but not recommended — integrators that accept SVG must follow TIP-1026's SVG-handling guidance.
+Per the [specification's recommended formats](https://tips.sh/1026#recommended-formats), use a square, single-frame rasterized image (PNG or WebP). SVG is allowed by the scheme allowlist but not recommended — integrators that accept SVG must follow its SVG-handling guidance.
 
 ## Pause Controls
 Pause controls `pause` and `unpause` govern token movement. When paused, transfers and memo transfers halt, but administrative and configuration functions remain allowed. The `paused()` getter reflects the current state and must be checked by all affected entrypoints.
@@ -503,7 +503,7 @@ System level functions `systemTransferFrom`, `transferFeePreTx`, and `transferFe
 
 `transferFeePreTx` respects the token's pause state and will revert if the token is paused. However, `transferFeePostTx` is intentionally allowed to execute even when the token is paused. This ensures that a transaction which pauses the token can still complete successfully and receive its fee refund. Apart from this specific refund transfer, no other token transfers can occur after a pause event.
 
-### Implicit approvals for listed precompiles (TIP-1035)
+### Implicit approvals for listed precompiles
 An Implicit Approval List names the precompiles that may pull TIP-20 tokens without a prior `approve`. Listed precompiles call the internal `system_transfer_from(from, to, amount)` entrypoint, which:
 
 - Is **not** part of the public TIP-20 ABI and **not** callable by external contracts or EOAs.
@@ -513,7 +513,7 @@ An Implicit Approval List names the precompiles that may pull TIP-20 tokens with
 
 This generalizes the system-only path described above (`systemTransferFrom`, `transferFeePreTx`, `transferFeePostTx`) to an allow-list of precompiles — the StablecoinDEX, FeeAMM, and the `TIP20ChannelReserve` precompile. Normal `approve`, `permit`, `allowance`, and `transferFrom` behavior is unchanged.
 
-### Payment-channel reserve (TIP-1034)
+### Payment-channel reserve
 The enshrined `TIP20ChannelReserve` precompile at [`0x4D50500000000000000000000000000000000000`](https://explore.tempo.xyz/address/0x4D50500000000000000000000000000000000000) (ASCII `MPP`) is a TIP-20 consumer rather than a change to the TIP-20 contract itself — it pulls funds via the implicit-approval path above and emits standard `Transfer` events from the host TIP-20. See the [enshrined TIP-20 reserve channel section of the T5 page](/docs/protocol/upgrades/t5#enshrined-tip-20-reserve-channel) for the channel lifecycle, channel ID derivation, and event surface.
 
 
@@ -657,7 +657,7 @@ This section captures TIP-20 changes introduced by the [T6 network upgrade](/doc
 
 T6 introduces one change that affects the TIP-20 transfer and mint surface:
 
-### TIP-1028: account-level receive policies
+### Account-level receive policies
 
 The TIP-20 `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `systemTransferFrom`, `mint`, and `mintWithMemo` flows gain a receive-policy check after the existing TIP-403 transfer-policy check. The receive policy is owned by the receiver and configured on the TIP-403 precompile via a new `setReceivePolicy(...)` function; it is enforced via `validateReceivePolicy(token, sender, receiver)`. For `transfer`/`transferFrom`/memo variants/`systemTransferFrom`, the sender for policy purposes is the `from` argument; for `mint`/`mintWithMemo` it is `msg.sender`.
 
@@ -665,7 +665,7 @@ If the receive policy blocks the operation, **the call still succeeds**. Deliver
 
 - The token's existing TIP-403 policy is checked first and continues to revert on failure. Only receive-policy failures redirect.
 - The host TIP-20 emits its standard `Transfer` event to `0xB10C000000000000000000000000000000000000` on a redirected transfer; the guard separately emits a `TransferBlocked` event with the information needed to claim the receipt. Blocked receipts are not enumerable on chain — indexers must subscribe to `TransferBlocked` to surface claimable funds.
-- TIP-1022 virtual addresses are resolved to the master address before any receive-policy check. Receipts are recorded against the master while preserving the original `to` for attribution.
+- Virtual addresses are resolved to the master address before any receive-policy check. Receipts are recorded against the master while preserving the original `to` for attribution.
 - `approve`, `permit`, and `burn` are not affected. Fee deposits and refunds via `transfer_fee_pre_tx` and `transfer_fee_post_tx` are not affected. TIP-20 internal balances and reward flows are not affected.
 
-See [TIP-1028](https://tips.sh/1028) for the full specification, including the `ReceivePolicyGuard` claim interface and recovery-authority rules.
+Read the [full specification](https://tips.sh/1028), including the `ReceivePolicyGuard` claim interface and recovery-authority rules.

--- a/src/pages/docs/protocol/tip20/virtual-addresses.mdx
+++ b/src/pages/docs/protocol/tip20/virtual-addresses.mdx
@@ -38,7 +38,7 @@ The important idea is simple: the virtual address is for routing and attribution
 
 ## Address format
 
-A virtual address is still a normal 20-byte EVM address. [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) gives those 20 bytes a specific layout:
+A virtual address is still a normal 20-byte EVM address. The [specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) gives those 20 bytes a specific layout:
 
 ```text
 0x | masterId (4 bytes) | VIRTUAL_MAGIC (10 bytes) | userTag (6 bytes)
@@ -134,15 +134,15 @@ If the sender and registered master wallet are the same address, two `Transfer` 
 
 ## What this does not do
 
-TIP-1022 is deliberately narrow in scope.
+Virtual address forwarding is deliberately narrow in scope.
 
 ### It only changes TIP-20 deposit paths
 
-Virtual forwarding applies only to the TIP-20 transfer and mint paths defined by [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md). It is not a general EVM alias system.
+Virtual forwarding applies only to the TIP-20 transfer and mint paths defined by the [specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md). It is not a general EVM alias system.
 
 ### It does not change ERC-20 contracts deployed on Tempo
 
-If a non-TIP-20 token contract receives a transfer to a virtual address, that contract treats it as a normal literal address. TIP-1022 does not help there.
+If a non-TIP-20 token contract receives a transfer to a virtual address, that contract treats it as a normal literal address. Virtual address forwarding does not apply there.
 
 ### It does not make every protocol virtual-address aware
 
@@ -160,7 +160,7 @@ Adopting virtual addresses is straightforward conceptually:
 - ongoing operations: derive deposit addresses offchain
 - reconciliation: decode the `userTag` from events and credit the right customer internally
 
-If you want the exact transfer semantics, event shape, and validation rules, read [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) alongside the [TIP-20 specification](/docs/protocol/tip20/spec).
+If you want the exact transfer semantics, event shape, and validation rules, read the [virtual address specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) alongside the [TIP-20 specification](/docs/protocol/tip20/spec).
 
 ## Learn more about TIP-20 virtual addresses
 
@@ -172,7 +172,7 @@ If you want the exact transfer semantics, event shape, and validation rules, rea
     icon="lucide:file-text"
   />
   <Card
-    title="TIP-1022 specification"
+    title="Virtual address specification"
     description="Read the full TIP with address derivation, forwarding semantics, and invariants."
     to="https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md"
     icon="lucide:file-text"

--- a/src/pages/docs/protocol/tip403/receive-policies.mdx
+++ b/src/pages/docs/protocol/tip403/receive-policies.mdx
@@ -8,7 +8,7 @@ import { MermaidDiagram } from '../../../../components/MermaidDiagram'
 
 # Receive Policies
 
-Receive policies let a receiver control which [TIP-20](/docs/protocol/tip20/overview) tokens it accepts and which senders may send those tokens to it. This page summarizes the protocol behavior from [TIP-1028](https://tips.sh/1028).
+Receive policies let a receiver control which [TIP-20](/docs/protocol/tip20/overview) tokens it accepts and which senders may send those tokens to it. This page summarizes the protocol behavior from the [specification](https://tips.sh/1028).
 
 When a receive policy blocks an inbound TIP-20 transfer or mint, the call still succeeds. Delivery is redirected to `ReceivePolicyGuard`, and the guard records a receipt for that blocked transfer or mint. The token's [TIP-403](/docs/protocol/tip403/spec) policy checks still run first and still revert on failure.
 
@@ -76,7 +76,7 @@ The recovery authority controls who can claim future blocked receipts:
 | receiver address | the receiver |
 | another nonzero address | that address |
 
-Nonzero recovery authorities must not be `ReceivePolicyGuard`, [TIP-1022](https://tips.sh/1022) virtual addresses, or system precompile addresses that cannot initiate calls. A virtual address must not call `setReceivePolicy(...)`; configure the resolved master address instead.
+Nonzero recovery authorities must not be `ReceivePolicyGuard`, [virtual addresses](/docs/protocol/tip20/virtual-addresses), or system precompile addresses that cannot initiate calls. A virtual address must not call `setReceivePolicy(...)`; configure the resolved master address instead.
 
 If no receive policy is set, all transfers and mints are allowed by the receive-policy layer.
 
@@ -126,7 +126,7 @@ A claim resumes the original inbound when `recoveryAuthority != address(0)` and 
 
 A resume claim does not recheck the receiver's receive policy. It still requires the receiver to be currently authorized under the token's TIP-403 policy as the destination of the release.
 
-For blocked TIP-1022 transfers to a virtual address, the receiver is the resolved master, so a resume releases directly to the master.
+For blocked transfers to a virtual address, the receiver is the resolved master, so a resume releases directly to the master.
 
 ### Reroute claims
 
@@ -135,7 +135,7 @@ All other claims are reroutes, including every originator-authorized claim.
 A reroute must:
 
 - reject `to == ReceivePolicyGuard`
-- resolve `to` if it is a TIP-1022 virtual address, or revert if resolution fails
+- resolve `to` if it is a virtual address, or revert if resolution fails
 - require the policy subject to be authorized as a sender under the token's TIP-403 policy
 - require the resolved destination to be authorized as a recipient under the token's TIP-403 policy
 - require the resolved destination's receive policy to accept the policy subject as sender
@@ -207,7 +207,7 @@ event ReceiptBurned(
 
 <Cards>
   <Card
-    title="TIP-1028"
+    title="Receive policies specification"
     description="Approved specification for address-level receive policies."
     to="https://tips.sh/1028"
     icon="lucide:file-text"

--- a/src/pages/docs/protocol/tip403/spec.mdx
+++ b/src/pages/docs/protocol/tip403/spec.mdx
@@ -232,7 +232,7 @@ TIP-20 tokens store the current TIP403 registry policy ID they adhere to in thei
 
 **Policy Changes:** When a token's transfer policy is changed via `changeTransferPolicyId()`, all future transfers are immediately subject to the new policy.
 
-**Virtual addresses:** Policy-configuration functions that accept literal member addresses (`createPolicyWithAccounts`, `modifyPolicyWhitelist`, `modifyPolicyBlacklist`) reject [TIP-1022](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1022.md) virtual addresses. TIP-20 policy checks for transfers and mints to a virtual address run against the resolved master wallet rather than the forwarding alias, so policy membership must be configured on the master address.
+**Virtual addresses:** Policy-configuration functions that accept literal member addresses (`createPolicyWithAccounts`, `modifyPolicyWhitelist`, `modifyPolicyBlacklist`) reject [virtual addresses](/docs/protocol/tip20/virtual-addresses). TIP-20 policy checks for transfers and mints to a virtual address run against the resolved master wallet rather than the forwarding alias, so policy membership must be configured on the master address.
 
 ### Example Usage
 

--- a/src/pages/docs/protocol/transactions/AccountKeychain.mdx
+++ b/src/pages/docs/protocol/transactions/AccountKeychain.mdx
@@ -191,7 +191,7 @@ interface IAccountKeychain {
 - `key_authorization` includes an optional trailing `witness: bytes32` field. When present, the witness is included in the signing hash, checked against the account's burned-witness set, and emitted when the key authorization is registered. The protocol otherwise treats it as opaque and application-defined, so apps can bind a single access-key authorization signature to an offchain challenge.
 
 :::info[T6 behavior — SDK encoders/decoders]
-The [T6 network upgrade](/docs/protocol/upgrades/t6) added **admin access keys** ([TIP-1049](https://tips.sh/1049)). For partners maintaining transaction tooling, the wire-level change is two new trailing optional fields on the `KeyAuthorization` RLP payload:
+The [T6 network upgrade](/docs/protocol/upgrades/t6) added [admin access keys](/docs/protocol/upgrades/t6#admin-access-keys). For partners maintaining transaction tooling, the wire-level change is two new trailing optional fields on the `KeyAuthorization` RLP payload:
 
 ```text
 rlp([chain_id, key_type, key_id, expiry?, limits?, allowed_calls?, witness?, is_admin?, account?])

--- a/src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx
+++ b/src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx
@@ -623,7 +623,7 @@ There is one decoder nuance: because `KeyAuthorization` uses canonical trailing 
 Do not hand-encode `expiry = 0` or rely on `Some(0)` as a sentinel. The supported encoding to target is omission, and the protocol translates omitted expiry to `u64::MAX` when materializing the `AccountKeychain.authorizeKey(...)` call.
 :::
 
-Intrinsic gas for `key_authorization` accounts for the storage written for periodic-limit state and call-scope entries. See [TIP-1011](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1011.md#intrinsic-gas-for-key-authorization) for slot-counting rules.
+Intrinsic gas for `key_authorization` accounts for the storage written for periodic-limit state and call-scope entries. See the [specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1011.md#intrinsic-gas-for-key-authorization) for slot-counting rules.
 
 #### Keychain Precompile
 
@@ -1081,7 +1081,7 @@ def calculate_key_authorization_gas(key_auth: SignedKeyAuthorization) -> uint256
     Returns:
         gas_cost: uint256
 
-    Note: This is a simplified illustration. See TIP-1011 for the canonical
+    Note: This is a simplified illustration. See the enhanced access key permissions specification for the canonical
     slot-counting rules covering periodic-limit state and call-scope storage.
     """
     # Constants - KeyAuthorization pays FULL signature verification costs
@@ -1113,7 +1113,7 @@ def calculate_key_authorization_gas(key_auth: SignedKeyAuthorization) -> uint256
     gas += num_limits * COLD_SSTORE_SET_GAS  # 22,000 per limit
 
     # Step 5: Per-call-scope storage cost (target + selector + recipients).
-    # See TIP-1011 for exact slot accounting; this counts one slot per
+    # See the enhanced access key permissions specification for exact slot accounting; this counts one slot per
     # (target, selector, recipient) triple as a conservative approximation.
     num_scope_slots = 0
     if key_auth.allowed_calls:

--- a/src/pages/docs/protocol/upgrades/t2.mdx
+++ b/src/pages/docs/protocol/upgrades/t2.mdx
@@ -23,16 +23,16 @@ Node operators needed to upgrade to the T2-compatible release before the testnet
 ## Overview
 
 T2 built on T1 and introduced the following features:
-- Compound transfer policies ([TIP-1015](https://tips.sh/1015))
-- Permit support for TIP-20 tokens ([TIP-1004](https://tips.sh/1004))
-- A new Validator Config V2 precompile ([TIP-1017](https://tips.sh/1017))
-- Security improvements ([TIP-1036](https://tips.sh/1036))
+- [Compound transfer policies](https://tips.sh/1015)
+- [Permit](https://tips.sh/1004) support for TIP-20 tokens
+- A new [Validator Config V2](https://tips.sh/1017) precompile
+- [T2 network upgrade](https://tips.sh/1036) security improvements
 
 ## Feature TIPs
 
-### TIP-1015: Compound Transfer Policies
+### Compound transfer policies
 
-**Spec:** [TIP-1015](https://tips.sh/1015)
+Read the [technical specification](https://tips.sh/1015).
 
 **TLDR:** Extended TIP-403 policies so token issuers can set different authorization rules for senders, recipients, and mint recipients. Previously a single policy applied to both sides of a transfer.
 
@@ -42,9 +42,9 @@ T2 built on T1 and introduced the following features:
 - If you integrate with TIP-403 policies: new `isAuthorizedSender()`, `isAuthorizedRecipient()`, and `isAuthorizedMintRecipient()` functions are available. The existing `isAuthorized()` still works (returns `senderCheck && recipientCheck`).
 - If you issue TIP-20 tokens: you can now create compound policies for use cases like vendor credits, directional KYC, or asymmetric compliance.
 
-### TIP-1017: Validator Config V2
+### Validator Config V2
 
-**Spec:** [TIP-1017](https://tips.sh/1017)
+Read the [technical specification](https://tips.sh/1017).
 
 **Operator guide:** [Controlling validator lifecycle](/docs/guide/node/validator-lifecycle)
 
@@ -56,9 +56,9 @@ T2 built on T1 and introduced the following features:
 - **Node operators:** Node operators didn't need to take action for the migration itself. Operators can now self-service IP updates, key rotation, and ownership transfers.
 - **Minimal nodes for validators:** Validator V2 unlocks minimal nodes for validators. Previously, validators had to keep ~64,000 blocks of history to reconstruct validator sets, requiring hundreds of GB of storage. V2 removes that requirement, letting validators query the set from the latest state only.
 
-### TIP-1004: Permit for TIP-20
+### Permit for TIP-20
 
-**Spec:** [TIP-1004](https://tips.sh/1004)
+Read the [technical specification](https://tips.sh/1004).
 
 **TLDR:** Added EIP-2612 compatible `permit()` to all TIP-20 tokens, enabling gasless approvals via off-chain signatures.
 
@@ -69,4 +69,4 @@ T2 built on T1 and introduced the following features:
 
 ### Meta TIP: Security Improvements
 
-[TIP-1036: T2 Hardfork Improvements](https://tips.sh/1036)
+Read the [technical specification](https://tips.sh/1036).

--- a/src/pages/docs/protocol/upgrades/t3.mdx
+++ b/src/pages/docs/protocol/upgrades/t3.mdx
@@ -24,9 +24,9 @@ Node operators needed to upgrade to the T3-compatible release before the testnet
 
 | TIP | What it does | Who should review |
 |-----|-------------|-------------------|
-| [TIP-1011](https://tips.sh/1011) | Periodic spending limits, call scoping, and a ban on access-key contract creation | Wallets, account SDKs, apps using connected apps or subscriptions |
-| [TIP-1020](https://tips.sh/1020) | Signature verification precompile for secp256k1, P256, and WebAuthn | Smart contract teams, account integrators, wallet SDKs |
-| [TIP-1022](https://tips.sh/1022) | [Virtual addresses](/docs/protocol/tip20/virtual-addresses) for TIP-20 deposit forwarding | Exchanges, ramps, custodians, payment processors, explorers, indexers |
+| [Enhanced access key permissions](https://tips.sh/1011) | Periodic spending limits, call scoping, and a ban on access-key contract creation | Wallets, account SDKs, apps using connected apps or subscriptions |
+| [Signature verification](https://tips.sh/1020) | Signature verification precompile for secp256k1, P256, and WebAuthn | Smart contract teams, account integrators, wallet SDKs |
+| [Virtual addresses](https://tips.sh/1022) | [Virtual addresses](/docs/protocol/tip20/virtual-addresses) for TIP-20 deposit forwarding | Exchanges, ramps, custodians, payment processors, explorers, indexers |
 
 ## Breaking changes
 
@@ -34,7 +34,7 @@ These breaking changes only affect access-key integrations. You need to update y
 
 ### Access-key authorization ABI
 
-Integrations that directly call `AccountKeychain.authorizeKey(...)` or manually encode `key_authorization` must use the TIP-1011 tuple-form ABI. The legacy selector `0x54063a55` no longer works — legacy calls fail with `LegacyAuthorizeKeySelectorChanged(newSelector: 0x980a6025)`.
+Integrations that directly call `AccountKeychain.authorizeKey(...)` or manually encode `key_authorization` must use the tuple-form ABI for enhanced access key permissions. The legacy selector `0x54063a55` no longer works — legacy calls fail with `LegacyAuthorizeKeySelectorChanged(newSelector: 0x980a6025)`.
 
 If you use an updated SDK, this is mostly a tooling upgrade. If you hand-encode calldata, use the exact tuple-form signature from the [Account Keychain precompile spec](/docs/protocol/transactions/AccountKeychain).
 
@@ -62,7 +62,7 @@ See [Virtual addresses for TIP-20 deposits](/docs/protocol/tip20/virtual-address
 
 ### Signature verification precompile
 
-[TIP-1020](https://tips.sh/1020) is additive — existing verifier setups keep working. Teams that want a standard onchain verification surface can adopt the precompile instead of maintaining custom verifier contracts. See the [Signature Verification with Foundry](/docs/sdk/foundry/signature-verifier) guide.
+Signature verification is additive — existing verifier setups keep working. Teams that want a standard onchain verification surface can adopt the precompile instead of maintaining custom verifier contracts. See the [Signature Verification with Foundry](/docs/sdk/foundry/signature-verifier) guide or read the [technical specification](https://tips.sh/1020).
 
 ## Compatible SDK releases
 
@@ -78,5 +78,5 @@ Tempo's broader tooling ecosystem is available in [Developer tools](/docs/quicks
 
 ## Related docs
 - [Virtual addresses for TIP-20 deposits](/docs/protocol/tip20/virtual-addresses)
-- [TIP-1022](https://tips.sh/1022)
+- [Virtual addresses](https://tips.sh/1022)
 - Coordinating meta TIP: [tempoxyz/tempo#3273](https://github.com/tempoxyz/tempo/pull/3273)

--- a/src/pages/docs/protocol/upgrades/t4.mdx
+++ b/src/pages/docs/protocol/upgrades/t4.mdx
@@ -23,8 +23,8 @@ Node operators needed to upgrade to the T4-compatible release (v1.7.0, released 
 ## Overview
 
 T4 introduced the following changes:
-- Embedding consensus context into the block header to unlock deferred verification and reduce finalization latency ([TIP-1031](https://tips.sh/1031))
-- A bundle of bug fixes and security hardening ([TIP-1046](https://tips.sh/1046))
+- [Consensus context in block headers](https://tips.sh/1031) to unlock deferred verification and reduce finalization latency
+- [T4 network upgrade](https://tips.sh/1046) bug fixes and security hardening
 
 ## Compatible SDK releases
 
@@ -37,11 +37,11 @@ See [Developer tools](/docs/quickstart/developer-tools) for the broader SDK ecos
 
 ## Related docs
 - [Network upgrades and releases](/docs/guide/node/network-upgrades)
-- [TIP-1031: Embed Consensus Context in the Block Header](https://tips.sh/1031)
-- [TIP-1046: T4 Hardfork Meta TIP](https://tips.sh/1046)
+- [Consensus context in block headers](https://tips.sh/1031)
+- [T4 network upgrade](https://tips.sh/1046)
 
 ## Feature TIPs
 
-### TIP-1031: Embed Consensus Context in the Block Header
+### Consensus context in block headers
 
-[TIP-1031](https://tips.sh/1031) added an optional `Context` field (epoch, view, parent view, leader) as the last field of `TempoHeader`. This commits consensus metadata to the block hash so Tempo blocks implement Commonware's `CertifiableBlock` trait, enabling deferred verification (optimistic notarization with async background verification) and reduced finalization latency. Pre-T4 headers are unchanged; post-T4 headers require the field, and validators reject mismatched context.
+The [specification](https://tips.sh/1031) added an optional `Context` field (epoch, view, parent view, leader) as the last field of `TempoHeader`. This commits consensus metadata to the block hash so Tempo blocks implement Commonware's `CertifiableBlock` trait, enabling deferred verification (optimistic notarization with async background verification) and reduced finalization latency. Pre-T4 headers are unchanged; post-T4 headers require the field, and validators reject mismatched context.

--- a/src/pages/docs/protocol/upgrades/t5.mdx
+++ b/src/pages/docs/protocol/upgrades/t5.mdx
@@ -28,7 +28,7 @@ T5 focuses on four integration areas, plus a storage correctness fix:
 - **Clearer DEX state.** Flip orders can use the same tick on both sides and keep the same `orderId` after each flip.
 - **Simpler fee-token liquidity.** FeeAMM routing can use two hops, so issuers usually do not need a direct pool against every validator payout token.
 - **Better token and key metadata.** TIP-20 tokens can expose an on-chain `logoURI`, listed precompiles can pull TIP-20 tokens without a separate approval, and key authorizations can include an app-defined witness digest.
-- **Storage correctness fix.** Shrinking writes to dynamic precompile storage clear their stale tail slots at the hardfork boundary ([TIP-1057](https://tips.sh/1057)).
+- **Storage correctness fix.** Shrinking writes to dynamic precompile storage clear their stale tail slots at the T5 hardfork boundary.
 
 Most T5 changes are additive: existing TIP-20 tokens, MPP contracts, and non-flip DEX flows continue to work.
 
@@ -50,13 +50,13 @@ Measured gas savings versus the legacy reserve contract:
 
 These numbers cover only the channel operation itself. Under the legacy path, first-time users also had to send a separate `approve` transaction before opening a channel. With the precompile on the Implicit Approvals List, that approval round trip and allowance storage write are removed.
 
-Read the technical specification at [TIP-1034](https://tips.sh/1034).
+Read the [technical specification](https://tips.sh/1034).
 
 ### Payment lane classification
 
 T5 moved payment-lane eligibility from local builder policy into consensus. The allow-list covers TIP-20 calls and the new `TIP20ChannelReserve` precompile, so reserve-channel transactions are classified consistently across the network.
 
-Read the technical specification at [TIP-1045](https://tips.sh/1045).
+Read the [technical specification](https://tips.sh/1045).
 
 ### DEX flip-order improvements
 
@@ -67,7 +67,7 @@ The upgrade changed flip orders in two ways:
 
 This makes a market-making strategy easier to track over time. Indexers should treat `OrderFlipped` as the latest active state for that `orderId`.
 
-Read the technical specifications at [TIP-1030](https://tips.sh/1030) and [TIP-1056](https://tips.sh/1056).
+Read the technical specifications for [same-tick flip orders](https://tips.sh/1030) and [keeping order IDs across flips](https://tips.sh/1056).
 
 ### Multihop FeeAMM routing
 
@@ -75,7 +75,7 @@ FeeAMM can now route through two pools when there is no usable direct pool betwe
 
 For token issuers, this usually means pairing against one liquid quote token, such as `pathUSD`, instead of provisioning direct pools against every validator payout token.
 
-Read the technical specification at [TIP-1033](https://tips.sh/1033).
+Read the [technical specification](https://tips.sh/1033).
 
 ### Optional on-chain logoURI
 
@@ -83,7 +83,7 @@ TIP-20 tokens can expose an optional `logoURI` field. Wallets and explorers can 
 
 The field is capped at 256 bytes, and non-empty values must use an allowed URI scheme: `https`, `http`, `ipfs`, or `data`.
 
-Read the technical specification at [TIP-1026](https://tips.sh/1026).
+Read the [technical specification](https://tips.sh/1026).
 
 ### Implicit approvals
 
@@ -91,13 +91,13 @@ Listed protocol precompiles can pull TIP-20 tokens without a prior `approve`. Th
 
 The internal transfer path is not part of the public TIP-20 ABI and cannot be called by EOAs or external contracts. It still enforces balance checks, TIP-403 transfer policies, AccountKeychain spending limits, and emits the standard TIP-20 `Transfer` event.
 
-Read the technical specification at [TIP-1035](https://tips.sh/1035).
+Read the [technical specification](https://tips.sh/1035).
 
 ### Witness digest in key authorizations
 
 `key_authorization` now supports an optional `witness: bytes32` field. Apps can bind one key-authorization signature to an application challenge, which removes the need for a separate challenge signature in login or delegated-access flows.
 
-Read the technical specification at [TIP-1053](https://tips.sh/1053).
+Read the [technical specification](https://tips.sh/1053).
 
 ### Storage correctness fix
 
@@ -105,7 +105,7 @@ T5 gates one precompile storage fix at the hardfork boundary. Overwriting a `Vec
 
 This changes storage state and gas at the activation boundary, but no public ABI changes and no integrator action is required.
 
-Read the technical specification at [TIP-1057](https://tips.sh/1057).
+Read the [technical specification](https://tips.sh/1057).
 
 ## Compatible SDK releases
 

--- a/src/pages/docs/protocol/upgrades/t6.mdx
+++ b/src/pages/docs/protocol/upgrades/t6.mdx
@@ -56,7 +56,7 @@ Practical benefits:
 
 Try the [receive policies demo](https://tempo.xyz/receive-policies) to see the credited, held, and recovery flow.
 
-Read the technical specification at [TIP-1028](https://tips.sh/1028).
+Read the [technical specification](https://tips.sh/1028).
 
 ### Admin access keys
 
@@ -72,7 +72,7 @@ Practical benefits:
 
 Admin keys are only for key management and admin verification. They can authorize and revoke other keys, but they cannot carry spending limits, call scopes, or expiry settings.
 
-Read the technical specification at [TIP-1049](https://tips.sh/1049).
+Read the [technical specification](https://tips.sh/1049).
 
 ## Compatible releases
 
@@ -110,7 +110,7 @@ For receivers and integrators, the operating flow is:
 - Blocked inbound `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, `systemTransferFrom`, `mint`, and `mintWithMemo` calls still succeed, but delivery is redirected to `ReceivePolicyGuard` at `0xB10C000000000000000000000000000000000000`.
 - Senders observing a successful `Transfer` event from the host TIP-20 to `0xB10C000000000000000000000000000000000000` should not assume the receiver was credited. Wallets and accounting systems should read the guard receipt to track redirected funds.
 - Blocked-transfer receipts are not enumerable onchain. Wallets and dashboards that surface claimable funds need indexers that listen for the `TransferBlocked` event emitted by `ReceivePolicyGuard`.
-- TIP-1022 virtual addresses are resolved to the master address before any receive-policy check. Receipts are recorded against the master while preserving the original `to` for attribution.
+- Virtual addresses are resolved to the master address before any receive-policy check. Receipts are recorded against the master while preserving the original `to` for attribution.
 - `approve`, `permit`, and `burn` are unaffected. Fee deposits and refunds (`transfer_fee_pre_tx` / `transfer_fee_post_tx`) are also unaffected.
 
 ### For admin access keys
@@ -134,6 +134,6 @@ For account and app integrators, the operating flow is:
 - The `AuthorizedKey` packed storage slot gains a new `is_admin` boolean at byte 11.
 - Admin keys cannot carry spending limits, call scopes, or expiry. Authorizations that combine `admin = true` with non-default `enforceLimits`, `allowedCalls`, or `expiry` are rejected.
 - `AccountKeychain` adds `authorizeAdminKey(keyId, signatureType, witness)` for provisioning admin keys. The existing `KeyAuthorized` event is unchanged, and a new `AdminKeyAuthorized(account, publicKey)` event is emitted alongside it when `admin = true`.
-- TIP-1020 `SignatureVerifier` adds `verifyKeychain(account, digest, sig)` and `verifyKeychainAdmin(account, digest, sig)`. These methods combine signature recovery with key-status checks.
+- Signature verification through `SignatureVerifier` adds `verifyKeychain(account, digest, sig)` and `verifyKeychainAdmin(account, digest, sig)`. These methods combine signature recovery with key-status checks.
 - The RLP `KeyAuthorization` encoding gains an optional trailing `is_admin` flag and `account` field in the signed payload. SDK encoders and decoders should update in lockstep.
 - `verifyKeychainAdmin` does not bind the `account` argument into the signed `digest`. Callers should include a replay domain, such as chain ID, contract address, and account address, in the digest they ask users or keys to sign.

--- a/src/pages/docs/quickstart/evm-compatibility.mdx
+++ b/src/pages/docs/quickstart/evm-compatibility.mdx
@@ -98,7 +98,7 @@ At the VM layer, all opcodes are supported out of the box. Due to the lack of a 
 
 ### State Creation Costs
 
-Tempo uses higher gas costs for state-creating operations to prevent state growth attacks ([TIP-1000](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md)):
+Tempo's [state creation costs](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md) are higher to prevent state growth attacks:
 
 | Operation | Tempo | Ethereum |
 |-----------|-------|----------|

--- a/src/pages/docs/quickstart/tokenlist.mdx
+++ b/src/pages/docs/quickstart/tokenlist.mdx
@@ -50,7 +50,7 @@ As an example, here's Tempo's tokenlist, fetched from [tokenlist.tempo.xyz/list/
 
 3. **Add icon** to `data/<chain_id>/icons/<address>.svg` (lowercase address) in `apps/tokenlist`
 
-   Separately, TIP-20 tokens can also carry an optional on-chain `logoURI` ([TIP-1026](https://tips.sh/1026)) that wallets and explorers read directly from the token contract. Because that icon is fetched from an untrusted source, TIP-1026 recommends a square, rasterized PNG or WebP (max 256 bytes; `https`, `http`, `ipfs`, or `data` scheme). Setting it is optional and independent of this PR — registering here still adds richer metadata (`coingeckoId`, `bridgeInfo`, display `label`) and a fallback icon for clients that don't read on-chain `logoURI`.
+   Separately, TIP-20 tokens can also carry an optional on-chain [`logoURI`](/docs/protocol/tip20/spec#logo-uri) that wallets and explorers read directly from the token contract. The Logo URI specification recommends a square, rasterized PNG or WebP (max 256 bytes; `https`, `http`, `ipfs`, or `data` scheme) because clients fetch the icon from an untrusted source. Setting it is optional and independent of this PR — registering here still adds richer metadata (`coingeckoId`, `bridgeInfo`, display `label`) and a fallback icon for clients that don't read on-chain `logoURI`.
 
 4. **Submit PR** with as much information as you think is helpful for review.
 

--- a/src/pages/docs/sdk/foundry/signature-verifier.mdx
+++ b/src/pages/docs/sdk/foundry/signature-verifier.mdx
@@ -1,11 +1,11 @@
 ---
 title: Signature Verification in Foundry
-description: Verify secp256k1, P256, and WebAuthn signatures in smart contracts using the TIP-1020 SignatureVerifier precompile with Foundry.
+description: Verify secp256k1, P256, and WebAuthn signatures in smart contracts using the SignatureVerifier precompile with Foundry.
 ---
 
 # Signature Verification with Foundry
 
-The [TIP-1020](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md) `SignatureVerifier` precompile is available on Tempo. It lets contracts verify secp256k1, P256, and WebAuthn signatures through a single interface — no custom verifier contracts needed.
+The [`SignatureVerifier` precompile](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md) is available on Tempo. It provides signature verification for secp256k1, P256, and WebAuthn through a single interface — no custom verifier contracts needed.
 
 The Foundry project template for Tempo ships with a working example that demonstrates signature verification in a relayed mail contract. Initialize it with:
 
@@ -144,6 +144,6 @@ The secp256k1 and P256 relay tests use Tempo mode through the template's Foundry
 
 ## Related signature verification docs
 
-- [TIP-1020: Signature Verification Precompile](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md)
+- [Signature verification specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md)
 - [T6 Network Upgrade](/docs/protocol/upgrades/t6)
 - [Foundry for Tempo](/docs/sdk/foundry)

--- a/src/snippets/tempo-tx-properties.mdx
+++ b/src/snippets/tempo-tx-properties.mdx
@@ -1548,7 +1548,7 @@ In **Viem** and **Wagmi**, expiring nonces are handled automatically.
 
 ### Expiring Nonces
 
-[TIP-1009](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1009.md) introduces expiring nonces: transactions automatically expire if not executed within a specified time window. 
+The [expiring nonces specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1009.md) defines transactions that automatically expire if they are not executed within a specified time window.
 
 **Benefits:**
 - No nonce tracking required
@@ -2076,7 +2076,7 @@ For cases requiring ordered sequences within a key, Tempo's **2D nonce system** 
 </Tabs>
 
 :::warning
-**Reuse nonce keys instead of generating random ones.** Creating a new nonce key incurs a state creation cost that increases with the number of active keys (see [TIP-1000](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md)). For most applications, using a small set of sequential nonce keys (e.g., `1n`, `2n`, `3n`) is sufficient and much more cost-effective than generating random nonce keys for each transaction.
+**Reuse nonce keys instead of generating random ones.** Creating a new nonce key incurs a state creation cost that increases with the number of active keys (see [State creation costs](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1000.md)). For most applications, using a small set of sequential nonce keys (e.g., `1n`, `2n`, `3n`) is sufficient and much more cost-effective than generating random nonce keys for each transaction.
 :::
 
 ### Scheduled Transactions


### PR DESCRIPTION
## Summary

- replace visible actionable TIP-number references with the audit sheet's recommended terminology across guides, protocol references, upgrade pages, interactive demos, and shared snippets
- keep generic `TIP` / `TIPs`, `TIP-20`, and `TIP-403` terminology unchanged
- use internal docs links where available and generic specification labels for retained canonical spec links

## Audit coverage

- confirmed all 132 applicable numbered-reference audit rows are addressed on current `main`
- did not change blog posts or canonical standards pages under `src/pages/docs/protocol/tips/tip-*.mdx`
- left the four T7 rows in `src/pages/docs/protocol/upgrades/t7.mdx` unchanged because [#666](https://github.com/tempoxyz/docs/pull/666) is already modifying that file
- one audited row targeted the removed `src/pages/docs/protocol/tip20-rewards/spec.mdx` file and requires no change on current `main`

Audit sheet: https://docs.google.com/spreadsheets/d/1ouosn9FSV7hyPwv1lVDtAX9zzcbL3MglqWMUmfe6jzs/edit

## Validation

- `pnpm exec biome check src/components/guides/VirtualAddressesFastDemo.tsx src/components/guides/VirtualAddressesLiveDemo.tsx`
- `pnpm check:types`
- required repository searches for `TIP-`, `TIPs`, `TIP`, `/protocol/tips`, and `tips.sh`
- remaining numbered references classified as 105 canonical TIP-page lines and 4 T7 lines retained for #666
- `pnpm test` could not execute because Vocs failed to fetch its external OpenAPI specification during startup

Prompted by: tom
