### PR TITLE
Restore TIPs redirect to tips.sh

### DIFF
--- a/src/pages/docs/protocol/index.mdx
+++ b/src/pages/docs/protocol/index.mdx
@@ -77,7 +77,7 @@ For private execution internals, start with Tempo Zones and the [zone accounts s
   <Card
     title="TIPs"
     description="Browse Tempo Improvement Proposals for standards, process changes, and protocol history."
-    to="/docs/protocol/tips"
+    to="https://tips.sh/"
     icon="lucide:file-text"
   />
   <Card

--- a/src/pages/docs/protocol/tips/index.mdx
+++ b/src/pages/docs/protocol/tips/index.mdx
@@ -10,11 +10,7 @@ export function TipsRedirect() {
     window.location.replace('https://tips.sh/')
   }, [])
 
-  return (
-    <p>
-      Redirecting to <a href="https://tips.sh/">tips.sh</a>.
-    </p>
-  )
+  return null
 }
 
 <TipsRedirect />

--- a/src/pages/docs/protocol/tips/index.mdx
+++ b/src/pages/docs/protocol/tips/index.mdx
@@ -3,14 +3,9 @@ title: Tempo Improvement Proposals
 description: Tempo Improvement Proposals live at tips.sh.
 ---
 
-import { useEffect } from 'react'
-
-export function TipsRedirect() {
-  useEffect(() => {
-    window.location.replace('https://tips.sh/')
-  }, [])
-
-  return null
-}
-
-<TipsRedirect />
+<meta httpEquiv="refresh" content="0;url=https://tips.sh/" />
+<script
+  dangerouslySetInnerHTML={{
+    __html: "globalThis.location.replace('https://tips.sh/')",
+  }}
+/>

--- a/src/pages/docs/protocol/tips/index.mdx
+++ b/src/pages/docs/protocol/tips/index.mdx
@@ -1,12 +1,20 @@
 ---
 title: Tempo Improvement Proposals
-description: Browse Tempo Improvement Proposals covering protocol changes, network upgrades, precompiles, transaction formats, and stablecoin standards.
+description: Tempo Improvement Proposals live at tips.sh.
 ---
 
-import { TipsList } from '../../../../components/TipsList'
+import { useEffect } from 'react'
 
-# Tempo Improvement Proposals (TIPs)
+export function TipsRedirect() {
+  useEffect(() => {
+    window.location.replace('https://tips.sh/')
+  }, [])
 
-TIPs are design documents that describe changes to the Tempo protocol. Each TIP provides a complete specification that serves as the source of truth for implementation.
+  return (
+    <p>
+      Redirecting to <a href="https://tips.sh/">tips.sh</a>.
+    </p>
+  )
+}
 
-<TipsList />
+<TipsRedirect />


### PR DESCRIPTION
## Summary

- Points the Tempo Protocol TIPs card directly to `https://tips.sh/`.
- Leaves `/docs/protocol/tips` as a silent server-safe redirect for direct/stale links, with no public redirect copy rendered.

## Preview

- Protocol overview: https://tempo-docs-git-docs-restore-tips-redirect-tempoxyz.vercel.app/docs/protocol
- Stale TIPs route: https://tempo-docs-git-docs-restore-tips-redirect-tempoxyz.vercel.app/docs/protocol/tips

Use `/docs/...` on the Vercel preview. `/developers/...` is the production proxy path on `tempo.xyz`, not the preview path.

## Why

The TIPs entry previously sent readers to the standalone TIPs site. Current docs had drifted back to a local TIPs page, so direct visits to `/developers/docs/protocol/tips` no longer behaved like the old redirect.

## Validation

- Replaced the React hook redirect with plain HTML refresh/script tags so the stale route can render server-side before redirecting.
- Reviewed the PR diff against `main`; only the protocol overview card and TIPs page changed.
