### PR TITLE
fix: guard client-routed blog links

### DIFF
--- a/src/marketing/next-shims.test.ts
+++ b/src/marketing/next-shims.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { isClientRoutedBlogHref } from './next-shims'
+
+describe('isClientRoutedBlogHref', () => {
+  it.each([
+    undefined,
+    null,
+    '',
+    '/docs',
+    '/developers/docs',
+    'https://tempo.xyz/developers/blog',
+  ])('returns false for %j', (href) => {
+    expect(isClientRoutedBlogHref(href)).toBe(false)
+  })
+
+  it.each([
+    '/blog',
+    '/blog/t7-network-upgrade',
+    '/developers/blog',
+    '/developers/blog/t7-network-upgrade',
+  ])('recognizes %s as a client-routed blog path', (href) => {
+    expect(isClientRoutedBlogHref(href)).toBe(true)
+  })
+})

--- a/src/marketing/next-shims.tsx
+++ b/src/marketing/next-shims.tsx
@@ -10,15 +10,15 @@ import { unstable_RouterContext as WakuRouterContext } from 'waku/router/client'
 export type Metadata = Record<string, unknown>
 
 type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
-  href: string
+  href?: string
   children?: ReactNode
 }
 
 const prefetchedPaths = new Set<string>()
 
-function prefetchPath(href: string) {
+function prefetchPath(href: unknown) {
   if (typeof document === 'undefined') return
-  if (!href.startsWith('/') || prefetchedPaths.has(href)) return
+  if (typeof href !== 'string' || !href.startsWith('/') || prefetchedPaths.has(href)) return
   prefetchedPaths.add(href)
 
   const link = document.createElement('link')
@@ -28,7 +28,9 @@ function prefetchPath(href: string) {
   document.head.appendChild(link)
 }
 
-function isClientRoutedBlogHref(href: string) {
+export function isClientRoutedBlogHref(href: unknown): href is string {
+  if (typeof href !== 'string') return false
+
   return (
     href === '/blog' ||
     href.startsWith('/blog/') ||


### PR DESCRIPTION
## Motivation

Prevent an undefined link target from crashing the developers landing page during client hydration.

## Summary

- Guard blog-route and prefetch checks against missing or non-string `href` values.
- Add regression coverage for missing, invalid, and valid blog link targets.

## Key design considerations

- Treat invalid link targets as ordinary anchors instead of routing them through Waku.
- Keep valid `/blog` and `/developers/blog` links client-routed.