### PR TITLE
fix(marketing): normalize developers pathname

### DIFF
--- a/src/marketing/next-shims.test.ts
+++ b/src/marketing/next-shims.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isClientRoutedBlogHref } from './next-shims'
+import { isClientRoutedBlogHref, normalizeMarketingPathname } from './next-shims'
 
 describe('isClientRoutedBlogHref', () => {
   it.each([
@@ -20,5 +20,18 @@ describe('isClientRoutedBlogHref', () => {
     '/developers/blog/t7-network-upgrade',
   ])('recognizes %s as a client-routed blog path', (href) => {
     expect(isClientRoutedBlogHref(href)).toBe(true)
+  })
+})
+
+describe('normalizeMarketingPathname', () => {
+  it.each([
+    ['/developers', '/'],
+    ['/developers/', '/'],
+    ['/developers/build', '/build'],
+    ['/developers/blog/t7-network-upgrade', '/blog/t7-network-upgrade'],
+    ['/', '/'],
+    ['/blog', '/blog'],
+  ])('normalizes %s to %s', (pathname, expected) => {
+    expect(normalizeMarketingPathname(pathname)).toBe(expected)
   })
 })

--- a/src/marketing/next-shims.tsx
+++ b/src/marketing/next-shims.tsx
@@ -92,8 +92,14 @@ export function Image({ priority: _priority, fill: _fill, alt, ...props }: Image
   return <img alt={alt} {...props} />
 }
 
+export function normalizeMarketingPathname(pathname: string) {
+  if (pathname === '/developers') return '/'
+  if (pathname.startsWith('/developers/')) return pathname.slice('/developers'.length)
+  return pathname
+}
+
 export function usePathname() {
-  return typeof window === 'undefined' ? '/' : window.location.pathname
+  return typeof window === 'undefined' ? '/' : normalizeMarketingPathname(window.location.pathname)
 }
 
 export function notFound(): never {


### PR DESCRIPTION
## Summary
- normalize the public `/developers` prefix before marketing header pathname matching
- keep server and client active-navigation markup identical during hydration
- add regression coverage for proxied and direct marketing paths

## Validation
- `VITE_USE_HTTP=true pnpm exec vitest run src/marketing/next-shims.test.ts`
- `pnpm exec biome check src/marketing/next-shims.tsx src/marketing/next-shims.test.ts`
- `pnpm build`
- Playwright against a local `/developers` reverse-proxy topology: no React hydration error

Prompted by: @letstokenize
