### PR TITLE
docs: update T7 post-launch fee wording

### DIFF
--- a/blogs/t7-network-upgrade.md
+++ b/blogs/t7-network-upgrade.md
@@ -15,7 +15,7 @@ T7 replaces Tempo's fixed base fee with a bounded dynamic base fee. The new cap 
 
 *T7 keeps a hard cap on the base fee while allowing lower fees during off-peak periods.*
 
-As an example, the typical gas for a TIP-20 token transfer between two existing users (~50,000 gas) now costs about $0.0006 at the new cap and about $0.00003 at the quiet-period floor, compared to $0.001 today. At the floor, that transfer is therefore about 33x cheaper than today's fixed fee.
+As an example, a typical TIP-20 token transfer between two existing users (~50,000 gas) now costs about $0.0006 at the new cap and about $0.00003 at the quiet-period floor, compared with the old fixed fee of $0.001. At the floor, that transfer is about 33x cheaper than the old fixed fee.
 
 ![A diagram showing the base fee falling when block usage is below target and rising back toward the cap as usage increases.](/blog/t7-dynamic-base-fee-response.svg)
 


### PR DESCRIPTION
## Summary
- replace pre-launch “today” fee comparisons with the old fixed fee
- use post-launch phrasing in the TIP-20 transfer example

## Validation
- `git diff --check`

Prompted by: @juandolealt