### PR TITLE
Unify Tempo entity metadata across developer pages

### DIFF
--- a/e2e/seo-head.test.ts
+++ b/e2e/seo-head.test.ts
@@ -40,9 +40,9 @@ const cases: {
 }[] = [
   {
     path: '/',
-    title: 'Tempo',
-    ogTitle: 'Tempo',
-    descriptionIncludes: 'blockchain designed for payments',
+    title: 'Tempo developers',
+    ogTitle: 'Tempo developers',
+    descriptionIncludes: 'payments-first Layer 1 blockchain',
     ogImageIncludes: '/og-docs.png',
   },
   {

--- a/src/components/DocsJsonLd.test.tsx
+++ b/src/components/DocsJsonLd.test.tsx
@@ -1,23 +1,77 @@
 import { describe, expect, it } from 'vitest'
-import { createDocsJsonLdSchema, serializeJsonLd } from './DocsJsonLd'
+import { serializeJsonLd } from '../lib/tempo-entity'
+import { createDocsJsonLdSchema } from './DocsJsonLd'
 
 function techArticle(schema: ReturnType<typeof createDocsJsonLdSchema>) {
-  const article = schema['@graph'].find((entry) => entry['@type'] === 'TechArticle')
+  const article = schema['@graph'].find((entry) => {
+    const type = entry['@type']
+    return type === 'TechArticle' || (Array.isArray(type) && type.includes('TechArticle'))
+  })
   if (!article) throw new Error('TechArticle schema is missing')
   return article
 }
 
 describe('DocsJsonLd', () => {
   it.each([
-    ['/docs', 'https://docs.tempo.xyz/docs'],
-    ['docs/api', 'https://docs.tempo.xyz/docs/api'],
-    ['/docs/quickstart/integrate-tempo', 'https://docs.tempo.xyz/docs/quickstart/integrate-tempo'],
+    ['/docs', 'https://tempo.xyz/developers/docs'],
+    ['docs/api', 'https://tempo.xyz/developers/docs/api'],
+    [
+      '/docs/quickstart/integrate-tempo',
+      'https://tempo.xyz/developers/docs/quickstart/integrate-tempo',
+    ],
   ])('uses the page path in TechArticle URLs', (path, url) => {
     const article = techArticle(createDocsJsonLdSchema({ path }))
 
     expect(article).toMatchObject({
       '@id': url,
       url,
+      isPartOf: { '@id': 'https://tempo.xyz/#website' },
+      about: { '@id': 'https://tempo.xyz/#organization' },
+    })
+  })
+
+  it('uses page metadata and the canonical Tempo entity graph', () => {
+    const schema = createDocsJsonLdSchema({
+      path: '/docs/api',
+      title: 'Tempo API',
+      description: 'API reference for Tempo developers.',
+    })
+    const article = techArticle(schema)
+    const website = schema['@graph'].find((entry) => entry['@type'] === 'WebSite')
+    const organization = schema['@graph'].find((entry) => entry['@type'] === 'Corporation')
+
+    expect(article).toMatchObject({
+      '@type': ['WebPage', 'TechArticle'],
+      name: 'Tempo API',
+      headline: 'Tempo API',
+      description: 'API reference for Tempo developers.',
+    })
+    expect(website).toMatchObject({
+      '@id': 'https://tempo.xyz/#website',
+      name: 'Tempo',
+      alternateName: ['Tempo Blockchain', 'tempo.xyz'],
+      url: 'https://tempo.xyz',
+    })
+    expect(organization).toMatchObject({
+      '@id': 'https://tempo.xyz/#organization',
+      name: 'Tempo',
+      alternateName: ['Tempo Blockchain', 'tempo.xyz'],
+      sameAs: expect.arrayContaining([
+        'https://www.linkedin.com/company/tempo',
+        'https://www.crunchbase.com/organization/tempo-24b7',
+        'https://www.wikidata.org/wiki/Q140472934',
+      ]),
+    })
+  })
+
+  it.each([
+    ['/docs', 'Tempo documentation'],
+    ['/docs/api', 'Tempo API'],
+    ['/docs/guide/payments/send-a-payment', 'Send a payment'],
+  ])('derives a distinct fallback title for %s', (path, title) => {
+    expect(techArticle(createDocsJsonLdSchema({ path }))).toMatchObject({
+      name: title,
+      headline: title,
     })
   })
 

--- a/src/components/DocsJsonLd.tsx
+++ b/src/components/DocsJsonLd.tsx
@@ -1,82 +1,71 @@
 import { useRouter } from 'vocs'
-
-const tempoSameAs = [
-  'https://x.com/tempo',
-  'https://twitter.com/tempo',
-  'https://github.com/tempoxyz',
-  'https://www.linkedin.com/company/tempoxyz',
-  'https://www.crunchbase.com/organization/tempo-87e4',
-]
-
-const tempoKnowsAbout = [
-  'stablecoin payments',
-  'cross-border payments',
-  'global payouts',
-  'agentic payments',
-  'machine payments',
-  'enterprise settlement',
-  'payment blockchains',
-  'Layer 1 blockchain',
-  'stablecoin infrastructure',
-]
-
-const description =
-  'Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Tempo documentation covers stablecoin payments, global payouts, agentic payments, APIs, wallets, and protocol specifications.'
+import {
+  canonicalDevelopersUrl,
+  serializeJsonLd,
+  TEMPO_ENTITY_DESCRIPTION,
+  TEMPO_ORGANIZATION_ID,
+  TEMPO_WEBSITE_ID,
+  tempoOrganizationSchema,
+  tempoWebsiteSchema,
+} from '../lib/tempo-entity'
 
 type DocsJsonLdOptions = {
   path?: string
+  title?: string
+  description?: string
 }
 
 export function createDocsJsonLdSchema(options: DocsJsonLdOptions = {}) {
-  const path = options.path || '/docs'
-  const pathname = path.startsWith('/') ? path : `/${path}`
-  const url = `https://docs.tempo.xyz${pathname}`
+  const url = canonicalDevelopersUrl(options.path || '/docs')
+  const title = options.title || titleFromPath(options.path || '/docs')
+  const description = options.description || TEMPO_ENTITY_DESCRIPTION
 
   return {
     '@context': 'https://schema.org',
     '@graph': [
+      tempoOrganizationSchema(),
+      tempoWebsiteSchema(),
       {
-        '@type': 'Organization',
-        '@id': 'https://tempo.xyz/#organization',
-        name: 'Tempo',
-        url: 'https://tempo.xyz',
-        description,
-        sameAs: tempoSameAs,
-        knowsAbout: tempoKnowsAbout,
-      },
-      {
-        '@type': 'WebSite',
-        '@id': 'https://docs.tempo.xyz/#website',
-        name: 'Tempo Docs',
-        url: 'https://docs.tempo.xyz',
-        description,
-        publisher: { '@id': 'https://tempo.xyz/#organization' },
-      },
-      {
-        '@type': 'TechArticle',
+        '@type': ['WebPage', 'TechArticle'],
         '@id': url,
         url,
-        headline: 'Tempo documentation',
+        name: title,
+        headline: title,
         description,
-        isPartOf: { '@id': 'https://docs.tempo.xyz/#website' },
-        about: { '@id': 'https://tempo.xyz/#organization' },
-        publisher: { '@id': 'https://tempo.xyz/#organization' },
+        isPartOf: { '@id': TEMPO_WEBSITE_ID },
+        about: { '@id': TEMPO_ORGANIZATION_ID },
+        publisher: { '@id': TEMPO_ORGANIZATION_ID },
       },
     ],
   }
 }
 
-export function serializeJsonLd(schema: unknown) {
-  return JSON.stringify(schema)
-    .replace(/</g, '\\u003c')
-    .replace(/>/g, '\\u003e')
-    .replace(/&/g, '\\u0026')
+function titleFromPath(path: string) {
+  const segment = path.split('/').filter(Boolean).at(-1)
+  if (!segment || segment === 'docs') return 'Tempo documentation'
+
+  const labels: Record<string, string> = {
+    api: 'Tempo API',
+    cli: 'Tempo CLI',
+    rpc: 'RPC',
+    sdk: 'Tempo SDKs',
+    tip20: 'TIP-20',
+    tip403: 'TIP-403',
+  }
+  if (labels[segment]) return labels[segment]
+
+  return segment
+    .split('-')
+    .map((word, index) => (index === 0 ? `${word[0]?.toUpperCase() ?? ''}${word.slice(1)}` : word))
+    .join(' ')
 }
 
-export default function DocsJsonLd(props: { path?: string }) {
+export default function DocsJsonLd(props: { path?: string; title?: string; description?: string }) {
   const { path } = useRouter()
   const schema = createDocsJsonLdSchema({
     path: props.path ?? path,
+    title: props.title,
+    description: props.description,
   })
 
   return (

--- a/src/components/MarketingJsonLd.test.tsx
+++ b/src/components/MarketingJsonLd.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { createMarketingJsonLdSchema } from './MarketingJsonLd'
+
+describe('MarketingJsonLd', () => {
+  it.each([
+    ['/', 'https://tempo.xyz/developers/'],
+    ['/build', 'https://tempo.xyz/developers/build'],
+  ])('uses the canonical developer URL for %s', (route, url) => {
+    const schema = createMarketingJsonLdSchema({
+      route,
+      title: 'Tempo developers',
+      description: 'Developer resources for Tempo.',
+    })
+    const page = schema['@graph'].find((entry) => entry['@type'] === 'WebPage')
+
+    expect(page).toMatchObject({
+      '@id': url,
+      url,
+      name: 'Tempo developers',
+      description: 'Developer resources for Tempo.',
+      isPartOf: { '@id': 'https://tempo.xyz/#website' },
+      about: { '@id': 'https://tempo.xyz/#organization' },
+      publisher: { '@id': 'https://tempo.xyz/#organization' },
+    })
+  })
+})

--- a/src/components/MarketingJsonLd.tsx
+++ b/src/components/MarketingJsonLd.tsx
@@ -1,0 +1,46 @@
+import {
+  canonicalDevelopersUrl,
+  serializeJsonLd,
+  TEMPO_ORGANIZATION_ID,
+  TEMPO_WEBSITE_ID,
+  tempoOrganizationSchema,
+  tempoWebsiteSchema,
+} from '../lib/tempo-entity'
+
+type MarketingJsonLdOptions = {
+  route: string
+  title: string
+  description: string
+}
+
+export function createMarketingJsonLdSchema(options: MarketingJsonLdOptions) {
+  const url = canonicalDevelopersUrl(options.route)
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      tempoOrganizationSchema(),
+      tempoWebsiteSchema(),
+      {
+        '@type': 'WebPage',
+        '@id': url,
+        url,
+        name: options.title,
+        description: options.description,
+        isPartOf: { '@id': TEMPO_WEBSITE_ID },
+        about: { '@id': TEMPO_ORGANIZATION_ID },
+        publisher: { '@id': TEMPO_ORGANIZATION_ID },
+      },
+    ],
+  }
+}
+
+export default function MarketingJsonLd(options: MarketingJsonLdOptions) {
+  return (
+    <script
+      type="application/ld+json"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD requires innerHTML; content is escaped above.
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(createMarketingJsonLdSchema(options)) }}
+    />
+  )
+}

--- a/src/components/PageHead.tsx
+++ b/src/components/PageHead.tsx
@@ -29,6 +29,7 @@ export default function PageHead({
   return (
     <MdxPageContextProvider frontmatter={{ title, description }}>
       <Head />
+      <meta property="og:site_name" content="Tempo" />
       <meta property="og:image:alt" content={title} />
       {children}
     </MdxPageContextProvider>

--- a/src/lib/tempo-entity.ts
+++ b/src/lib/tempo-entity.ts
@@ -1,0 +1,75 @@
+export const TEMPO_ORIGIN = 'https://tempo.xyz'
+export const TEMPO_DEVELOPERS_ORIGIN = `${TEMPO_ORIGIN}/developers`
+export const TEMPO_ORGANIZATION_ID = `${TEMPO_ORIGIN}/#organization`
+export const TEMPO_WEBSITE_ID = `${TEMPO_ORIGIN}/#website`
+
+export const TEMPO_ENTITY_DESCRIPTION =
+  'Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Tempo is built for stablecoin payments, global payouts, agentic payments, and enterprise settlement.'
+
+export const TEMPO_ALTERNATE_NAMES = ['Tempo Blockchain', 'tempo.xyz']
+
+export const TEMPO_SAME_AS = [
+  'https://x.com/tempo',
+  'https://twitter.com/tempo',
+  'https://github.com/tempoxyz',
+  'https://www.linkedin.com/company/tempo',
+  'https://www.crunchbase.com/organization/tempo-24b7',
+  'https://www.wikidata.org/wiki/Q140472934',
+]
+
+export const TEMPO_KNOWS_ABOUT = [
+  'stablecoin payments',
+  'cross-border payments',
+  'global payouts',
+  'agentic payments',
+  'machine payments',
+  'enterprise settlement',
+  'payment blockchains',
+  'Layer 1 blockchain',
+  'stablecoin infrastructure',
+]
+
+export function canonicalDevelopersUrl(path = '/') {
+  const pathname = path.startsWith('/') ? path : `/${path}`
+  return pathname === '/' ? `${TEMPO_DEVELOPERS_ORIGIN}/` : `${TEMPO_DEVELOPERS_ORIGIN}${pathname}`
+}
+
+export function tempoOrganizationSchema() {
+  return {
+    '@type': 'Corporation',
+    '@id': TEMPO_ORGANIZATION_ID,
+    name: 'Tempo',
+    alternateName: TEMPO_ALTERNATE_NAMES,
+    url: TEMPO_ORIGIN,
+    logo: {
+      '@type': 'ImageObject',
+      '@id': `${TEMPO_ORIGIN}/#logo`,
+      url: `${TEMPO_ORIGIN}/apple-touch-icon.png`,
+      contentUrl: `${TEMPO_ORIGIN}/apple-touch-icon.png`,
+      width: 180,
+      height: 180,
+    },
+    description: TEMPO_ENTITY_DESCRIPTION,
+    sameAs: TEMPO_SAME_AS,
+    knowsAbout: TEMPO_KNOWS_ABOUT,
+  }
+}
+
+export function tempoWebsiteSchema() {
+  return {
+    '@type': 'WebSite',
+    '@id': TEMPO_WEBSITE_ID,
+    name: 'Tempo',
+    alternateName: TEMPO_ALTERNATE_NAMES,
+    url: TEMPO_ORIGIN,
+    description: TEMPO_ENTITY_DESCRIPTION,
+    publisher: { '@id': TEMPO_ORGANIZATION_ID },
+  }
+}
+
+export function serializeJsonLd(schema: unknown) {
+  return JSON.stringify(schema)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+}

--- a/src/marketing/MarketingRoute.tsx
+++ b/src/marketing/MarketingRoute.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { lazy, type ReactNode, Suspense, useEffect, useState } from 'react'
+import MarketingJsonLd from '../components/MarketingJsonLd'
 import PageHead from '../components/PageHead'
 import { type RouteMetadata, routeMetadata } from './routeMetadata'
 
@@ -100,6 +101,11 @@ export default function MarketingRoute({
   return (
     <>
       <PageHead title={resolvedMetadata.title} description={resolvedMetadata.description}>
+        <MarketingJsonLd
+          route={route}
+          title={resolvedMetadata.title}
+          description={resolvedMetadata.description}
+        />
         {head}
       </PageHead>
       {children}

--- a/src/marketing/index.html
+++ b/src/marketing/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tempo</title>
-    <meta name="description" content="The only blockchain designed for payments. Sub-second transactions, sub-cent fees." />
+    <title>Tempo developers</title>
+    <meta name="description" content="Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Explore APIs, SDKs, wallets, and protocol documentation." />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Tempo" />
+    <meta property="og:title" content="Tempo developers" />
     <meta property="og:site_name" content="Tempo" />
-    <meta property="og:description" content="The only blockchain designed for payments. Sub-second transactions, sub-cent fees." />
-    <meta property="og:image" content="/api/og?title=Tempo&description=The%20only%20blockchain%20designed%20for%20payments.%20Sub-second%20transactions%2C%20sub-cent%20fees.&section=BUILD&v=2" />
+    <meta property="og:description" content="Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Explore APIs, SDKs, wallets, and protocol documentation." />
+    <meta property="og:image" content="/api/og?title=Tempo%20developers&section=BUILD&v=2" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Tempo" />
-    <meta name="twitter:description" content="The only blockchain designed for payments. Sub-second transactions, sub-cent fees." />
-    <meta property="twitter:image" content="/api/og?title=Tempo&description=The%20only%20blockchain%20designed%20for%20payments.%20Sub-second%20transactions%2C%20sub-cent%20fees.&section=BUILD&v=2" />
+    <meta name="twitter:title" content="Tempo developers" />
+    <meta name="twitter:description" content="Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Explore APIs, SDKs, wallets, and protocol documentation." />
+    <meta property="twitter:image" content="/api/og?title=Tempo%20developers&section=BUILD&v=2" />
     <link rel="icon" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)" type="image/svg+xml" />
     <link rel="icon" href="/favicon-light.svg" media="(prefers-color-scheme: light)" type="image/svg+xml" />
     <link rel="preload" href="/fonts/pilat/Pilat-Book.woff2" as="font" type="font/woff2" crossorigin />

--- a/src/marketing/routeMetadata.ts
+++ b/src/marketing/routeMetadata.ts
@@ -6,9 +6,9 @@ export type RouteMetadata = { title: string; description: string }
 
 export const routeMetadata: Record<string, RouteMetadata> = {
   '/': {
-    title: 'Tempo',
+    title: 'Tempo developers',
     description:
-      'The only blockchain designed for payments. Sub-second transactions, sub-cent fees.',
+      'Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Explore APIs, SDKs, wallets, and protocol documentation.',
   },
   '/build': {
     title: 'Build on Tempo',


### PR DESCRIPTION
## Why

The developer and documentation site was publishing a separate `Tempo Docs` website entity on `docs.tempo.xyz`, while production pages canonicalize to `tempo.xyz/developers`. It also referenced stale LinkedIn and Crunchbase profiles. That can fragment Tempo's entity signals across the web and developer properties.

## What

- Use the canonical `tempo.xyz` organization and website IDs across developer and documentation pages
- Emit canonical `tempo.xyz/developers` URLs for page-level structured data
- Add Tempo organization, website, and web page JSON-LD to developer marketing routes
- Align alternate names, social profiles, Crunchbase, and Wikidata with tempo.xyz
- Replace retired developer homepage metadata with approved payments-first language
- Add distinct fallback titles for documentation and API pages
- Add regression coverage for canonical URLs and entity relationships

## Validation

- `pnpm test`, 138 tests passed
- `pnpm check:types`
- `CI=true pnpm build`
- `CI=true pnpm exec playwright test e2e/seo-head.test.ts`, 8 tests passed
- Biome check on touched TypeScript files