### PR TITLE
Redirect next.docs.tempo.xyz to canonical developer docs

### DIFF
--- a/src/lib/docs-routing.test.ts
+++ b/src/lib/docs-routing.test.ts
@@ -20,86 +20,98 @@ function findRedirect(source: string) {
   return redirects.find((redirect) => redirect.source === source)
 }
 
+function matchesHostCondition(redirect: Redirect, host: string) {
+  return (
+    Array.isArray(redirect.has) &&
+    redirect.has.some((condition) => {
+      if (
+        typeof condition !== 'object' ||
+        condition === null ||
+        !('type' in condition) ||
+        !('value' in condition) ||
+        condition.type !== 'host' ||
+        typeof condition.value !== 'string'
+      ) {
+        return false
+      }
+
+      return new RegExp(condition.value).test(host)
+    })
+  )
+}
+
 function findHostRedirect(source: string, host: string) {
   return hostRedirects.find(
-    (redirect) =>
-      redirect.source === source &&
-      Array.isArray(redirect.has) &&
-      redirect.has.some(
-        (condition) =>
-          typeof condition === 'object' &&
-          condition !== null &&
-          'type' in condition &&
-          'value' in condition &&
-          condition.type === 'host' &&
-          condition.value === host,
-      ),
+    (redirect) => redirect.source === source && matchesHostCondition(redirect, host),
   )
 }
 
 function findHostRedirectIndex(source: string, host: string) {
   return vercelConfig.redirects.findIndex(
-    (redirect) =>
-      redirect.source === source &&
-      Array.isArray(redirect.has) &&
-      redirect.has.some(
-        (condition) =>
-          typeof condition === 'object' &&
-          condition !== null &&
-          'type' in condition &&
-          'value' in condition &&
-          condition.type === 'host' &&
-          condition.value === host,
-      ),
+    (redirect) => redirect.source === source && matchesHostCondition(redirect, host),
   )
 }
 
 describe('docs routing redirects', () => {
-  it.each([
-    ['/', 'https://tempo.xyz/developers'],
-    ['/developers', 'https://tempo.xyz/developers'],
-    ['/developers/:path*', 'https://tempo.xyz/developers/:path*'],
-    ['/:path*', 'https://tempo.xyz/developers/:path*'],
-  ])('redirects docs.tempo.xyz%s to %s', (source, destination) => {
-    expect(findHostRedirect(source, 'docs.tempo.xyz')).toMatchObject({
-      source,
-      destination,
-      permanent: true,
+  describe.each(['docs.tempo.xyz', 'next.docs.tempo.xyz'])('canonical redirects for %s', (host) => {
+    it.each([
+      ['/', 'https://tempo.xyz/developers'],
+      ['/developers', 'https://tempo.xyz/developers'],
+      ['/developers/:path*', 'https://tempo.xyz/developers/:path*'],
+      ['/:path*', 'https://tempo.xyz/developers/:path*'],
+    ])('redirects %s to %s', (source, destination) => {
+      expect(findHostRedirect(source, host)).toMatchObject({
+        source,
+        destination,
+        permanent: true,
+      })
+    })
+
+    it.each([
+      ['/guide/bridge-usdc-stargate', 'https://tempo.xyz/developers/docs/guide/bridge-layerzero'],
+      ['/guide/bridge-usdc-relay', 'https://tempo.xyz/developers/docs/guide/bridge-relay'],
+      [
+        '/guide/node/validator-config-v2',
+        'https://tempo.xyz/developers/docs/guide/node/network-upgrades',
+      ],
+      [
+        '/AccountKeychain',
+        'https://tempo.xyz/developers/docs/protocol/transactions/AccountKeychain',
+      ],
+      ['/developer-tools', 'https://tempo.xyz/developers/docs/ecosystem'],
+      ['/learn/partners', 'https://tempo.xyz/developers/docs/partners'],
+      ['/docs/learn/partners', 'https://tempo.xyz/developers/docs/partners'],
+      ['/docs/guide/using-tempo-with-ai/partners', 'https://tempo.xyz/developers/docs/partners'],
+      ['/build/partners', 'https://tempo.xyz/developers/docs/partners'],
+      ['/network-upgrades', 'https://tempo.xyz/developers/docs/guide/node/network-upgrades'],
+      [
+        '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|hosted-services|changelog|partners)',
+        'https://tempo.xyz/developers/docs/:section',
+      ],
+      [
+        '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|developer-tools|hosted-services)/:path*',
+        'https://tempo.xyz/developers/docs/:section/:path*',
+      ],
+    ])('redirects legacy route %s to %s before the host catch-all', (source, destination) => {
+      expect(findHostRedirect(source, host)).toMatchObject({
+        source,
+        destination,
+        permanent: true,
+      })
+
+      expect(findHostRedirectIndex(source, host)).toBeLessThan(
+        findHostRedirectIndex('/:path*', host),
+      )
     })
   })
 
   it.each([
-    ['/guide/bridge-usdc-stargate', 'https://tempo.xyz/developers/docs/guide/bridge-layerzero'],
-    ['/guide/bridge-usdc-relay', 'https://tempo.xyz/developers/docs/guide/bridge-relay'],
-    [
-      '/guide/node/validator-config-v2',
-      'https://tempo.xyz/developers/docs/guide/node/network-upgrades',
-    ],
-    ['/AccountKeychain', 'https://tempo.xyz/developers/docs/protocol/transactions/AccountKeychain'],
-    ['/developer-tools', 'https://tempo.xyz/developers/docs/ecosystem'],
-    ['/learn/partners', 'https://tempo.xyz/developers/docs/partners'],
-    ['/docs/learn/partners', 'https://tempo.xyz/developers/docs/partners'],
-    ['/docs/guide/using-tempo-with-ai/partners', 'https://tempo.xyz/developers/docs/partners'],
-    ['/build/partners', 'https://tempo.xyz/developers/docs/partners'],
-    ['/network-upgrades', 'https://tempo.xyz/developers/docs/guide/node/network-upgrades'],
-    [
-      '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|hosted-services|changelog|partners)',
-      'https://tempo.xyz/developers/docs/:section',
-    ],
-    [
-      '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|developer-tools|hosted-services)/:path*',
-      'https://tempo.xyz/developers/docs/:section/:path*',
-    ],
-  ])('redirects legacy docs host %s to %s before the host catch-all', (source, destination) => {
-    expect(findHostRedirect(source, 'docs.tempo.xyz')).toMatchObject({
-      source,
-      destination,
-      permanent: true,
-    })
-
-    expect(findHostRedirectIndex(source, 'docs.tempo.xyz')).toBeLessThan(
-      findHostRedirectIndex('/:path*', 'docs.tempo.xyz'),
-    )
+    '/',
+    '/developers',
+    '/developers/:path*',
+    '/:path*',
+  ])('does not redirect developers.tempo.xyz%s to avoid proxy loops', (source) => {
+    expect(findHostRedirect(source, 'developers.tempo.xyz')).toBeUndefined()
   })
 
   it.each([

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers",
@@ -16,7 +16,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers",
@@ -27,7 +27,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/:path*",
@@ -38,7 +38,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/guide/bridge-layerzero",
@@ -49,7 +49,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/guide/bridge-relay",
@@ -60,7 +60,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/guide/node/network-upgrades",
@@ -71,7 +71,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/protocol/transactions/AccountKeychain",
@@ -82,7 +82,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/ecosystem",
@@ -93,7 +93,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/partners",
@@ -104,7 +104,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/partners",
@@ -115,7 +115,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/partners",
@@ -126,7 +126,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/partners",
@@ -137,7 +137,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/guide/node/network-upgrades",
@@ -148,7 +148,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/:section",
@@ -159,7 +159,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/docs/:section/:path*",
@@ -170,7 +170,7 @@
       "has": [
         {
           "type": "host",
-          "value": "docs.tempo.xyz"
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
         }
       ],
       "destination": "https://tempo.xyz/developers/:path*",


### PR DESCRIPTION
## What changed

- Extend the existing permanent docs-host redirect rules to match `next.docs.tempo.xyz`.
- Preserve the existing canonical path mappings, including legacy docs routes.
- Add routing coverage for both docs hosts and a regression assertion that `developers.tempo.xyz` never matches.

## Why

`next.docs.tempo.xyz` currently serves an indexable duplicate site. Its homepage returns 200 with `index, follow`, and its canonical URL and sitemap point to a Vercel preview deployment. Permanent redirects consolidate those URLs under `https://tempo.xyz/developers` and prevent the preview host from competing with the canonical Tempo entity.

The proxy origin `developers.tempo.xyz` is deliberately excluded because redirecting it can create a loop through the tempo-web proxy.

## Validation

- `CI=true pnpm exec vitest run src/lib/docs-routing.test.ts` (54 tests passed)
- `pnpm check:types`
- `CI=true pnpm build` (425 files generated)
- `pnpm exec biome check src/lib/docs-routing.test.ts vercel.json`
