### PR TITLE
fix(docs): preserve receive policies links

### DIFF
--- a/blogs/t6.md
+++ b/blogs/t6.md
@@ -45,11 +45,11 @@ A platform can configure deposit addresses to accept only the stablecoins it sup
 
 A regulated business can define which addresses are allowed to send to an account. This gives compliance and operations teams a protocol-native control for inbound payments, rather than relying only on monitoring after funds have already arrived.
 
-Read the [specification](https://tips.sh/1028), [learn more in the docs](/docs/learn/tempo/receive-policies#account-level-receive-policies), and [try the demo](https://tempo.xyz/receive-policies).
+Read the [specification](https://tips.sh/1028), [learn more in the docs](/docs/guide/payments/configure-receive-policies), and [try the demo](https://tempo.xyz/receive-policies).
 
 ## Admin access keys
 
-[Access keys](/docs/protocol/transactions#access-keys) on Tempo let users and applications authorize limited actions. They are useful for subscriptions, delegated payments, automated operations, and other flows where a narrowly scoped key is safer than using the root key directly.
+[Access keys](/docs/protocol/transactions/AccountKeychain#access-keys) on Tempo let users and applications authorize limited actions. They are useful for subscriptions, delegated payments, automated operations, and other flows where a narrowly scoped key is safer than using the root key directly.
 
 Without admin access keys, key management itself depends on the root key. Admin access keys change that: an account can designate certain access keys as administrators, and those keys can authorize and revoke other keys on the account's behalf. This separates account ownership from day-to-day key administration:
 
@@ -63,7 +63,7 @@ Without admin access keys, key management itself depends on the root key. Admin 
 
 T6 also gives contracts a canonical way to verify key status. `verifyKeychain` confirms whether a signature came from an active key on an account, and `verifyKeychainAdmin` confirms whether it came from the root key or an admin key. This gives builders an out-of-the-box, safe primitive for authorization instead of requiring every contract to rebuild key-status checks. Note that `verifyKeychainAdmin` does not bind the account into the signed digest, so callers should include a replay domain such as chain ID, contract address, and account address in the message they ask a key to sign.
 
-Read the [specification](https://tips.sh/1049) and [learn more in the docs](/docs/protocol/transactions#access-keys).
+Read the [specification](https://tips.sh/1049) and [learn more in the docs](/docs/protocol/transactions/AccountKeychain#access-keys).
 
 ## What integrators should know
 
@@ -74,8 +74,8 @@ See the [v1.9.1 release](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) 
 ## Resources
 
 - [T6 upgrade docs](/docs/protocol/upgrades/t6)
-- [Receive policies overview](/docs/learn/tempo/receive-policies#account-level-receive-policies)
-- [Access keys](/docs/protocol/transactions#access-keys)
+- [Receive policies overview](/docs/guide/payments/configure-receive-policies)
+- [Access keys](/docs/protocol/transactions/AccountKeychain#access-keys)
 - [Receive policies specification](https://tips.sh/1028)
 - [Admin access keys specification](https://tips.sh/1049)
 - [Receive policies demo](https://tempo.xyz/receive-policies)

--- a/src/lib/docs-routing.ts
+++ b/src/lib/docs-routing.ts
@@ -61,6 +61,10 @@ export const proxiedLegacyDocsRoutes = [
     destination: '/docs/server/relay-handler',
   },
   {
+    source: '/docs/learn/tempo/receive-policies',
+    destination: '/docs/guide/payments/configure-receive-policies',
+  },
+  {
     source: '/learn/tempo/receive-policies',
     destination: '/docs/guide/payments/configure-receive-policies',
   },
@@ -187,6 +191,10 @@ export const legacyDocsHostRoutes = [
     destination: `${canonicalDevelopersOrigin}/docs/server/relay-handler`,
   },
   {
+    source: '/docs/learn/tempo/receive-policies',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/payments/configure-receive-policies`,
+  },
+  {
     source: '/learn/tempo/receive-policies',
     destination: `${canonicalDevelopersOrigin}/docs/guide/payments/configure-receive-policies`,
   },
@@ -245,6 +253,11 @@ export const routingSmokeCases = {
       expectedFinalStatus: 200,
     },
     {
+      path: '/developers/docs/learn/tempo/receive-policies',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/guide/payments/configure-receive-policies`,
+      expectedFinalStatus: 200,
+    },
+    {
       path: '/developers/learn/use-cases/payroll',
       expectedLocation: 'https://tempo.xyz/learn/stablecoin-payroll/',
       expectedFinalStatus: 200,
@@ -275,6 +288,11 @@ export const routingSmokeCases = {
     {
       path: '/accounts/server/handler.relay',
       expectedLocation: `${canonicalDevelopersOrigin}/docs/server/relay-handler`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/docs/learn/tempo/receive-policies',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/guide/payments/configure-receive-policies`,
       expectedFinalStatus: 200,
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -336,6 +336,17 @@
       "permanent": true
     },
     {
+      "source": "/docs/learn/tempo/receive-policies",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/payments/configure-receive-policies",
+      "permanent": true
+    },
+    {
       "source": "/learn/tempo/receive-policies",
       "has": [
         {
@@ -794,6 +805,11 @@
     {
       "source": "/developers/accounts/server/handler.relay",
       "destination": "/developers/docs/server/relay-handler",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/learn/tempo/receive-policies",
+      "destination": "/developers/docs/guide/payments/configure-receive-policies",
       "permanent": true
     },
     {


### PR DESCRIPTION
## Summary

- Point the T6 article at the canonical receive-policy guide and the actual AccountKeychain access-key anchor.
- Add the retired `/docs/learn/tempo/receive-policies` path to the shared routing contract for both the legacy docs host and the `/developers` proxy.
- Keep legacy requests on a single redirect to `/docs/guide/payments/configure-receive-policies` instead of relying on the existing multi-hop fallback chain.

## Test plan

- `CI=true corepack pnpm test` (360 tests)
- `CI=true corepack pnpm run check:anchors` (236 links across 196 pages)
- `CI=true corepack pnpm run check:types`
- `CI=true corepack pnpm exec biome check blogs/t6.md src/lib/docs-routing.ts vercel.json`
- `NODE_OPTIONS=--max-old-space-size=8192 CI=true corepack pnpm run build`
- `CI=true corepack pnpm run check:markdown`
- `git diff --check`
