### PR TITLE
fix(performance): use production default benchmark feed

### DIFF
--- a/src/marketing/app/_components/stats.ts
+++ b/src/marketing/app/_components/stats.ts
@@ -57,10 +57,9 @@ export function statValue(stat: Stat): string {
   return stat.main.unit ? `${stat.main.value} ${stat.main.unit}` : stat.main.value
 }
 
-// Nightly TIP-20 benchmark runs. PR-preview deployment for now — swap for the
-// production URL when it lands.
+// Latest nightly default TIP-20 benchmark run from the production perf API.
 const PERF_API_URL =
-  'https://pr-77-tempo-apps-internal-perf-public.tempo-dev.workers.dev/api/perf/runs?feed=nightly&limit=1&scenario_id=tip20-50k'
+  'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=1&scenario_id=default-50k'
 
 type PerfRuns = {
   runs?: {

--- a/src/marketing/app/_components/stats.ts
+++ b/src/marketing/app/_components/stats.ts
@@ -59,7 +59,7 @@ export function statValue(stat: Stat): string {
 
 // Latest nightly default TIP-20 benchmark run from the production perf API.
 const PERF_API_URL =
-  'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=1&scenario_id=default-50k'
+  'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=1&scenario_id=tip20-50k'
 
 type PerfRuns = {
   runs?: {

--- a/src/marketing/app/performance/_lib/runs.ts
+++ b/src/marketing/app/performance/_lib/runs.ts
@@ -3,7 +3,7 @@
 // this module fetches the whole feed for the /performance charts.
 
 const PERF_API_URL =
-  'https://pr-77-tempo-apps-internal-perf-public.tempo-dev.workers.dev/api/perf/runs?feed=nightly&limit=100'
+  'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=100&scenario_id=default-50k'
 
 type ApiRun = {
   id?: string

--- a/src/marketing/app/performance/_lib/runs.ts
+++ b/src/marketing/app/performance/_lib/runs.ts
@@ -3,7 +3,7 @@
 // this module fetches the whole feed for the /performance charts.
 
 const PERF_API_URL =
-  'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=100&scenario_id=default-50k'
+  'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=100&scenario_id=tip20-50k'
 
 type ApiRun = {
   id?: string


### PR DESCRIPTION
## Summary
- replace the hardcoded PR #77 perf API endpoints with `https://perf.tempo.xyz`
- filter both the performance chart and homepage stats to the canonical `tip20-50k` series

## Dependency and merge order
- depends on tempoxyz/tempo-apps-internal#122
- #122 merges legacy `tip20-50k` and renamed `default`/`default-50k` runs into one continuous TIP-20 history
- merge and deploy #122 first, verify the production API, then merge this PR

## Validation
- `pnpm check:types`
- `pnpm check` (passes with 8 pre-existing warnings)

Prompted by: @emmajam