### PR TITLE
fix: use root-relative marketing links on previews

### DIFF
--- a/src/marketing/app/_lib/developersPaths.test.ts
+++ b/src/marketing/app/_lib/developersPaths.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('developersPath', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('uses root-relative paths outside production deployments', async () => {
+    vi.stubEnv('VERCEL_ENV', 'preview')
+    const { developersPath } = await import('./developersPaths')
+
+    expect(developersPath('/')).toBe('/')
+    expect(developersPath('/docs')).toBe('/docs')
+    expect(developersPath('/build/tempo-transactions')).toBe('/build/tempo-transactions')
+  })
+
+  it('uses the developers mount in production deployments', async () => {
+    vi.stubEnv('VERCEL_ENV', 'production')
+    const { developersPath } = await import('./developersPaths')
+
+    expect(developersPath('/')).toBe('/developers')
+    expect(developersPath('/docs')).toBe('/developers/docs')
+    expect(developersPath('/build/tempo-transactions')).toBe(
+      '/developers/build/tempo-transactions',
+    )
+  })
+})

--- a/src/marketing/app/_lib/developersPaths.ts
+++ b/src/marketing/app/_lib/developersPaths.ts
@@ -1,6 +1,14 @@
 export const DEVELOPERS_BASE_PATH = '/developers'
 
+function normalizedPath(path: string): string {
+  if (path === '/') return '/'
+  return path.startsWith('/') ? path : `/${path}`
+}
+
 export function developersPath(path: string): string {
-  if (path === '/') return DEVELOPERS_BASE_PATH
-  return `${DEVELOPERS_BASE_PATH}${path.startsWith('/') ? path : `/${path}`}`
+  const normalized = normalizedPath(path)
+
+  if (import.meta.env.VERCEL_ENV !== 'production') return normalized
+  if (normalized === '/') return DEVELOPERS_BASE_PATH
+  return `${DEVELOPERS_BASE_PATH}${normalized}`
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,9 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
+    define: {
+      'import.meta.env.VERCEL_ENV': JSON.stringify(process.env.VERCEL_ENV ?? ''),
+    },
     plugins: [
       blogPostsPlugin(),
       marketingPages(),


### PR DESCRIPTION
## Summary
- make marketing links use root-relative paths on non-production deployments
- keep the /developers mount for production deployments
- add coverage for preview vs production path generation

## Verification
- VITE_USE_HTTP=true pnpm exec vitest run src/marketing/app/_lib/developersPaths.test.ts src/marketing/next-shims.test.ts src/components/DocsHeader.test.ts src/lib/docs-routing.test.ts
- VITE_USE_HTTP=true pnpm exec tsc --noEmit --pretty false --project tsconfig.json
- CI=true VITE_USE_HTTP=true pnpm run build

This PR intentionally does not include the Tempo Accounts destination change from docs#672.