### PR TITLE
fix: exclude `Management API` from API reference

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -205,7 +205,7 @@ export default defineConfig({
     {
       path: '/docs/api',
       spec: 'https://api.tempo.xyz/openapi.json',
-      exclude: ['Platform API'],
+      exclude: ['Management API'],
       sidebar: {
         backLink: false,
         collapsed: true,


### PR DESCRIPTION
Excludes the `Management API` tag group from the generated API reference. The OpenAPI group was renamed from `Platform API`, leaving internal management endpoints visible.