### PR TITLE
Add Envio to Data & Analytics

### DIFF
--- a/src/pages/docs/quickstart/developer-tools.mdx
+++ b/src/pages/docs/quickstart/developer-tools.mdx
@@ -104,7 +104,7 @@ The hosted indexer powers explorer-style reads and supports ClickHouse-backed an
 
 [Envio](https://envio.dev/?utm_source=tempo&utm_medium=partner-docs) is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. Envio supports Tempo through HyperSync, its data engine that serves as the default data source and syncs historical data up to 2000x faster than traditional RPC. Developers can auto-generate an indexer from any verified contract, write event handlers in TypeScript, JavaScript, or ReScript, and query indexed data through GraphQL.
 
-Get started with the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=tempo&utm_medium=partner-docs) and deploy on [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=tempo&utm_medium=partner-docs).
+Get started with the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=tempo&utm_medium=partner-docs) and deploy on [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=tempo&utm_medium=partner-docs). See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=tempo&utm_medium=partner-docs).
 
 ### Allium
 

--- a/src/pages/docs/quickstart/developer-tools.mdx
+++ b/src/pages/docs/quickstart/developer-tools.mdx
@@ -102,7 +102,7 @@ The hosted indexer powers explorer-style reads and supports ClickHouse-backed an
 
 ### Envio
 
-[Envio](https://envio.dev/?utm_source=tempo&utm_medium=partner-docs) is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. Envio supports Tempo through HyperSync, its data engine that serves as the default data source and syncs historical data up to 2000x faster than traditional RPC. Developers can auto-generate an indexer from any verified contract, write event handlers in TypeScript, JavaScript, or ReScript, and query indexed data through GraphQL.
+[Envio](https://envio.dev/?utm_source=tempo&utm_medium=partner-docs) is the data layer for blockchain apps. It gives Tempo developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Envio supports Tempo through HyperSync, its data engine that serves as the default data source and syncs historical data up to 2000x faster than traditional RPC. Developers can auto-generate an indexer from any verified contract, write event handlers in TypeScript, JavaScript, or ReScript, and query indexed data through GraphQL.
 
 Get started with the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=tempo&utm_medium=partner-docs) and deploy on [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=tempo&utm_medium=partner-docs). See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=tempo&utm_medium=partner-docs).
 

--- a/src/pages/docs/quickstart/developer-tools.mdx
+++ b/src/pages/docs/quickstart/developer-tools.mdx
@@ -100,6 +100,12 @@ Get started with the [Squid docs](https://docs.squidrouter.com/) or try the [bri
 
 The hosted indexer powers explorer-style reads and supports ClickHouse-backed analytical queries for expensive reads like holder lists and token activity. Try the [interactive TIDX example](/docs/developer-tools/indexer#interactive-tidx-sql-example) or read the [TIDX README](https://github.com/tempoxyz/tidx) to run your own indexer.
 
+### Envio
+
+[Envio](https://envio.dev/?utm_source=tempo&utm_medium=partner-docs) is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. Envio supports Tempo through HyperSync, its data engine that serves as the default data source and syncs historical data up to 2000x faster than traditional RPC. Developers can auto-generate an indexer from any verified contract, write event handlers in TypeScript, JavaScript, or ReScript, and query indexed data through GraphQL.
+
+Get started with the [HyperIndex quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=tempo&utm_medium=partner-docs) and deploy on [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service?utm_source=tempo&utm_medium=partner-docs).
+
 ### Allium
 
 [Allium](https://www.allium.so) is an enterprise blockchain data platform that delivers real-time, analytics-ready datasets through a unified schema across chains. Developers can fetch wallet, token, and price data in milliseconds without managing infrastructure, decoding raw data, or inferring transactions—making it easy to focus on building Tempo applications.


### PR DESCRIPTION
Adds Envio to the data indexers listed on this page.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. It indexes Tempo via HyperSync as the default data source.

- Website: https://envio.dev
- Docs: https://docs.envio.dev
- HyperIndex quickstart: https://docs.envio.dev/docs/HyperIndex/quickstart

The entry mirrors the format of the other indexer entries already on the page.
