### PR TITLE
Add Hercle to docs ecosystem

### DIFF
--- a/src/pages/docs/ecosystem/orchestration.mdx
+++ b/src/pages/docs/ecosystem/orchestration.mdx
@@ -37,7 +37,7 @@ Get started with [Bridge's Tempo Integration Guide](https://apidocs.bridge.xyz/g
 
 ## Hercle
 
-[Hercle](https://www.hercle.com/) provides institutional cross-border payment infrastructure connecting fiat, stablecoins, and digital assets. Teams on Tempo can access competitive FX rates in EUR, GBP, and 20+ emerging-market currencies.
+[Hercle](https://www.hercle.com/) provides institutional cross-border payment infrastructure connecting fiat, stablecoins, and digital assets. Teams on Tempo can access competitive FX rates in EUR, GBP, and 30+ local currencies.
 
 For EUR and GBP, Hercle also supports pay-ins, payouts, and stablecoin on-ramps and off-ramps, giving payment companies one route from local currency through the onchain leg and back to local currency.
 

--- a/src/pages/docs/ecosystem/orchestration.mdx
+++ b/src/pages/docs/ecosystem/orchestration.mdx
@@ -35,6 +35,14 @@ Get started by creating an account [here](https://app.brale.xyz/buy/signup/).
 
 Get started with [Bridge's Tempo Integration Guide](https://apidocs.bridge.xyz/get-started/guides/move-money/tempo-integration-guide#tempo-integration-guide).
 
+## Hercle
+
+[Hercle](https://www.hercle.com/) provides institutional cross-border payment infrastructure connecting fiat, stablecoins, and digital assets. Teams on Tempo can access competitive FX rates in EUR, GBP, and 20+ emerging-market currencies.
+
+For EUR and GBP, Hercle also supports pay-ins, payouts, and stablecoin on-ramps and off-ramps, giving payment companies one route from local currency through the onchain leg and back to local currency.
+
+[Check supported corridors](https://www.hercle.com/corridor-checker/) or [contact Hercle](https://www.hercle.com/contact/) to get started.
+
 ## UR
 
 [UR](https://ur.app/partners/tempo) provides infrastructure that connects stablecoin settlement with fiat rails for platforms building global financial services.


### PR DESCRIPTION
## Summary

- Add Hercle to Issuance & Orchestration
- Describe competitive FX coverage across EUR, GBP, and 30+ local currencies alongside EUR/GBP payment infrastructure
- Link to Hercle’s corridor checker and contact page

## Why

Developers evaluating FX and cross-border payment infrastructure on Tempo should be able to discover Hercle in the docs ecosystem section.

## Validation

- pnpm check:types
- pnpm build

Unit tests could not start because the local certificate plugin requires interactive sudo to install a trusted certificate.