### PR TITLE
security: harden CORS origin validation on faucet and index-supply

### DIFF
--- a/src/pages/_api/api/faucet.ts
+++ b/src/pages/_api/api/faucet.ts
@@ -53,18 +53,26 @@ async function fund(address: `0x${string}`, headers: Record<string, string>): Pr
   }
 }
 
-function cors(origin: string | null): Record<string, string> {
+function isAllowedOrigin(origin: string): boolean {
   const allowedOrigins = ['https://tempo.xyz', 'https://docs.tempo.xyz']
-
-  if (origin?.includes('vercel.app')) allowedOrigins.push(origin)
   if (process.env.NODE_ENV === 'development') allowedOrigins.push('http://localhost:5173')
+  if (allowedOrigins.includes(origin)) return true
 
+  try {
+    const { protocol, hostname } = new URL(origin)
+    return protocol === 'https:' && hostname.endsWith('.vercel.app')
+  } catch {
+    return false
+  }
+}
+
+function cors(origin: string | null): Record<string, string> {
   const headers: Record<string, string> = {
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, x-api-token',
   }
 
-  if (origin && allowedOrigins.includes(origin)) headers['Access-Control-Allow-Origin'] = origin
+  if (origin && isAllowedOrigin(origin)) headers['Access-Control-Allow-Origin'] = origin
 
   return headers
 }

--- a/src/pages/_api/api/index-supply.ts
+++ b/src/pages/_api/api/index-supply.ts
@@ -119,19 +119,26 @@ export async function OPTIONS(request: Request): Promise<Response> {
   return new Response(null, { status: 200, headers: cors(origin) })
 }
 
-function cors(origin: string | null): Record<string, string> {
+function isAllowedOrigin(origin: string): boolean {
   const allowedOrigins = ['https://tempo.xyz', 'https://mainnet.docs.tempo.xyz']
-
-  if (origin?.includes('vercel.app')) allowedOrigins.push(origin)
   if (process.env.NODE_ENV === 'development') allowedOrigins.push('http://localhost:5173')
+  if (allowedOrigins.includes(origin)) return true
 
+  try {
+    const { protocol, hostname } = new URL(origin)
+    return protocol === 'https:' && hostname.endsWith('.vercel.app')
+  } catch {
+    return false
+  }
+}
+
+function cors(origin: string | null): Record<string, string> {
   const headers: Record<string, string> = {
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, x-api-token',
   }
 
-  if (origin && allowedOrigins.some((allowed) => origin.startsWith(allowed)))
-    headers['Access-Control-Allow-Origin'] = origin
+  if (origin && isAllowedOrigin(origin)) headers['Access-Control-Allow-Origin'] = origin
 
   return headers
 }


### PR DESCRIPTION
# Harden CORS origin validation on the faucet and Index Supply endpoints

## Severity: Security — origin allowlist bypass

Both public API routes reflect the caller's `Origin` back into
`Access-Control-Allow-Origin` after a check that can be trivially satisfied by
an attacker-controlled domain. That defeats the whole point of the allowlist:
any web page can drive authenticated, state-changing `POST`s to these
endpoints from a victim's browser.

## Two bypasses

**1. `startsWith` prefix match (Index Supply).**

```ts
allowedOrigins.some((allowed) => origin.startsWith(allowed))
```

`https://tempo.xyz.attacker.com` starts with `https://tempo.xyz`, so it passes
and gets reflected.

**2. `includes('vercel.app')` substring match (both routes).**

```ts
if (origin?.includes('vercel.app')) allowedOrigins.push(origin)
```

Preview deployments legitimately live on `*.vercel.app`, but a substring test
also green-lights `https://vercel.app.attacker.com` and
`https://evil-vercel.app.co`.

## The fix

Replaced the loose checks with an exact allowlist plus a real host match for
preview URLs, extracted into a small `isAllowedOrigin(origin)` helper in each
file:

- exact equality against the known origins (this is what `faucet.ts` already
  did for its base list — the substring branch was the hole);
- `new URL(origin)` parse, then `protocol === 'https:' && hostname.endsWith('.vercel.app')`
  so only genuine Vercel subdomains match, and a malformed `Origin` header
  falls through to "denied".

Each endpoint keeps its own base allowlist unchanged
(`mainnet.docs.tempo.xyz` for Index Supply, `docs.tempo.xyz` for the faucet)
and the localhost dev entry.

## Verification

- `pnpm check:types` — clean.
- Manual reasoning against the bypass strings above: all now rejected;
  `https://tempo.xyz`, `https://<base>`, `https://foo.vercel.app`, and
  `http://localhost:5173` (dev only) still allowed.
