### PR TITLE
fix: classify non-mcp /api/* requests as 'other', not 'docs'

### DIFF
--- a/e2e/docs-request-classifier.test.ts
+++ b/e2e/docs-request-classifier.test.ts
@@ -198,6 +198,16 @@ const cases: ClassificationCase[] = [
       surface: 'docs',
     },
   },
+  {
+    name: 'non-mcp api route is not a docs surface',
+    input: { path: '/api/og', userAgent: 'facebookexternalhit/1.1' },
+    expected: {
+      agent_kind: 'human',
+      match_source: 'none',
+      shouldTrack: false,
+      surface: 'other',
+    },
+  },
 ]
 
 for (const item of cases) {

--- a/src/lib/docs-request-classifier.ts
+++ b/src/lib/docs-request-classifier.ts
@@ -192,6 +192,10 @@ function classifySurface(path: string): DocsRequestSurface {
 
   if (pathname === '/llms.txt' || pathname === '/llms-full.txt') return 'llms'
   if (pathname === '/api/mcp' || pathname.startsWith('/api/mcp/')) return 'mcp'
+  // Every other /api/* route (og, feedback, faucet, index-supply, ...) is an
+  // application endpoint, not a docs surface. Without this, isDocsPage() treats
+  // extensionless paths like /api/og as 'docs' and mislabels their traffic.
+  if (pathname === '/api' || pathname.startsWith('/api/')) return 'other'
   if (pathname === '/skill.md') return 'skill'
   if (pathname.startsWith('/.well-known/')) return 'well_known'
   if (pathname.endsWith('.md')) return 'markdown'


### PR DESCRIPTION
# Stop counting non-MCP `/api/*` requests as documentation traffic

`classifyDocsRequest` powers the server-side analytics that tell us which AI
agents and crawlers hit the docs. Right now it quietly files a chunk of
plain application traffic under the `docs` surface, which skews every report
built on top of it.

### Where it goes wrong

`classifySurface` special-cases `/api/mcp`, then falls through to
`isDocsPage`:

```ts
function isDocsPage(pathname: string) {
  const lastSegment = pathname.split('/').pop() ?? ''
  return !lastSegment.includes('.')   // "no file extension" == a docs page
}
```

`/api/og`, `/api/feedback`, `/api/faucet`, `/api/index-supply` all have an
extensionless last segment, so they’re labelled `surface: 'docs'`. From there:

- an OG-image unfurl from Slackbot/`facebookexternalhit` (UA without
  `mozilla/5.0`) trips the `unknown_ua` branch and is recorded as an
  `unknown_ai` **docs** view;
- a scripted `POST /api/faucet` is recorded as a `developer_tool` **docs**
  request.

The `DocsRequestSurface` docblock already says unrelated APIs belong in
`other` — the classifier just never enforced it.

### Change

One guard, right after the existing `/api/mcp` check:

```ts
if (pathname === '/api' || pathname.startsWith('/api/')) return 'other'
```

MCP keeps its dedicated surface; everything else under `/api/` becomes
`other`, which is excluded from agent-surface tracking. Added a regression
case (`/api/og` → `surface: 'other'`, `shouldTrack: false`) to the
table-driven classifier tests.

### Checks
`pnpm check:types` passes. New case added to
`e2e/docs-request-classifier.test.ts`.