### PR TITLE
docs: bump tempo-alloy to v1.10.1

### DIFF
--- a/src/pages/docs/sdk/rust/index.mdx
+++ b/src/pages/docs/sdk/rust/index.mdx
@@ -17,7 +17,7 @@ To install the Tempo extension, you will need to install [Alloy](https://alloy.r
 
 ```bash [cargo]
 cargo add alloy tokio
-cargo add tempo-alloy --git https://github.com/tempoxyz/tempo --tag v1.4.2
+cargo add tempo-alloy --git https://github.com/tempoxyz/tempo --tag v1.8.0
 ```
 
 :::tip

--- a/src/pages/docs/sdk/rust/index.mdx
+++ b/src/pages/docs/sdk/rust/index.mdx
@@ -17,7 +17,7 @@ To install the Tempo extension, you will need to install [Alloy](https://alloy.r
 
 ```bash [cargo]
 cargo add alloy tokio
-cargo add tempo-alloy --git https://github.com/tempoxyz/tempo --tag v1.8.0
+cargo add tempo-alloy --git https://github.com/tempoxyz/tempo --tag tempo-alloy@1.10.1
 ```
 
 :::tip


### PR DESCRIPTION
## Summary

- update the Rust SDK install command from the legacy workspace tag `v1.4.2` to the current crate release `tempo-alloy@1.10.1`