### PR TITLE
docs: add Bitwise node infrastructure

### DIFF
--- a/src/pages/docs/ecosystem/node-infrastructure.mdx
+++ b/src/pages/docs/ecosystem/node-infrastructure.mdx
@@ -13,6 +13,14 @@ With [Alchemy](https://alchemy.com), build the fastest and most reliable Tempo a
 
 Sign up through the [Alchemy dashboard](https://dashboard.alchemy.com/?utm_source=chain_partner&utm_medium=referral&utm_campaign=tempo) and visit the [Alchemy docs](https://www.alchemy.com/docs/node#tldr) to start building.
 
+## Bitwise
+
+[Bitwise](https://onchain.bitwiseinvestments.com/) is one of the world's largest crypto asset managers, with $11B+ in client assets firmwide, and offers staking and validator infrastructure through its in-house staking team. The team has run infrastructure at scale since 2018, operating validators across leading proof-of-stake networks, and is ISO 27001 certified.
+
+Bitwise has experience serving a broad spectrum of clients, from asset managers and banks to centralized exchanges, wallet providers, and venture capital firms. Its staking team engages directly with the stakeholders of each network, supports partners, and delivers insights that keep clients ahead.
+
+Reach out through the [Bitwise Onchain contact page](https://onchain.bitwiseinvestments.com/contact) to support Tempo validator infrastructure.
+
 ## Blockdaemon
 
 [Blockdaemon](https://app.blockdaemon.com/) provides institutional-grade node and API infrastructure, along with staking and MPC wallet services. Their globally distributed platform supports enterprise-scale, production workloads with strong reliability and compliance guarantees.


### PR DESCRIPTION
## Summary

- Adds Bitwise to the Node Infrastructure ecosystem docs.
- Links to Bitwise Onchain and the Bitwise Onchain contact page for Tempo validator infrastructure support.
- Uses Bitwise's current `$11B+` client assets figure from its onchain site.

## Validation

- `pnpm build` passed locally in the clean worktree.
- `git diff --check` passed.