### PR TITLE
fix(performance): update nightly scenario cutovers

### DIFF
--- a/src/marketing/app/_components/stats.ts
+++ b/src/marketing/app/_components/stats.ts
@@ -57,10 +57,9 @@ export function statValue(stat: Stat): string {
   return stat.main.unit ? `${stat.main.value} ${stat.main.unit}` : stat.main.value
 }
 
-// Nightly TIP-20 benchmark runs. PR-preview deployment for now — swap for the
-// production URL when it lands.
+// Latest run from the current nightly benchmark preset.
 const PERF_API_URL =
-  'https://pr-77-tempo-apps-internal-perf-public.tempo-dev.workers.dev/api/perf/runs?feed=nightly&limit=1&scenario_id=tip20-50k'
+  'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=1&scenario_id=tip20-50k'
 
 type PerfRuns = {
   runs?: {

--- a/src/marketing/app/performance/_lib/runs.ts
+++ b/src/marketing/app/performance/_lib/runs.ts
@@ -2,8 +2,11 @@
 // fetchStats() (app/_components/stats.ts) overlays only the latest run;
 // this module fetches the whole feed for the /performance charts.
 
-const PERF_API_URL =
-  'https://pr-77-tempo-apps-internal-perf-public.tempo-dev.workers.dev/api/perf/runs?feed=nightly&limit=100'
+const PERF_API_URL = 'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=100'
+
+const DEFAULT_SCENARIO_FROM = '2026-07-13'
+const DEFAULT_SCENARIO_ID = 'tip20-50k'
+const TIP20_SCENARIO_UNTIL = '2026-07-10'
 
 type ApiRun = {
   id?: string
@@ -56,6 +59,18 @@ const timeLabel = (iso: string) =>
     timeZone: 'UTC',
   })} UTC`
 
+function isNightlyScenario(run: ApiRun): boolean {
+  const startedAt = run.startedAt
+  const scenarioId = run.scenario?.id
+  if (!startedAt || !scenarioId) return false
+
+  if (startedAt >= DEFAULT_SCENARIO_FROM) {
+    return scenarioId === DEFAULT_SCENARIO_ID
+  }
+
+  return startedAt < TIP20_SCENARIO_UNTIL && scenarioId.startsWith('tip20-')
+}
+
 // Oldest → newest (the API returns newest first). Empty array when the API
 // is down or the shape changes; callers render a fallback notice.
 export async function fetchPerfRuns(): Promise<PerfRun[]> {
@@ -64,8 +79,9 @@ export async function fetchPerfRuns(): Promise<PerfRun[]> {
     if (!res.ok) return []
     const data = (await res.json()) as { runs?: ApiRun[] }
     return (data.runs ?? [])
-      .filter((r): r is Required<Pick<ApiRun, 'startedAt' | 'metrics'>> & ApiRun =>
-        Boolean(r.startedAt && r.metrics?.settledTps),
+      .filter(
+        (r): r is Required<Pick<ApiRun, 'startedAt' | 'metrics'>> & ApiRun =>
+          Boolean(r.startedAt && r.metrics?.settledTps) && isNightlyScenario(r),
       )
       .map((r) => ({
         id: r.id ?? r.startedAt,


### PR DESCRIPTION
## Summary
- switch homepage and performance charts to `perf.tempo.xyz`
- filter nightly chart data across the scenario cutover dates
- preserve historical TIP-20 runs while selecting `tip20-50k` from July 13 onward

## Validation
- `pnpm exec biome check src/marketing/app/_components/stats.ts src/marketing/app/performance/_lib/runs.ts`
- `pnpm check:types`
- `pnpm build` *(blocked after typecheck by a timeout fetching an unrelated remote OpenAPI schema in the Vocs llms plugin)*

Prompted by: @emmajam