### PR TITLE
Fix API overview page alignment

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -243,9 +243,10 @@
     }
   }
 
+  /* Keep overview pages centered even when they embed an API playground. */
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    )
+    ):not(:has([data-v-openapi-overview]))
     > [data-v-main] {
     @media (width >= 1376px) {
       padding-right: 0;
@@ -254,7 +255,7 @@
 
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    )
+    ):not(:has([data-v-openapi-overview]))
     > [data-v-gutter-right] {
     @media (width >= 1376px) {
       display: none;
@@ -263,11 +264,11 @@
 
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    )
+    ):not(:has([data-v-openapi-overview]))
     [data-v-openapi-header],
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    )
+    ):not(:has([data-v-openapi-overview]))
     [data-v-openapi-description] {
     width: 100%;
     max-width: none;
@@ -278,11 +279,29 @@
 
   [data-layout][data-v-sidebar][data-v-content-width="full"]:has(
       [data-v-openapi]:not([data-v-openapi-landing])
-    )
+    ):not(:has([data-v-openapi-overview]))
     [data-v-openapi]
     [data-v-content] {
     margin-left: 0;
     margin-right: 0;
+  }
+
+  [data-layout][data-v-sidebar][data-v-content-width="full"]:has([data-v-openapi-overview])
+    > [data-v-main]
+    > [data-v-content] {
+    @media (width >= 1376px) {
+      max-width: var(--vocs-spacing-content);
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
+
+  [data-layout][data-v-sidebar][data-v-content-width="full"]:has([data-v-openapi-overview])
+    [data-v-gutter-right] {
+    @media (width >= 1376px) {
+      right: max(0px, calc((100% - var(--tempo-docs-shell-width)) * 0.5)) !important;
+      left: auto !important;
+    }
   }
 
   [data-v-sidebar-container] [data-v-sidebar] {


### PR DESCRIPTION
## Summary
- keep the Tempo API overview page on the standard centered docs layout
- preserve the full-width layout for individual OpenAPI endpoint pages
- restore the standard right-side outline position on the overview

## Validation
- `pnpm check:types`
- `pnpm exec biome check src/pages/_root.css` (only existing/required CSS warnings)
- `git diff --check`
- browser-verified at a 2048×1152 viewport against the live DOM: API and Tools & SDKs headings both start at `638.5px`
- rendered verification screenshot uploaded to the originating Slack thread

Prompted by: @tanishqsh