### PR TITLE
docs: link console actions directly

### DIFF
--- a/src/pages/docs/api.mdx
+++ b/src/pages/docs/api.mdx
@@ -61,7 +61,7 @@ There are three ways to authenticate, depending on the throughput you need:
 Public access lets you try the API and serve low-volume reads, and [MPP](/docs/api/authentication#mpp-paying-per-request) lets you pay per request without a key. For higher, dedicated quotas, use an API key.
 
 :::info
-Create production and sandbox API keys in [Tempo API Console](https://console.tempo.xyz). Follow the [console quickstart](/docs/api/console) to set up a project and make your first authenticated request.
+Create production and sandbox API keys in [Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys). Follow the [console quickstart](/docs/api/console) to set up a project and make your first authenticated request.
 :::
 
 ## Try a Tempo API request

--- a/src/pages/docs/api/authentication.mdx
+++ b/src/pages/docs/api/authentication.mdx
@@ -16,7 +16,7 @@ The Tempo API supports three ways to authenticate a request, so you can start wi
 Most read endpoints are open to **public** (anonymous) callers, so no credential is required to get started. To raise your throughput, pay per request with [MPP](#mpp-paying-per-request) or send an **API key**. Some endpoints, such as webhook management, require a key.
 
 :::info
-Create production and sandbox API keys in [Tempo API Console](https://console.tempo.xyz). The [console API-key guide](/docs/api/console/api-keys) covers project selection, scopes, storage, rotation, and revocation.
+Create production and sandbox API keys in [Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys). The [console API-key guide](/docs/api/console/api-keys) covers project selection, scopes, storage, rotation, and revocation.
 :::
 
 ## API Keys

--- a/src/pages/docs/api/console.mdx
+++ b/src/pages/docs/api/console.mdx
@@ -30,11 +30,11 @@ Most console pages show information across the organization. Use the project fil
 
 ### Sign in to Tempo API Console
 
-Open [console.tempo.xyz](https://console.tempo.xyz) and sign in. If you have access to more than one organization, choose the organization you want to configure from the organization menu.
+Open [**Projects** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/projects) and sign in. If you have access to more than one organization, choose the organization you want to configure from the organization menu.
 
 ### Create a project
 
-Select **Projects**, then **New project**. Enter a name that identifies the app or integration using the API, then select **Create project**.
+Open [**New project** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/new). Enter a name that identifies the app or integration using the API, then select **Create project**.
 
 Projects hold API keys and provide an attribution boundary for usage. Create separate projects when you need to track or revoke integrations independently.
 
@@ -46,7 +46,7 @@ Sandbox API keys are restricted to non-mainnet chains and default to testnet. Pr
 
 ### Create an API key
 
-Select **API Keys**, then **New key**. Choose the project, give the key a descriptive name, and review its scopes before selecting **Create key**.
+Open [**New sandbox key** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox). Choose the project, give the key a descriptive name, and review its scopes before selecting **Create key**.
 
 The console selects the available self-service scopes by default. If you clear every scope, the key is created without access to any scoped API.
 
@@ -69,7 +69,7 @@ A sandbox key automatically targets testnet when the request does not specify `c
 
 ### Review usage
 
-Select **Usage** and choose your project from the filter. The page reports request volume, errors, sponsored transactions, high-volume routes, and usage by API key for the selected environment.
+Open [**Sandbox usage** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/usage%3Fenv%3Dsandbox) and choose your project from the filter. The page reports request volume, errors, sponsored transactions, high-volume routes, and usage by API key for the selected environment.
 
 :::::
 

--- a/src/pages/docs/api/console.mdx
+++ b/src/pages/docs/api/console.mdx
@@ -34,19 +34,19 @@ Open [**Projects** in Tempo API Console](https://console.tempo.xyz/?to=/:organiz
 
 ### Create a project
 
-Open [**New project** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/new). Enter a name that identifies the app or integration using the API, then select **Create project**.
+Open [**Projects** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/projects), then select [**New project**](https://console.tempo.xyz/?to=/:organization/new). Enter a name that identifies the app or integration using the API, then select **Create project**.
 
 Projects hold API keys and provide an attribution boundary for usage. Create separate projects when you need to track or revoke integrations independently.
 
 ### Start in sandbox
 
-Open the organization menu and select **Switch to sandbox**. The amber banner confirms that the console is showing sandbox state.
+Open the organization menu and select [**Switch to sandbox**](https://console.tempo.xyz/?to=/:organization/projects%3Fenv%3Dsandbox). The amber banner confirms that the console is showing sandbox state.
 
 Sandbox API keys are restricted to non-mainnet chains and default to testnet. Production and sandbox credentials, usage, and billing state are separate.
 
 ### Create an API key
 
-Open [**New sandbox key** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox). Choose the project, give the key a descriptive name, and review its scopes before selecting **Create key**.
+Open [**Sandbox API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox), then select [**New key**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox). Choose the project, give the key a descriptive name, and review its scopes before selecting **Create key**.
 
 The console selects the available self-service scopes by default. If you clear every scope, the key is created without access to any scoped API.
 

--- a/src/pages/docs/api/console.mdx
+++ b/src/pages/docs/api/console.mdx
@@ -30,11 +30,11 @@ Most console pages show information across the organization. Use the project fil
 
 ### Sign in to Tempo API Console
 
-Open [**Projects** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/projects) and sign in. If you have access to more than one organization, choose the organization you want to configure from the organization menu.
+Open [console.tempo.xyz](https://console.tempo.xyz/?to=/:organization/projects) and sign in. If you have access to more than one organization, choose the organization you want to configure from the organization menu.
 
 ### Create a project
 
-Open [**Projects** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/projects), then select [**New project**](https://console.tempo.xyz/?to=/:organization/new). Enter a name that identifies the app or integration using the API, then select **Create project**.
+Select [**Projects**](https://console.tempo.xyz/?to=/:organization/projects), then [**New project**](https://console.tempo.xyz/?to=/:organization/new). Enter a name that identifies the app or integration using the API, then select **Create project**.
 
 Projects hold API keys and provide an attribution boundary for usage. Create separate projects when you need to track or revoke integrations independently.
 
@@ -46,7 +46,7 @@ Sandbox API keys are restricted to non-mainnet chains and default to testnet. Pr
 
 ### Create an API key
 
-Open [**Sandbox API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox), then select [**New key**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox). Choose the project, give the key a descriptive name, and review its scopes before selecting **Create key**.
+Select [**API Keys**](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox), then [**New key**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox). Choose the project, give the key a descriptive name, and review its scopes before selecting **Create key**.
 
 The console selects the available self-service scopes by default. If you clear every scope, the key is created without access to any scoped API.
 
@@ -69,7 +69,7 @@ A sandbox key automatically targets testnet when the request does not specify `c
 
 ### Review usage
 
-Open [**Sandbox usage** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/usage%3Fenv%3Dsandbox) and choose your project from the filter. The page reports request volume, errors, sponsored transactions, high-volume routes, and usage by API key for the selected environment.
+Select [**Usage**](https://console.tempo.xyz/?to=/:organization/usage%3Fenv%3Dsandbox) and choose your project from the filter. The page reports request volume, errors, sponsored transactions, high-volume routes, and usage by API key for the selected environment.
 
 :::::
 

--- a/src/pages/docs/api/console/api-keys.mdx
+++ b/src/pages/docs/api/console/api-keys.mdx
@@ -15,11 +15,11 @@ You need at least one project before creating a key.
 
 ### Choose the environment
 
-Open the organization menu in [Tempo API Console](https://console.tempo.xyz) and switch to **Sandbox** or **Production**. Check for the amber sandbox banner before continuing.
+Open [**API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys), then open the organization menu and switch to **Sandbox** or **Production**. Check for the amber sandbox banner before continuing.
 
 ### Open the new-key form
 
-Select **API Keys**, then **New key**.
+Open the [**production new-key form**](https://console.tempo.xyz/?to=/:organization/api-keys/new) or [**sandbox new-key form**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox) in Tempo API Console.
 
 ### Choose a project and name
 
@@ -74,11 +74,11 @@ Replace the old token in the integration's secret configuration and deploy or re
 
 ### Verify the replacement
 
-Make a request with the new key and check the project's **Usage** page. Confirm that requests are attributed to the replacement key.
+Make a request with the new key and check [**Usage** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/usage). Filter to the project and confirm that requests are attributed to the replacement key.
 
 ### Revoke the old key
 
-Return to **API Keys**, open the old key's actions menu, select **Revoke key**, and confirm. Requests using that token stop authenticating.
+Return to [**API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys), open the old key's actions menu, select **Revoke key**, and confirm. Requests using that token stop authenticating.
 
 :::::
 

--- a/src/pages/docs/api/console/api-keys.mdx
+++ b/src/pages/docs/api/console/api-keys.mdx
@@ -15,11 +15,11 @@ You need at least one project before creating a key.
 
 ### Choose the environment
 
-Open [**API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys), then open the organization menu and switch to **Sandbox** or **Production**. Check for the amber sandbox banner before continuing.
+Open [**API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys), then open the organization menu and switch to [**Sandbox**](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox) or [**Production**](https://console.tempo.xyz/?to=/:organization/api-keys). Check for the amber sandbox banner before continuing.
 
 ### Open the new-key form
 
-Open the [**production new-key form**](https://console.tempo.xyz/?to=/:organization/api-keys/new) or [**sandbox new-key form**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox) in Tempo API Console.
+From [**API Keys**](https://console.tempo.xyz/?to=/:organization/api-keys), select [**New key**](https://console.tempo.xyz/?to=/:organization/api-keys/new). For sandbox, use [**Sandbox API Keys**](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox) and [**New sandbox key**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox).
 
 ### Choose a project and name
 

--- a/src/pages/docs/api/console/api-keys.mdx
+++ b/src/pages/docs/api/console/api-keys.mdx
@@ -15,11 +15,11 @@ You need at least one project before creating a key.
 
 ### Choose the environment
 
-Open [**API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys), then open the organization menu and switch to [**Sandbox**](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox) or [**Production**](https://console.tempo.xyz/?to=/:organization/api-keys). Check for the amber sandbox banner before continuing.
+Open the organization menu in [Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys) and switch to [**Sandbox**](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox) or [**Production**](https://console.tempo.xyz/?to=/:organization/api-keys). Check for the amber sandbox banner before continuing.
 
 ### Open the new-key form
 
-From [**API Keys**](https://console.tempo.xyz/?to=/:organization/api-keys), select [**New key**](https://console.tempo.xyz/?to=/:organization/api-keys/new). For sandbox, use [**Sandbox API Keys**](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox) and [**New sandbox key**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox).
+Select [**API Keys**](https://console.tempo.xyz/?to=/:organization/api-keys), then [**New key**](https://console.tempo.xyz/?to=/:organization/api-keys/new).
 
 ### Choose a project and name
 
@@ -74,11 +74,11 @@ Replace the old token in the integration's secret configuration and deploy or re
 
 ### Verify the replacement
 
-Make a request with the new key and check [**Usage** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/usage). Filter to the project and confirm that requests are attributed to the replacement key.
+Make a request with the new key and check the project's [**Usage**](https://console.tempo.xyz/?to=/:organization/usage) page. Confirm that requests are attributed to the replacement key.
 
 ### Revoke the old key
 
-Return to [**API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys), open the old key's actions menu, select **Revoke key**, and confirm. Requests using that token stop authenticating.
+Return to [**API Keys**](https://console.tempo.xyz/?to=/:organization/api-keys), open the old key's actions menu, select **Revoke key**, and confirm. Requests using that token stop authenticating.
 
 :::::
 

--- a/src/pages/docs/api/console/projects-and-environments.mdx
+++ b/src/pages/docs/api/console/projects-and-environments.mdx
@@ -17,7 +17,7 @@ Each API key belongs to one project. Project attribution lets you filter API key
 
 ### Open Projects
 
-Select **Projects** in [Tempo API Console](https://console.tempo.xyz), then select **New project**.
+Open [**New project** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/new).
 
 ### Name the project
 

--- a/src/pages/docs/api/console/projects-and-environments.mdx
+++ b/src/pages/docs/api/console/projects-and-environments.mdx
@@ -17,7 +17,7 @@ Each API key belongs to one project. Project attribution lets you filter API key
 
 ### Open Projects
 
-Open [**Projects** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/projects), then select [**New project**](https://console.tempo.xyz/?to=/:organization/new).
+Select [**Projects** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/projects), then select [**New project**](https://console.tempo.xyz/?to=/:organization/new).
 
 ### Name the project
 

--- a/src/pages/docs/api/console/projects-and-environments.mdx
+++ b/src/pages/docs/api/console/projects-and-environments.mdx
@@ -17,7 +17,7 @@ Each API key belongs to one project. Project attribution lets you filter API key
 
 ### Open Projects
 
-Open [**New project** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/new).
+Open [**Projects** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/projects), then select [**New project**](https://console.tempo.xyz/?to=/:organization/new).
 
 ### Name the project
 

--- a/src/pages/docs/api/console/team.mdx
+++ b/src/pages/docs/api/console/team.mdx
@@ -25,7 +25,7 @@ Owners and admins can send invitations. Admins can grant only the Member role.
 
 ### Open Team
 
-Open [**Team** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/team).
+Select [**Team** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/team).
 
 ### Enter the invitation details
 
@@ -55,4 +55,4 @@ Role changes take effect for organization access after the update succeeds. They
 - **Remove a member:** open the member's actions menu, select **Remove**, and confirm.
 - **Leave an organization:** open your own actions menu and select **Leave organization**. The last owner cannot leave until another owner exists.
 
-Removing a member does not automatically revoke project API keys. Review [**API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys) separately when offboarding someone who managed integration credentials.
+Removing a member does not automatically revoke project API keys. Review [**API Keys**](https://console.tempo.xyz/?to=/:organization/api-keys) separately when offboarding someone who managed integration credentials.

--- a/src/pages/docs/api/console/team.mdx
+++ b/src/pages/docs/api/console/team.mdx
@@ -25,7 +25,7 @@ Owners and admins can send invitations. Admins can grant only the Member role.
 
 ### Open Team
 
-Select **Team** in [Tempo API Console](https://console.tempo.xyz).
+Open [**Team** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/team).
 
 ### Enter the invitation details
 
@@ -55,4 +55,4 @@ Role changes take effect for organization access after the update succeeds. They
 - **Remove a member:** open the member's actions menu, select **Remove**, and confirm.
 - **Leave an organization:** open your own actions menu and select **Leave organization**. The last owner cannot leave until another owner exists.
 
-Removing a member does not automatically revoke project API keys. Review **API Keys** separately when offboarding someone who managed integration credentials.
+Removing a member does not automatically revoke project API keys. Review [**API Keys** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/api-keys) separately when offboarding someone who managed integration credentials.

--- a/src/pages/docs/api/console/usage-and-billing.mdx
+++ b/src/pages/docs/api/console/usage-and-billing.mdx
@@ -9,7 +9,7 @@ Tempo API Console reports API activity and manages billing for fee sponsorship. 
 
 ## Review API usage
 
-Select **Usage** to inspect activity in the selected environment. Use the project selector to show all projects or one project.
+Open [**Usage** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/usage) to inspect activity in the selected environment. Use the project selector to show all projects or one project.
 
 The page includes:
 
@@ -36,7 +36,7 @@ Switch to the production or sandbox environment whose billing state you want to 
 
 ### Open Billing
 
-Select **Billing**, then find **Payment methods**.
+Open [**Billing** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/billing), then find **Payment methods**.
 
 ### Add the payment method
 
@@ -66,7 +66,7 @@ Production fee sponsorship requires an active billing source. A spend or sponsor
 ## Investigate unexpected usage
 
 1. Confirm that the console is showing the correct environment.
-2. Open **Usage** and filter to the affected project.
+2. Open [**Usage** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/usage) and filter to the affected project.
 3. Compare the **Routes** and **API keys** sections to find the source.
 4. Revoke a credential if its traffic is unexpected.
 5. Review the Billing page and adjust spend or sponsorship limits if needed.

--- a/src/pages/docs/api/console/usage-and-billing.mdx
+++ b/src/pages/docs/api/console/usage-and-billing.mdx
@@ -9,7 +9,7 @@ Tempo API Console reports API activity and manages billing for fee sponsorship. 
 
 ## Review API usage
 
-Open [**Usage** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/usage) to inspect activity in the selected environment. Use the project selector to show all projects or one project.
+Select [**Usage**](https://console.tempo.xyz/?to=/:organization/usage) to inspect activity in the selected environment. Use the project selector to show all projects or one project.
 
 The page includes:
 
@@ -36,7 +36,7 @@ Switch to the production or sandbox environment whose billing state you want to 
 
 ### Open Billing
 
-Open [**Billing** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/billing), then find **Payment methods**.
+Select [**Billing**](https://console.tempo.xyz/?to=/:organization/billing), then find **Payment methods**.
 
 ### Add the payment method
 
@@ -66,7 +66,7 @@ Production fee sponsorship requires an active billing source. A spend or sponsor
 ## Investigate unexpected usage
 
 1. Confirm that the console is showing the correct environment.
-2. Open [**Usage** in Tempo API Console](https://console.tempo.xyz/?to=/:organization/usage) and filter to the affected project.
+2. Open [**Usage**](https://console.tempo.xyz/?to=/:organization/usage) and filter to the affected project.
 3. Compare the **Routes** and **API keys** sections to find the source.
 4. Revoke a credential if its traffic is unexpected.
 5. Review the Billing page and adjust spend or sponsorship limits if needed.

--- a/src/pages/docs/api/fee-payer.mdx
+++ b/src/pages/docs/api/fee-payer.mdx
@@ -35,7 +35,7 @@ https://api.tempo.xyz/rpc/sponsor
 
 ### Sign into the Tempo Console
 
-Open the [Tempo Console](https://console.tempo.xyz) and select **Sign in with Tempo**.
+Open [**Projects** in Tempo Console](https://console.tempo.xyz/?to=/:organization/projects) and select **Sign in with Tempo**.
 
 :::info
 Tempo Console signups are currently limited. [Contact us](https://tempo.xyz/contact/) to request access.
@@ -43,11 +43,11 @@ Tempo Console signups are currently limited. [Contact us](https://tempo.xyz/cont
 
 ### Set up Organization
 
-Create an organization and project.
+Open [**New project** in Tempo Console](https://console.tempo.xyz/?to=/:organization/new), create an organization if prompted, and create the project.
 
 ### Set up Billing
 
-For this testnet example, switch to **Sandbox mode** (located in the top-left organization picker), then open **Billing** and add a payment method.
+For this testnet example, open [**Billing** in Tempo Console](https://console.tempo.xyz/?to=/:organization/billing%3Fenv%3Dsandbox) and add a payment method. The amber banner confirms that the console is in **Sandbox mode**.
 
 :::info
 For production, keep the Console in the production environment and do not switch to **Sandbox mode**. Production fee sponsorship requires active billing.
@@ -55,7 +55,7 @@ For production, keep the Console in the production environment and do not switch
 
 ### Get an API Key
 
-Open **API Keys**, select **New key**, choose your project, and create the key. Copy it when prompted; it is shown only once.
+Open [**New key** in Tempo Console](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox), choose your project, and create the key. Copy it when prompted; it is shown only once.
 
 ### Sponsor Transaction Fees
 

--- a/src/pages/docs/api/fee-payer.mdx
+++ b/src/pages/docs/api/fee-payer.mdx
@@ -43,11 +43,11 @@ Tempo Console signups are currently limited. [Contact us](https://tempo.xyz/cont
 
 ### Set up Organization
 
-Open [**New project** in Tempo Console](https://console.tempo.xyz/?to=/:organization/new), create an organization if prompted, and create the project.
+Open [**Projects** in Tempo Console](https://console.tempo.xyz/?to=/:organization/projects), then select [**New project**](https://console.tempo.xyz/?to=/:organization/new). Create an organization first if prompted.
 
 ### Set up Billing
 
-For this testnet example, open [**Billing** in Tempo Console](https://console.tempo.xyz/?to=/:organization/billing%3Fenv%3Dsandbox) and add a payment method. The amber banner confirms that the console is in **Sandbox mode**.
+For this testnet example, select [**Sandbox mode**](https://console.tempo.xyz/?to=/:organization/projects%3Fenv%3Dsandbox), then open [**Billing**](https://console.tempo.xyz/?to=/:organization/billing%3Fenv%3Dsandbox) and add a payment method. The amber banner confirms that the console is in sandbox mode.
 
 :::info
 For production, keep the Console in the production environment and do not switch to **Sandbox mode**. Production fee sponsorship requires active billing.
@@ -55,7 +55,7 @@ For production, keep the Console in the production environment and do not switch
 
 ### Get an API Key
 
-Open [**New key** in Tempo Console](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox), choose your project, and create the key. Copy it when prompted; it is shown only once.
+Open [**Sandbox API Keys** in Tempo Console](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox), select [**New key**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox), choose your project, and create the key. Copy it when prompted; it is shown only once.
 
 ### Sponsor Transaction Fees
 

--- a/src/pages/docs/api/fee-payer.mdx
+++ b/src/pages/docs/api/fee-payer.mdx
@@ -35,7 +35,7 @@ https://api.tempo.xyz/rpc/sponsor
 
 ### Sign into the Tempo Console
 
-Open [**Projects** in Tempo Console](https://console.tempo.xyz/?to=/:organization/projects) and select **Sign in with Tempo**.
+Open the [Tempo Console](https://console.tempo.xyz/?to=/:organization/projects) and select **Sign in with Tempo**.
 
 :::info
 Tempo Console signups are currently limited. [Contact us](https://tempo.xyz/contact/) to request access.
@@ -43,11 +43,11 @@ Tempo Console signups are currently limited. [Contact us](https://tempo.xyz/cont
 
 ### Set up Organization
 
-Open [**Projects** in Tempo Console](https://console.tempo.xyz/?to=/:organization/projects), then select [**New project**](https://console.tempo.xyz/?to=/:organization/new). Create an organization first if prompted.
+Create an organization and project.
 
 ### Set up Billing
 
-For this testnet example, select [**Sandbox mode**](https://console.tempo.xyz/?to=/:organization/projects%3Fenv%3Dsandbox), then open [**Billing**](https://console.tempo.xyz/?to=/:organization/billing%3Fenv%3Dsandbox) and add a payment method. The amber banner confirms that the console is in sandbox mode.
+For this testnet example, switch to [**Sandbox mode**](https://console.tempo.xyz/?to=/:organization/projects%3Fenv%3Dsandbox) (located in the top-left organization picker), then open [**Billing**](https://console.tempo.xyz/?to=/:organization/billing%3Fenv%3Dsandbox) and add a payment method.
 
 :::info
 For production, keep the Console in the production environment and do not switch to **Sandbox mode**. Production fee sponsorship requires active billing.
@@ -55,7 +55,7 @@ For production, keep the Console in the production environment and do not switch
 
 ### Get an API Key
 
-Open [**Sandbox API Keys** in Tempo Console](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox), select [**New key**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox), choose your project, and create the key. Copy it when prompted; it is shown only once.
+Open [**API Keys**](https://console.tempo.xyz/?to=/:organization/api-keys%3Fenv%3Dsandbox), select [**New key**](https://console.tempo.xyz/?to=/:organization/api-keys/new%3Fenv%3Dsandbox), choose your project, and create the key. Copy it when prompted; it is shown only once.
 
 ### Sponsor Transaction Fees
 


### PR DESCRIPTION
Links Tempo API documentation actions directly to their organization-aware console destinations.