### PR TITLE
ci: require redirects for removed docs pages

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 permissions: {}
@@ -18,12 +19,36 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      issues: write
+      pull-requests: read
 
     steps:
       - name: Clone repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check removed docs routes
+        id: removed-doc-routes
+        if: github.event_name == 'pull_request'
+        run: node scripts/check-removed-doc-routes.mjs
+        env:
+          DOCS_ROUTE_GUARD_BASE: ${{ github.event.pull_request.base.sha }}
+          DOCS_REMOVAL_OK: ${{ contains(github.event.pull_request.labels.*.name, 'docs-removal-ok') }}
+
+      - name: Explain removed docs route failure
+        if: ${{ failure() && steps.removed-doc-routes.outcome == 'failure' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '.[] | select(.body | contains("<!-- docs-route-guard -->")) | .id' | grep -q .; then
+            exit 0
+          fi
+
+          gh pr comment "$PR_NUMBER" --body $'<!-- docs-route-guard -->\nA removed docs page is missing a Vocs redirect. Add a redirect in `vocs.config.ts`, or apply the `docs-removal-ok` label to explicitly acknowledge the intentional URL removal. Applying or removing the label reruns this check.'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/scripts/check-removed-doc-routes.mjs
+++ b/scripts/check-removed-doc-routes.mjs
@@ -1,0 +1,59 @@
+import { execFileSync } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+
+const base = process.env.DOCS_ROUTE_GUARD_BASE
+
+if (!base) {
+  console.log('Skipping removed docs route check outside a pull request.')
+  process.exit(0)
+}
+
+const deletedFiles = execFileSync(
+  'git',
+  ['diff', '--diff-filter=D', '--name-only', base + '...HEAD', '--', 'src/pages/docs'],
+  { encoding: 'utf8' },
+)
+  .split('\n')
+  .filter((file) => file.endsWith('.md') || file.endsWith('.mdx'))
+
+function routeFor(file) {
+  const route = file
+    .slice('src/pages/'.length)
+    .replace(/\.(?:md|mdx)$/, '')
+    .replace(/\/index$/, '')
+  return '/' + route
+}
+
+function sourceMatchesRoute(source, route) {
+  if (source === route) return true
+  if (!source.endsWith('/:path*')) return false
+
+  const prefix = source.slice(0, -7)
+  return route === prefix || route.startsWith(prefix + '/')
+}
+
+const vocsConfig = await readFile(new URL('../vocs.config.ts', import.meta.url), 'utf8')
+const redirectSources = [...vocsConfig.matchAll(/source:\s*'([^']+)'/g)].map(([, source]) => source)
+const missingRedirects = deletedFiles
+  .map(routeFor)
+  .filter((route) => !redirectSources.some((source) => sourceMatchesRoute(source, route)))
+
+if (missingRedirects.length === 0) {
+  console.log('Every removed docs page has a Vocs redirect.')
+  process.exit(0)
+}
+
+if (process.env.DOCS_REMOVAL_OK === 'true') {
+  console.warn(
+    'docs-removal-ok is present; allowing removed routes without redirects:\n' +
+      missingRedirects.map((route) => '- ' + route).join('\n'),
+  )
+  process.exit(0)
+}
+
+console.error(
+  'Removed docs routes need a Vocs redirect:\n' +
+    missingRedirects.map((route) => '- ' + route).join('\n') +
+    '\n\nAdd redirects, or apply the docs-removal-ok label to explicitly acknowledge the intentional break.',
+)
+process.exit(1)


### PR DESCRIPTION
## Motivation

Removing a file-based documentation page can silently break a public URL.

## Summary

- Detect deleted documentation pages in pull requests
- Require a matching Vercel redirect or the `docs-removal-ok` label

## Key design considerations

- The label is an explicit, reviewable acknowledgement for intentional URL removal.