### PR TITLE
fix: post docs route guard comments

### DIFF
--- a/.github/workflows/removed-doc-route-comment.yml
+++ b/.github/workflows/removed-doc-route-comment.yml
@@ -1,0 +1,39 @@
+name: Removed docs route comment
+
+on:
+  workflow_run:
+    workflows: [Verify]
+    types: [completed]
+
+permissions:
+  issues: write
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain removed docs route failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          if [[ -z "$PR_NUMBER" ]]; then
+            exit 0
+          fi
+
+          if ! gh api --paginate "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs?per_page=100" \
+            --jq '.jobs[] | select(.name == "Check") | .steps[] | select(.name == "Check removed docs routes" and .conclusion == "failure") | .name' | grep -q .; then
+            exit 0
+          fi
+
+          if gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '.[] | select(.body | contains("<!-- docs-route-guard -->")) | .id' | grep -q .; then
+            exit 0
+          fi
+
+          gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            -f body=$'<!-- docs-route-guard -->\nA removed docs page is missing a Vocs redirect. Add a redirect in `vocs.config.ts`, or apply the `docs-removal-ok` label to explicitly acknowledge the intentional URL removal. Applying or removing the label reruns this check.'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,7 +19,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      issues: write
       pull-requests: read
 
     steps:
@@ -30,25 +29,11 @@ jobs:
           fetch-depth: 0
 
       - name: Check removed docs routes
-        id: removed-doc-routes
         if: github.event_name == 'pull_request'
         run: node scripts/check-removed-doc-routes.mjs
         env:
           DOCS_ROUTE_GUARD_BASE: ${{ github.event.pull_request.base.sha }}
           DOCS_REMOVAL_OK: ${{ contains(github.event.pull_request.labels.*.name, 'docs-removal-ok') }}
-
-      - name: Explain removed docs route failure
-        if: ${{ failure() && steps.removed-doc-routes.outcome == 'failure' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          if gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments?per_page=100" \
-            --jq '.[] | select(.body | contains("<!-- docs-route-guard -->")) | .id' | grep -q .; then
-            exit 0
-          fi
-
-          gh pr comment "$PR_NUMBER" --body $'<!-- docs-route-guard -->\nA removed docs page is missing a Vocs redirect. Add a redirect in `vocs.config.ts`, or apply the `docs-removal-ok` label to explicitly acknowledge the intentional URL removal. Applying or removing the label reruns this check.'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0


### PR DESCRIPTION
## Motivation

The removed-docs guard fails correctly, but its PR comment uses a mutation that is not permitted by the workflow token.

## Summary

- Post the guidance comment through the issue-comment REST endpoint

## Key design considerations

- Uses the existing `issues: write` permission.