### PR TITLE
fix: harden docs routing contract

### DIFF
--- a/.github/workflows/docs-routing-smoke.yml
+++ b/.github/workflows/docs-routing-smoke.yml
@@ -1,0 +1,52 @@
+name: Docs routing smoke
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+    inputs:
+      canonical_origin:
+        description: Canonical Tempo origin to test
+        required: true
+        default: https://tempo.xyz
+      legacy_origin:
+        description: Legacy docs origin to test
+        required: true
+        default: https://docs.tempo.xyz
+
+permissions: {}
+
+jobs:
+  smoke:
+    name: Production redirect contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      DOCS_ROUTING_SMOKE_CANONICAL_ORIGIN: ${{ inputs.canonical_origin || 'https://tempo.xyz' }}
+      DOCS_ROUTING_SMOKE_LEGACY_ORIGIN: ${{ inputs.legacy_origin || 'https://docs.tempo.xyz' }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          run_install: false
+          version: 10.28.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.12.0
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify deployed routing
+        run: pnpm test:routing:smoke

--- a/README.md
+++ b/README.md
@@ -33,6 +33,47 @@ pnpm build          # Build for production
 pnpm preview        # Preview the production build
 ```
 
+## Routing and redirects
+
+The canonical public documentation URL is [`https://tempo.xyz/developers`](https://tempo.xyz/developers). This repository serves the docs application, while the Tempo web application proxies that public mount to this deployment.
+
+```mermaid
+flowchart LR
+  Legacy["docs.tempo.xyz\nnext.docs.tempo.xyz"] -->|"301"| Canonical["tempo.xyz/developers"]
+  Canonical -->|"Tempo web proxy"| Edge["Docs Vercel edge"]
+  Edge -->|"redirects and RSC rewrites"| Vocs["Vocs /docs routes"]
+  Vocs --> Pages["Documentation pages"]
+```
+
+### Routing ownership
+
+| Surface | Owner | Purpose |
+| --- | --- | --- |
+| `tempo.xyz/developers/*` | Tempo web | Canonical public mount and proxy to this deployment. |
+| `docs.tempo.xyz` and `next.docs.tempo.xyz` | `vercel.json` | Permanent redirects to the canonical public URL. |
+| Native `/docs/*` paths | `vocs.config.ts` | Page-level redirects after a request reaches Vocs. |
+| Proxied `/developers/docs/*` paths | `vercel.json` | Compatibility redirects that must run before Vocs. |
+| RSC artifacts | `vercel.json`, Vite, and the docs layout | Normalize the proxy mount until the docs runtime can own `/developers` natively. |
+
+`developers.tempo.xyz` is a proxy origin. Do not add it to the legacy-host redirect matcher: that creates a redirect loop through Tempo web.
+
+### Redirect invariants
+
+- A legacy URL redirects directly to its canonical URL; do not add redirect chains.
+- Native and proxied forms of a removed docs page both remain supported. Production Vocs redirects must use the canonical absolute destination so a proxy-relative `Location` cannot escape `/developers`.
+- Preserve path parameters and query strings unless a route intentionally maps to one replacement page.
+- Keep API compatibility routes exact. A broad `/api/:path*` redirect would shadow real handlers such as `/api/og` and `/api/feedback`.
+- Keep Vercel's `trailingSlash: false` and Vocs' `trailingSlashRedirect: false` paired. Changing only one can reintroduce the `/developers/docs` loop.
+
+### Move or remove a docs page
+
+1. Add the native redirect in `vocs.config.ts`. For a proxied legacy route, add it to [`src/lib/docs-routing.ts`](./src/lib/docs-routing.ts) so the Vercel mirror, tests, and smoke check share the contract.
+2. Add the matching `/developers/docs/...` Vercel redirect when the page is publicly available through the proxy mount.
+3. Run `pnpm test`, `pnpm check:types`, and `pnpm test:routing:smoke` against a deployment. The smoke command requires `DOCS_ROUTING_SMOKE_CANONICAL_ORIGIN` and `DOCS_ROUTING_SMOKE_LEGACY_ORIGIN`.
+4. For proxy or canonical URL changes, coordinate the Tempo web deployment first. Verify the public canonical URL before enabling legacy-host redirects.
+
+The pull-request route guard rejects deleted docs pages without both native and proxied redirects, unless the `docs-removal-ok` label explicitly records an intentional break. The scheduled **Docs routing smoke** workflow tests the deployed production redirect contract every day.
+
 ## Contributing
 
 Our contributor guidelines can be found in [`CONTRIBUTING.md`](https://github.com/tempoxyz/docs?tab=contributing-ov-file).

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "search:benchmark": "bun search-benchmark/run.ts",
     "test": "vitest run --dir src",
     "test:e2e": "playwright test",
+    "test:routing:smoke": "tsx scripts/smoke-docs-routing.ts",
     "bundle:analyze": "node --experimental-strip-types scripts/bundle-diff.ts --skip-build",
     "bundle:diff": "node --experimental-strip-types scripts/bundle-diff.ts",
     "bundle:save": "node --experimental-strip-types scripts/bundle-diff.ts --save",

--- a/scripts/check-removed-doc-routes.mjs
+++ b/scripts/check-removed-doc-routes.mjs
@@ -10,7 +10,7 @@ if (!base) {
 
 const deletedFiles = execFileSync(
   'git',
-  ['diff', '--diff-filter=D', '--name-only', base + '...HEAD', '--', 'src/pages/docs'],
+  ['diff', '--diff-filter=D', '--name-only', `${base}...HEAD`, '--', 'src/pages/docs'],
   { encoding: 'utf8' },
 )
   .split('\n')
@@ -21,7 +21,7 @@ function routeFor(file) {
     .slice('src/pages/'.length)
     .replace(/\.(?:md|mdx)$/, '')
     .replace(/\/index$/, '')
-  return '/' + route
+  return `/${route}`
 }
 
 function sourceMatchesRoute(source, route) {
@@ -29,35 +29,54 @@ function sourceMatchesRoute(source, route) {
   if (!source.endsWith('/:path*')) return false
 
   const prefix = source.slice(0, -7)
-  return route === prefix || route.startsWith(prefix + '/')
+  return route === prefix || route.startsWith(`${prefix}/`)
 }
 
-const vocsConfig = await readFile(new URL('../vocs.config.ts', import.meta.url), 'utf8')
-const redirectSources = [...vocsConfig.matchAll(/source:\s*'([^']+)'/g)].map(([, source]) => source)
-const missingRedirects = deletedFiles
+const [vocsConfig, routeContract, vercelConfigText] = await Promise.all([
+  readFile(new URL('../vocs.config.ts', import.meta.url), 'utf8'),
+  readFile(new URL('../src/lib/docs-routing.ts', import.meta.url), 'utf8'),
+  readFile(new URL('../vercel.json', import.meta.url), 'utf8'),
+])
+const redirectSources = [vocsConfig, routeContract].flatMap((config) =>
+  [...config.matchAll(/source:\s*'([^']+)'/g)].map(([, source]) => source),
+)
+const vercelRedirectSources = JSON.parse(vercelConfigText).redirects.map(
+  (redirect) => redirect.source,
+)
+const missingAppRedirects = deletedFiles
   .map(routeFor)
   .filter((route) => !redirectSources.some((source) => sourceMatchesRoute(source, route)))
+const missingProxyRedirects = deletedFiles
+  .map(routeFor)
+  .filter(
+    (route) =>
+      !vercelRedirectSources.some((source) => sourceMatchesRoute(source, `/developers${route}`)),
+  )
+const missingRedirects = [
+  ...missingAppRedirects.map((route) => `Vocs route: ${route}`),
+  ...missingProxyRedirects.map((route) => `Proxy route: /developers${route}`),
+]
 
 if (missingRedirects.length === 0) {
-  console.log('Every removed docs page has a Vocs redirect.')
+  console.log('Every removed docs page has native and proxied redirects.')
   process.exit(0)
 }
 
 if (process.env.DOCS_REMOVAL_OK === 'true') {
   console.warn(
     'docs-removal-ok is present; allowing removed routes without redirects:\n' +
-      missingRedirects.map((route) => '- ' + route).join('\n'),
+      missingRedirects.map((route) => `- ${route}`).join('\n'),
   )
   process.exit(0)
 }
 
 const message =
-  'Removed docs routes need a Vocs redirect:\n' +
-  missingRedirects.map((route) => '- ' + route).join('\n') +
-  '\n\nAdd redirects, or apply the docs-removal-ok label to explicitly acknowledge the intentional break.'
+  'Removed docs routes need native and proxied redirects:\n' +
+  missingRedirects.map((route) => `- ${route}`).join('\n') +
+  '\n\nAdd both redirects, or apply the docs-removal-ok label to explicitly acknowledge the intentional break.'
 
 console.error(
-  `::error title=Removed docs route requires redirect::${message.replace(/\n/g, '%0A')}`,
+  `::error title=Removed docs route requires redirects::${message.replace(/\n/g, '%0A')}`,
 )
 console.error(message)
 process.exit(1)

--- a/scripts/smoke-docs-routing.ts
+++ b/scripts/smoke-docs-routing.ts
@@ -1,0 +1,66 @@
+import { canonicalDevelopersOrigin, routingSmokeCases } from '../src/lib/docs-routing'
+
+type SmokeCase =
+  | (typeof routingSmokeCases.canonical)[number]
+  | (typeof routingSmokeCases.legacy)[number]
+
+function originFromEnv(name: string) {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required`)
+  return new URL(value).origin
+}
+
+function urlFor(origin: string, path: string) {
+  return new URL(path, `${origin}/`).toString()
+}
+
+async function request(url: string) {
+  return fetch(url, { redirect: 'manual' })
+}
+
+async function checkCase(origin: string, testCase: SmokeCase) {
+  const source = urlFor(origin, testCase.path)
+  const response = await request(source)
+
+  if ('expectedStatus' in testCase) {
+    if (response.status !== testCase.expectedStatus) {
+      throw new Error(`${source} returned ${response.status}; expected ${testCase.expectedStatus}`)
+    }
+    return
+  }
+
+  if ('expectedNonRedirect' in testCase) {
+    if (response.status >= 300 && response.status < 400) {
+      throw new Error(`${source} unexpectedly redirected to ${response.headers.get('location')}`)
+    }
+    return
+  }
+
+  const location = response.headers.get('location')
+  if (location !== testCase.expectedLocation) {
+    throw new Error(`${source} redirected to ${location}; expected ${testCase.expectedLocation}`)
+  }
+
+  const finalResponse = await request(new URL(location, source).toString())
+  if (finalResponse.status !== testCase.expectedFinalStatus) {
+    throw new Error(
+      `${source} reached ${location} with ${finalResponse.status}; expected ${testCase.expectedFinalStatus}`,
+    )
+  }
+}
+
+const canonicalOrigin = originFromEnv('DOCS_ROUTING_SMOKE_CANONICAL_ORIGIN')
+const legacyOrigin = originFromEnv('DOCS_ROUTING_SMOKE_LEGACY_ORIGIN')
+
+if (canonicalOrigin !== new URL(canonicalDevelopersOrigin).origin) {
+  console.warn(
+    `Canonical smoke target is ${canonicalOrigin}; expected production origin ${new URL(canonicalDevelopersOrigin).origin}.`,
+  )
+}
+
+for (const testCase of routingSmokeCases.canonical) await checkCase(canonicalOrigin, testCase)
+for (const testCase of routingSmokeCases.legacy) await checkCase(legacyOrigin, testCase)
+
+console.log(
+  `Validated ${routingSmokeCases.canonical.length + routingSmokeCases.legacy.length} deployed routing cases.`,
+)

--- a/src/lib/docs-routing.test.ts
+++ b/src/lib/docs-routing.test.ts
@@ -2,6 +2,12 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import vocsConfig from '../../vocs.config'
+import {
+  canonicalDevelopersOrigin,
+  docsRouteDestination,
+  legacyDocsHostRoutes,
+  proxiedLegacyDocsRoutes,
+} from './docs-routing'
 
 type Redirect = {
   source: string
@@ -14,18 +20,6 @@ type VocsRedirect = {
   source: string
   destination: string
 }
-
-// tempo.xyz preserves `/developers` while proxying to this deployment. Vocs only
-// sees its native `/docs` routes, so each legacy redirect must also exist at the
-// proxy mount or the static router can return a 404 before Vocs runs.
-const proxiedLegacyRedirects = [
-  ['/docs/quickstart/developer-tools', '/docs/ecosystem'],
-  ['/docs/developer-tools', '/docs/ecosystem'],
-  ['/docs/developer-tools/fee-payer', '/docs/api/fee-payer'],
-  ['/docs/developer-tools/indexer', '/docs/api/indexer-api'],
-  ['/docs/hosted-services', '/docs/api'],
-  ['/docs/hosted-services/:path*', '/docs/api'],
-] as const
 
 const vercelConfig = JSON.parse(
   fs.readFileSync(path.join(process.cwd(), 'vercel.json'), 'utf-8'),
@@ -72,37 +66,44 @@ function findHostRedirectIndex(source: string, host: string) {
 }
 
 describe('docs routing redirects', () => {
+  it('keeps proxied route destinations inside the public mount in production', () => {
+    expect(docsRouteDestination('/docs/api', 'production')).toBe(
+      `${canonicalDevelopersOrigin}/docs/api`,
+    )
+    expect(docsRouteDestination('/docs/api', 'preview')).toBe('/docs/api')
+  })
+
   it('normalizes trailing slashes before static route handling', () => {
     expect(vercelConfig.trailingSlash).toBe(false)
   })
 
   describe('proxied legacy documentation routes', () => {
-    it.each(proxiedLegacyRedirects)(
-      'mirrors %s at the /developers mount',
-      (source, destination) => {
-        const proxySource = `/developers${source}`
-        const proxyDestination = `/developers${destination}`
-        const matchingProxyRedirects = redirects.filter(
-          (redirect) => redirect.source === proxySource,
-        )
+    it.each(proxiedLegacyDocsRoutes)('mirrors $source at the /developers mount', ({
+      source,
+      destination,
+    }) => {
+      const proxySource = `/developers${source}`
+      const proxyDestination = `/developers${destination}`
+      const matchingProxyRedirects = redirects.filter((redirect) => redirect.source === proxySource)
 
-        expect(
-          vocsRedirects.some(
-            (redirect) => redirect.source === source && redirect.destination === destination,
-          ),
-        ).toBe(true)
-        expect(matchingProxyRedirects).toEqual([
-          expect.objectContaining({
-            source: proxySource,
-            destination: proxyDestination,
-            permanent: true,
-          }),
-        ])
-      },
-    )
+      expect(
+        vocsRedirects.some(
+          (redirect) =>
+            redirect.source === source &&
+            redirect.destination === docsRouteDestination(destination),
+        ),
+      ).toBe(true)
+      expect(matchingProxyRedirects).toEqual([
+        expect.objectContaining({
+          source: proxySource,
+          destination: proxyDestination,
+          permanent: true,
+        }),
+      ])
+    })
 
     it('uses canonical no-slash proxy sources and destinations', () => {
-      for (const [source, destination] of proxiedLegacyRedirects) {
+      for (const { source, destination } of proxiedLegacyDocsRoutes) {
         const redirect = findRedirect(`/developers${source}`)
 
         expect(redirect?.source).not.toMatch(/\/$/)
@@ -126,42 +127,32 @@ describe('docs routing redirects', () => {
       })
     })
 
-    it.each([
-      ['/guide/bridge-usdc-stargate', 'https://tempo.xyz/developers/docs/guide/bridge-layerzero'],
-      ['/guide/bridge-usdc-relay', 'https://tempo.xyz/developers/docs/guide/bridge-relay'],
-      [
-        '/guide/node/validator-config-v2',
-        'https://tempo.xyz/developers/docs/guide/node/network-upgrades',
-      ],
-      [
-        '/AccountKeychain',
-        'https://tempo.xyz/developers/docs/protocol/transactions/AccountKeychain',
-      ],
-      ['/developer-tools', 'https://tempo.xyz/developers/docs/ecosystem'],
-      ['/developer-tools/fee-payer', 'https://tempo.xyz/developers/docs/api/fee-payer'],
-      ['/developer-tools/indexer', 'https://tempo.xyz/developers/docs/api/indexer-api'],
-      ['/hosted-services', 'https://tempo.xyz/developers/docs/api'],
-      ['/hosted-services/:path*', 'https://tempo.xyz/developers/docs/api'],
-      ['/learn/partners', 'https://tempo.xyz/developers/docs/partners'],
-      ['/docs/learn/partners', 'https://tempo.xyz/developers/docs/partners'],
-      ['/docs/guide/using-tempo-with-ai/partners', 'https://tempo.xyz/developers/docs/partners'],
-      ['/build/partners', 'https://tempo.xyz/developers/docs/partners'],
-      ['/network-upgrades', 'https://tempo.xyz/developers/docs/guide/node/network-upgrades'],
-      [
-        '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|changelog|partners)',
-        'https://tempo.xyz/developers/docs/:section',
-      ],
-      [
-        '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|developer-tools)/:path*',
-        'https://tempo.xyz/developers/docs/:section/:path*',
-      ],
-    ])('redirects legacy route %s to %s before the host catch-all', (source, destination) => {
+    it.each(legacyDocsHostRoutes)('redirects $source to $destination before the host catch-all', ({
+      source,
+      destination,
+    }) => {
       expect(findHostRedirect(source, host)).toMatchObject({
         source,
         destination,
         permanent: true,
       })
 
+      expect(findHostRedirectIndex(source, host)).toBeLessThan(
+        findHostRedirectIndex('/:path*', host),
+      )
+    })
+
+    it.each([
+      [
+        '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|changelog|partners)',
+        `${canonicalDevelopersOrigin}/docs/:section`,
+      ],
+      [
+        '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|developer-tools)/:path*',
+        `${canonicalDevelopersOrigin}/docs/:section/:path*`,
+      ],
+    ])('redirects legacy section %s to %s before the host catch-all', (source, destination) => {
+      expect(findHostRedirect(source, host)).toMatchObject({ source, destination, permanent: true })
       expect(findHostRedirectIndex(source, host)).toBeLessThan(
         findHostRedirectIndex('/:path*', host),
       )

--- a/src/lib/docs-routing.ts
+++ b/src/lib/docs-routing.ts
@@ -1,0 +1,100 @@
+export type DocsRouteContract = {
+  source: string
+  destination: string
+}
+
+export const canonicalDevelopersOrigin = 'https://tempo.xyz/developers'
+
+export function docsRouteDestination(destination: string, environment = process.env.VERCEL_ENV) {
+  if (environment === 'production') return `${canonicalDevelopersOrigin}${destination}`
+  return destination
+}
+
+// These routes are evaluated in three places: Vocs for native `/docs` traffic,
+// Vercel before the `/developers` proxy mount reaches Vocs, and the legacy docs
+// host. Keep the mappings here so tests and deployed smoke checks share one
+// contract.
+export const proxiedLegacyDocsRoutes = [
+  { source: '/docs/quickstart/developer-tools', destination: '/docs/ecosystem' },
+  { source: '/docs/developer-tools', destination: '/docs/ecosystem' },
+  { source: '/docs/developer-tools/fee-payer', destination: '/docs/api/fee-payer' },
+  { source: '/docs/developer-tools/indexer', destination: '/docs/api/indexer-api' },
+  { source: '/docs/hosted-services', destination: '/docs/api' },
+  { source: '/docs/hosted-services/:path*', destination: '/docs/api' },
+] as const satisfies readonly DocsRouteContract[]
+
+export const legacyDocsHostRoutes = [
+  {
+    source: '/guide/bridge-usdc-stargate',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/bridge-layerzero`,
+  },
+  {
+    source: '/guide/bridge-usdc-relay',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/bridge-relay`,
+  },
+  {
+    source: '/guide/node/validator-config-v2',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/node/network-upgrades`,
+  },
+  {
+    source: '/AccountKeychain',
+    destination: `${canonicalDevelopersOrigin}/docs/protocol/transactions/AccountKeychain`,
+  },
+  { source: '/developer-tools', destination: `${canonicalDevelopersOrigin}/docs/ecosystem` },
+  {
+    source: '/developer-tools/fee-payer',
+    destination: `${canonicalDevelopersOrigin}/docs/api/fee-payer`,
+  },
+  {
+    source: '/developer-tools/indexer',
+    destination: `${canonicalDevelopersOrigin}/docs/api/indexer-api`,
+  },
+  { source: '/hosted-services', destination: `${canonicalDevelopersOrigin}/docs/api` },
+  { source: '/hosted-services/:path*', destination: `${canonicalDevelopersOrigin}/docs/api` },
+  { source: '/learn/partners', destination: `${canonicalDevelopersOrigin}/docs/partners` },
+  { source: '/docs/learn/partners', destination: `${canonicalDevelopersOrigin}/docs/partners` },
+  {
+    source: '/docs/guide/using-tempo-with-ai/partners',
+    destination: `${canonicalDevelopersOrigin}/docs/partners`,
+  },
+  { source: '/build/partners', destination: `${canonicalDevelopersOrigin}/docs/partners` },
+  {
+    source: '/network-upgrades',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/node/network-upgrades`,
+  },
+] as const satisfies readonly DocsRouteContract[]
+
+export const routingSmokeCases = {
+  canonical: [
+    { path: '/developers', expectedStatus: 200 },
+    { path: '/developers/docs/quickstart/integrate-tempo', expectedStatus: 200 },
+    {
+      path: '/developers/docs/quickstart/developer-tools',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/ecosystem`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/developers/docs/hosted-services',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/api`,
+      expectedFinalStatus: 200,
+    },
+    { path: '/developers/api/og', expectedNonRedirect: true },
+  ],
+  legacy: [
+    {
+      path: '/guide/bridge-usdc-stargate',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/guide/bridge-layerzero`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/developer-tools/fee-payer',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/api/fee-payer`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/docs/quickstart/integrate-tempo',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/quickstart/integrate-tempo`,
+      expectedFinalStatus: 200,
+    },
+  ],
+} as const

--- a/src/lib/docs-routing.ts
+++ b/src/lib/docs-routing.ts
@@ -15,7 +15,6 @@ export function docsRouteDestination(destination: string, environment = process.
 // host. Keep the mappings here so tests and deployed smoke checks share one
 // contract.
 export const proxiedLegacyDocsRoutes = [
-  { source: '/docs/quickstart/developer-tools', destination: '/docs/ecosystem' },
   { source: '/docs/developer-tools', destination: '/docs/ecosystem' },
   { source: '/docs/developer-tools/fee-payer', destination: '/docs/api/fee-payer' },
   { source: '/docs/developer-tools/indexer', destination: '/docs/api/indexer-api' },
@@ -68,11 +67,7 @@ export const routingSmokeCases = {
   canonical: [
     { path: '/developers', expectedStatus: 200 },
     { path: '/developers/docs/quickstart/integrate-tempo', expectedStatus: 200 },
-    {
-      path: '/developers/docs/quickstart/developer-tools',
-      expectedLocation: `${canonicalDevelopersOrigin}/docs/ecosystem`,
-      expectedFinalStatus: 200,
-    },
+    { path: '/developers/docs/quickstart/developer-tools', expectedStatus: 200 },
     {
       path: '/developers/docs/hosted-services',
       expectedLocation: `${canonicalDevelopersOrigin}/docs/api`,

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,4 +1,5 @@
 import { Changelog, defineConfig, Embedding, McpSource, Reranker, Retriever } from 'vocs/config'
+import { docsRouteDestination, proxiedLegacyDocsRoutes } from './src/lib/docs-routing'
 import { createFeedbackAdapter } from './src/lib/feedback-adapter'
 
 // Only set baseUrl in production — Vocs injects a <base> tag from this value,
@@ -62,8 +63,9 @@ export default defineConfig({
   },
   title: 'Tempo Docs',
   titleTemplate: (path, { title }) => {
-    if (path === '/docs') return 'Tempo %s ⋅ Tempo Docs'
-    if (path.startsWith('/docs/')) return '%s ⋅ Tempo Docs'
+    const pagePath = typeof path === 'string' ? path : '/'
+    if (pagePath === '/docs') return 'Tempo %s ⋅ Tempo Docs'
+    if (pagePath.startsWith('/docs/')) return '%s ⋅ Tempo Docs'
     if (title?.includes('Tempo')) return undefined
     return '%s ⋅ Tempo'
   },
@@ -71,7 +73,8 @@ export default defineConfig({
   renderStrategy: 'partial-static',
   feedback: createFeedbackAdapter(),
   head(path) {
-    if (path === '/docs' || path.startsWith('/docs/'))
+    const pagePath = typeof path === 'string' ? path : '/'
+    if (pagePath === '/docs' || pagePath.startsWith('/docs/'))
       return { meta: { articleModifiedTime: false } }
     return undefined
   },
@@ -112,7 +115,8 @@ export default defineConfig({
   },
   sitemap: {
     lastmod: (path, { lastmod }) => {
-      if (path === '/docs' || path.startsWith('/docs/')) return false
+      const pagePath = typeof path === 'string' ? path : '/'
+      if (pagePath === '/docs' || pagePath.startsWith('/docs/')) return false
       return lastmod
     },
   },
@@ -135,7 +139,7 @@ export default defineConfig({
   // src/lib/og-sections.test.ts fails if the two drift.
   ogImageUrl: (path, options = {}) => {
     const urlBase = options.baseUrl?.replace(/\/$/, '') ?? ''
-    const docsPath = path.replace(/^\/docs(?=\/|$)/, '') || '/'
+    const docsPath = String(path ?? '').replace(/^\/docs(?=\/|$)/, '') || '/'
     const landingPaths = ['/', '/changelog']
     if (landingPaths.includes(docsPath)) return `${urlBase}/og-docs.png`
 
@@ -866,7 +870,7 @@ export default defineConfig({
             items: [
               {
                 text: 'T8',
-                badge: { text: 'Planned', variant: 'note' },
+                badge: { text: 'Planned', variant: 'note' as const },
                 link: '/docs/protocol/upgrades/t8',
               },
               {
@@ -1215,8 +1219,13 @@ export default defineConfig({
     { text: 'Wallet', link: 'https://wallet.tempo.xyz' },
   ],
   redirects: [
-    // Keep proxied `/developers` developer-tools and hosted-services equivalents
-    // in vercel.json synchronized; the static router runs before Vocs at that mount.
+    // Vercel mirrors these at `/developers` because the static router runs before
+    // Vocs at that proxy mount. The route contract and tests keep them aligned.
+    ...proxiedLegacyDocsRoutes.map((redirect) => ({
+      ...redirect,
+      destination: docsRouteDestination(redirect.destination),
+      status: 301,
+    })),
     {
       source: '/docs/documentation/protocol/:path*',
       destination: '/docs/protocol/:path*',
@@ -1224,36 +1233,6 @@ export default defineConfig({
     {
       source: '/docs/stablecoin-exchange/:path*',
       destination: '/docs/guide/stablecoin-dex/:path*',
-      status: 301,
-    },
-    {
-      source: '/docs/quickstart/developer-tools',
-      destination: '/docs/ecosystem',
-      status: 301,
-    },
-    {
-      source: '/docs/developer-tools',
-      destination: '/docs/ecosystem',
-      status: 301,
-    },
-    {
-      source: '/docs/developer-tools/fee-payer',
-      destination: '/docs/api/fee-payer',
-      status: 301,
-    },
-    {
-      source: '/docs/developer-tools/indexer',
-      destination: '/docs/api/indexer-api',
-      status: 301,
-    },
-    {
-      source: '/docs/hosted-services',
-      destination: '/docs/api',
-      status: 301,
-    },
-    {
-      source: '/docs/hosted-services/:path*',
-      destination: '/docs/api',
       status: 301,
     },
     {


### PR DESCRIPTION
## Motivation

Redirect handling spans the Tempo web proxy, Vercel edge rules, and Vocs. Relative redirects from proxied routes can escape the canonical `/developers` mount, while page removals can leave one public route form behind.

## Summary

- Document routing ownership, redirect invariants, diagrams, and the page-move runbook in the README.
- Add a shared contract for proxy-sensitive legacy redirects and test it against Vercel and Vocs configuration.
- Require both native and proxied redirects when documentation pages are deleted.
- Add a scheduled deployed-route smoke workflow.

## Key design considerations

- Production Vocs redirects use canonical absolute destinations; preview and local redirects stay origin-relative.
- The smoke workflow exercises canonical and legacy hosts because local preview cannot reproduce the Tempo proxy boundary.