### PR TITLE
Disable session replay on docs surfaces

### DIFF
--- a/src/components/PostHogSetup.tsx
+++ b/src/components/PostHogSetup.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import { POSTHOG_REPLAY_PRIVACY_CONFIG } from '../lib/posthog-privacy'
 
 function PostHogInitializer({ site }: { site: string }) {
   useEffect(() => {
@@ -18,12 +19,7 @@ function PostHogInitializer({ site }: { site: string }) {
         defaults: '2025-11-30',
         capture_exceptions: true,
         debug: import.meta.env.MODE === 'development',
-        session_recording: {
-          maskAllInputs: false,
-          maskInputOptions: {
-            password: true,
-          },
-        },
+        ...POSTHOG_REPLAY_PRIVACY_CONFIG,
       })
       posthog.register({ site })
     }

--- a/src/lib/posthog-privacy.test.ts
+++ b/src/lib/posthog-privacy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { POSTHOG_REPLAY_PRIVACY_CONFIG } from './posthog-privacy'
+
+describe('PostHog replay privacy', () => {
+  it('keeps session replay disabled for every shared browser surface', () => {
+    expect(POSTHOG_REPLAY_PRIVACY_CONFIG.disable_session_recording).toBe(true)
+  })
+
+  it('fails closed if session replay is enabled accidentally', () => {
+    expect(POSTHOG_REPLAY_PRIVACY_CONFIG).toMatchObject({
+      capture_performance: { network_timing: false },
+      enable_recording_console_log: false,
+      session_recording: {
+        maskAllInputs: true,
+        maskTextSelector: '*',
+        blockSelector: '[data-ph-sensitive]',
+        recordHeaders: false,
+        recordBody: false,
+        captureCanvas: { recordCanvas: false },
+        collectFonts: false,
+      },
+    })
+  })
+})

--- a/src/lib/posthog-privacy.ts
+++ b/src/lib/posthog-privacy.ts
@@ -1,0 +1,21 @@
+import type { PostHogConfig } from 'posthog-js'
+
+/**
+ * Session replay stays disabled on every surface that shares PostHogSetup,
+ * including docs, developers, and docs routes proxied through tempo.xyz.
+ * The remaining options fail closed if replay is ever enabled accidentally.
+ */
+export const POSTHOG_REPLAY_PRIVACY_CONFIG = {
+  disable_session_recording: true,
+  capture_performance: { network_timing: false },
+  enable_recording_console_log: false,
+  session_recording: {
+    maskAllInputs: true,
+    maskTextSelector: '*',
+    blockSelector: '[data-ph-sensitive]',
+    recordHeaders: false,
+    recordBody: false,
+    captureCanvas: { recordCanvas: false },
+    collectFonts: false,
+  },
+} satisfies Partial<PostHogConfig>


### PR DESCRIPTION
## Summary

- Disable PostHog session replay for the shared docs and developers initializer.
- Keep a fail-closed privacy configuration that masks all text and inputs if replay is enabled accidentally.
- Disable replay network timing, headers, bodies, console logs, canvas, and font capture.
- Add focused regression tests for the replay privacy contract.

## Validation

- `CI=true pnpm exec vitest run src/lib/posthog-privacy.test.ts` (2 tests passed)
- `pnpm run check:types`
- Biome check on touched files
- `git diff --check`

## Note

PR #676 also edits `PostHogSetup.tsx`. If it lands later, preserve this replay-disabled configuration during conflict resolution.