### PR TITLE
fix: exit routing smoke checks

### DIFF
--- a/scripts/smoke-docs-routing.ts
+++ b/scripts/smoke-docs-routing.ts
@@ -64,3 +64,5 @@ for (const testCase of routingSmokeCases.legacy) await checkCase(legacyOrigin, t
 console.log(
   `Validated ${routingSmokeCases.canonical.length + routingSmokeCases.legacy.length} deployed routing cases.`,
 )
+
+process.exit(0)


### PR DESCRIPTION
## Motivation

The deployed routing smoke command validated its cases but remained open while Node kept network connections alive, needlessly consuming the workflow timeout.

## Summary

- Exit the smoke command after all routing cases pass.
- Keep smoke failures unchanged so CI still reports assertion errors.

## Key design considerations

- The explicit success exit makes the scheduled production check deterministic without changing the redirect contract.