### PR TITLE
fix: recover legacy docs routes and index blog posts

### DIFF
--- a/src/lib/docs-routing.test.ts
+++ b/src/lib/docs-routing.test.ts
@@ -28,6 +28,8 @@ const vercelConfig = JSON.parse(
 const redirects = vercelConfig.redirects.filter((redirect) => !redirect.has)
 const hostRedirects = vercelConfig.redirects.filter((redirect) => redirect.has)
 const vocsRedirects = vocsConfig.redirects as VocsRedirect[]
+const legacySectionPathSource =
+  '/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|developer-tools)/:path*'
 
 function findRedirect(source: string) {
   return redirects.find((redirect) => redirect.source === source)
@@ -65,12 +67,20 @@ function findHostRedirectIndex(source: string, host: string) {
   )
 }
 
+function developersProxyDestination(destination: string) {
+  if (URL.canParse(destination)) return destination
+  return `/developers${destination}`
+}
+
 describe('docs routing redirects', () => {
   it('keeps proxied route destinations inside the public mount in production', () => {
     expect(docsRouteDestination('/docs/api', 'production')).toBe(
       `${canonicalDevelopersOrigin}/docs/api`,
     )
     expect(docsRouteDestination('/docs/api', 'preview')).toBe('/docs/api')
+    expect(docsRouteDestination('https://tempo.xyz/learn/stablecoin-payroll/', 'production')).toBe(
+      'https://tempo.xyz/learn/stablecoin-payroll/',
+    )
   })
 
   it('normalizes trailing slashes before static route handling', () => {
@@ -83,7 +93,6 @@ describe('docs routing redirects', () => {
       destination,
     }) => {
       const proxySource = `/developers${source}`
-      const proxyDestination = `/developers${destination}`
       const matchingProxyRedirects = redirects.filter((redirect) => redirect.source === proxySource)
 
       expect(
@@ -96,7 +105,7 @@ describe('docs routing redirects', () => {
       expect(matchingProxyRedirects).toEqual([
         expect.objectContaining({
           source: proxySource,
-          destination: proxyDestination,
+          destination: developersProxyDestination(destination),
           permanent: true,
         }),
       ])
@@ -107,8 +116,8 @@ describe('docs routing redirects', () => {
         const redirect = findRedirect(`/developers${source}`)
 
         expect(redirect?.source).not.toMatch(/\/$/)
-        expect(redirect?.destination).toBe(`/developers${destination}`)
-        expect(redirect?.destination).not.toMatch(/\/$/)
+        expect(redirect?.destination).toBe(developersProxyDestination(destination))
+        if (!URL.canParse(destination)) expect(redirect?.destination).not.toMatch(/\/$/)
       }
     })
   })
@@ -127,7 +136,7 @@ describe('docs routing redirects', () => {
       })
     })
 
-    it.each(legacyDocsHostRoutes)('redirects $source to $destination before the host catch-all', ({
+    it.each(legacyDocsHostRoutes)('redirects $source to $destination before broad host rules', ({
       source,
       destination,
     }) => {
@@ -137,6 +146,9 @@ describe('docs routing redirects', () => {
         permanent: true,
       })
 
+      expect(findHostRedirectIndex(source, host)).toBeLessThan(
+        findHostRedirectIndex(legacySectionPathSource, host),
+      )
       expect(findHostRedirectIndex(source, host)).toBeLessThan(
         findHostRedirectIndex('/:path*', host),
       )

--- a/src/lib/docs-routing.ts
+++ b/src/lib/docs-routing.ts
@@ -6,6 +6,7 @@ export type DocsRouteContract = {
 export const canonicalDevelopersOrigin = 'https://tempo.xyz/developers'
 
 export function docsRouteDestination(destination: string, environment = process.env.VERCEL_ENV) {
+  if (URL.canParse(destination)) return destination
   if (environment === 'production') return `${canonicalDevelopersOrigin}${destination}`
   return destination
 }
@@ -20,6 +21,81 @@ export const proxiedLegacyDocsRoutes = [
   { source: '/docs/developer-tools/indexer', destination: '/docs/api/indexer-api' },
   { source: '/docs/hosted-services', destination: '/docs/api' },
   { source: '/docs/hosted-services/:path*', destination: '/docs/api' },
+  {
+    source: '/docs/guide/use-accounts/add-funds',
+    destination: '/docs/guide/getting-funds',
+  },
+  {
+    source: '/docs/guide/use-accounts/authorize-access-keys',
+    destination: '/docs/guide/tempo-transaction#access-keys',
+  },
+  {
+    source: '/docs/guide/use-accounts/batch-transactions',
+    destination: '/docs/guide/tempo-transaction#batch-calls',
+  },
+  {
+    source: '/docs/guide/use-accounts/fee-sponsorship',
+    destination: '/docs/guide/payments/sponsor-user-fees',
+  },
+  {
+    source: '/docs/guide/use-accounts/scheduled-transactions',
+    destination: '/docs/guide/tempo-transaction#scheduled-transactions',
+  },
+  {
+    source: '/docs/guide/use-accounts/webauthn-p256-signatures',
+    destination: '/docs/protocol/transactions/spec-tempo-transaction#signature-types',
+  },
+  { source: '/docs/sdk/typescript/server', destination: '/docs/server' },
+  { source: '/docs/sdk/typescript/server/handlers', destination: '/docs/server' },
+  {
+    source: '/docs/sdk/typescript/server/handler.feePayer',
+    destination: '/docs/server/relay-handler#feepayer',
+  },
+  { source: '/accounts/server', destination: '/docs/server' },
+  {
+    source: '/accounts/server/handler.feePayer',
+    destination: '/docs/server/relay-handler#feepayer',
+  },
+  {
+    source: '/accounts/server/handler.relay',
+    destination: '/docs/server/relay-handler',
+  },
+  {
+    source: '/learn/tempo/receive-policies',
+    destination: '/docs/guide/payments/configure-receive-policies',
+  },
+  {
+    source: '/learn/use-cases/agentic-commerce',
+    destination: 'https://tempo.xyz/learn/blockchain-payments/',
+  },
+  {
+    source: '/learn/use-cases/embedded-finance',
+    destination: 'https://tempo.xyz/learn/stablecoin-payments/',
+  },
+  {
+    source: '/learn/use-cases/global-payouts',
+    destination: 'https://tempo.xyz/learn/global-payouts/',
+  },
+  {
+    source: '/learn/use-cases/microtransactions',
+    destination: 'https://tempo.xyz/learn/microtransactions/',
+  },
+  {
+    source: '/learn/use-cases/payroll',
+    destination: 'https://tempo.xyz/learn/stablecoin-payroll/',
+  },
+  {
+    source: '/learn/use-cases/remittances',
+    destination: 'https://tempo.xyz/learn/cross-border-payments/',
+  },
+  {
+    source: '/learn/use-cases/tokenized-deposits',
+    destination: 'https://tempo.xyz/learn/tokenized-deposits/',
+  },
+  {
+    source: '/docs/protocol/tips/tip-1028',
+    destination: 'https://tips.sh/1028',
+  },
 ] as const satisfies readonly DocsRouteContract[]
 
 export const legacyDocsHostRoutes = [
@@ -61,6 +137,87 @@ export const legacyDocsHostRoutes = [
     source: '/network-upgrades',
     destination: `${canonicalDevelopersOrigin}/docs/guide/node/network-upgrades`,
   },
+  {
+    source: '/guide/use-accounts/add-funds',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/getting-funds`,
+  },
+  {
+    source: '/guide/use-accounts/authorize-access-keys',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/tempo-transaction#access-keys`,
+  },
+  {
+    source: '/guide/use-accounts/batch-transactions',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/tempo-transaction#batch-calls`,
+  },
+  {
+    source: '/guide/use-accounts/fee-sponsorship',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/payments/sponsor-user-fees`,
+  },
+  {
+    source: '/guide/use-accounts/scheduled-transactions',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/tempo-transaction#scheduled-transactions`,
+  },
+  {
+    source: '/guide/use-accounts/webauthn-p256-signatures',
+    destination: `${canonicalDevelopersOrigin}/docs/protocol/transactions/spec-tempo-transaction#signature-types`,
+  },
+  {
+    source: '/sdk/typescript/server',
+    destination: `${canonicalDevelopersOrigin}/docs/server`,
+  },
+  {
+    source: '/sdk/typescript/server/handlers',
+    destination: `${canonicalDevelopersOrigin}/docs/server`,
+  },
+  {
+    source: '/sdk/typescript/server/handler.feePayer',
+    destination: `${canonicalDevelopersOrigin}/docs/server/relay-handler#feepayer`,
+  },
+  { source: '/accounts/server', destination: `${canonicalDevelopersOrigin}/docs/server` },
+  {
+    source: '/accounts/server/handler.feePayer',
+    destination: `${canonicalDevelopersOrigin}/docs/server/relay-handler#feepayer`,
+  },
+  {
+    source: '/accounts/server/handler.relay',
+    destination: `${canonicalDevelopersOrigin}/docs/server/relay-handler`,
+  },
+  {
+    source: '/learn/tempo/receive-policies',
+    destination: `${canonicalDevelopersOrigin}/docs/guide/payments/configure-receive-policies`,
+  },
+  {
+    source: '/learn/use-cases/agentic-commerce',
+    destination: 'https://tempo.xyz/learn/blockchain-payments/',
+  },
+  {
+    source: '/learn/use-cases/embedded-finance',
+    destination: 'https://tempo.xyz/learn/stablecoin-payments/',
+  },
+  {
+    source: '/learn/use-cases/global-payouts',
+    destination: 'https://tempo.xyz/learn/global-payouts/',
+  },
+  {
+    source: '/learn/use-cases/microtransactions',
+    destination: 'https://tempo.xyz/learn/microtransactions/',
+  },
+  {
+    source: '/learn/use-cases/payroll',
+    destination: 'https://tempo.xyz/learn/stablecoin-payroll/',
+  },
+  {
+    source: '/learn/use-cases/remittances',
+    destination: 'https://tempo.xyz/learn/cross-border-payments/',
+  },
+  {
+    source: '/learn/use-cases/tokenized-deposits',
+    destination: 'https://tempo.xyz/learn/tokenized-deposits/',
+  },
+  {
+    source: '/protocol/tips/tip-1028',
+    destination: 'https://tips.sh/1028',
+  },
 ] as const satisfies readonly DocsRouteContract[]
 
 export const routingSmokeCases = {
@@ -71,6 +228,21 @@ export const routingSmokeCases = {
     {
       path: '/developers/docs/hosted-services',
       expectedLocation: `${canonicalDevelopersOrigin}/docs/api`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/developers/docs/guide/use-accounts/batch-transactions',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/guide/tempo-transaction#batch-calls`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/developers/accounts/server/handler.relay',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/server/relay-handler`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/developers/learn/use-cases/payroll',
+      expectedLocation: 'https://tempo.xyz/learn/stablecoin-payroll/',
       expectedFinalStatus: 200,
     },
     { path: '/developers/api/og', expectedNonRedirect: true },
@@ -89,6 +261,21 @@ export const routingSmokeCases = {
     {
       path: '/docs/quickstart/integrate-tempo',
       expectedLocation: `${canonicalDevelopersOrigin}/docs/quickstart/integrate-tempo`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/guide/use-accounts/batch-transactions',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/guide/tempo-transaction#batch-calls`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/accounts/server/handler.relay',
+      expectedLocation: `${canonicalDevelopersOrigin}/docs/server/relay-handler`,
+      expectedFinalStatus: 200,
+    },
+    {
+      path: '/learn/use-cases/payroll',
+      expectedLocation: 'https://tempo.xyz/learn/stablecoin-payroll/',
       expectedFinalStatus: 200,
     },
   ],

--- a/src/lib/sitemap.test.ts
+++ b/src/lib/sitemap.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { finalizeSitemap } from './sitemap'
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://tempo.xyz/developers/blog</loc>
+  </url>
+  <url>
+    <loc>https://tempo.xyz/developers/blog/[slug]</loc>
+    <lastmod>2026-07-18</lastmod>
+  </url>
+  <url>
+    <loc>https://tempo.xyz/developers/example/[id]</loc>
+  </url>
+</urlset>`
+
+describe('finalizeSitemap', () => {
+  it('replaces the blog template with canonical post URLs and removes other templates', () => {
+    const result = finalizeSitemap(sitemap, ['t7-network-upgrade', 't6'])
+
+    expect(result).toContain('<loc>https://tempo.xyz/developers/blog/t6</loc>')
+    expect(result).toContain('<loc>https://tempo.xyz/developers/blog/t7-network-upgrade</loc>')
+    expect(result.indexOf('/blog/t6')).toBeLessThan(result.indexOf('/blog/t7-network-upgrade'))
+    expect(result).not.toContain('[slug]')
+    expect(result).not.toContain('[id]')
+  })
+
+  it('does not duplicate a blog URL that the sitemap already contains', () => {
+    const withExistingPost = sitemap.replace(
+      '</urlset>',
+      '  <url>\n    <loc>https://tempo.xyz/developers/blog/t6</loc>\n  </url>\n</urlset>',
+    )
+    const result = finalizeSitemap(withExistingPost, ['t6'])
+
+    expect(result.match(/<loc>https:\/\/tempo\.xyz\/developers\/blog\/t6<\/loc>/g)).toHaveLength(1)
+  })
+
+  it('uses the blog index when the framework stops emitting a template route', () => {
+    const withoutBlogTemplate = sitemap.replace(
+      / {2}<url>\n {4}<loc>https:\/\/tempo\.xyz\/developers\/blog\/\[slug\]<\/loc>\n {4}<lastmod>2026-07-18<\/lastmod>\n {2}<\/url>\n/,
+      '',
+    )
+    const result = finalizeSitemap(withoutBlogTemplate, ['t6'])
+
+    expect(result).toContain('<loc>https://tempo.xyz/developers/blog/t6</loc>')
+  })
+})

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,0 +1,39 @@
+const TEMPLATE_URL_PATTERN = /<url>\s*<loc>([^<]*\/\[[^\]]+\][^<]*)<\/loc>[\s\S]*?<\/url>\s*/g
+const LOCATION_PATTERN = /<loc>([^<]+)<\/loc>/g
+
+export function finalizeSitemap(sitemap: string, blogPostSlugs: readonly string[]): string {
+  let blogBaseUrl: string | undefined
+
+  const withoutTemplates = sitemap.replace(TEMPLATE_URL_PATTERN, (_entry, location: string) => {
+    const blogTemplate = /^(.*\/blog\/)\[slug\]\/?$/.exec(location)
+    if (blogTemplate) blogBaseUrl = blogTemplate[1]
+    return ''
+  })
+
+  const existingLocations = new Set(
+    Array.from(withoutTemplates.matchAll(LOCATION_PATTERN), ([, location]) => location),
+  )
+
+  if (!blogBaseUrl) {
+    const blogIndexUrl = Array.from(existingLocations).find((location) =>
+      /\/blog\/?$/.test(location),
+    )
+    if (blogIndexUrl) blogBaseUrl = `${blogIndexUrl.replace(/\/$/, '')}/`
+  }
+
+  const uniqueSlugs = [...new Set(blogPostSlugs)].sort((a, b) => a.localeCompare(b))
+  if (uniqueSlugs.length === 0) return withoutTemplates
+  if (!blogBaseUrl) throw new Error('Could not resolve the blog base URL from the sitemap')
+  if (!withoutTemplates.includes('</urlset>')) {
+    throw new Error('Could not find the sitemap urlset closing tag')
+  }
+
+  const entries = uniqueSlugs
+    .map((slug) => `${blogBaseUrl}${encodeURIComponent(slug)}`)
+    .filter((location) => !existingLocations.has(location))
+    .map((location) => `  <url>\n    <loc>${location}</loc>\n  </url>`)
+
+  if (entries.length === 0) return withoutTemplates
+
+  return withoutTemplates.replace('</urlset>', `${entries.join('\n')}\n</urlset>`)
+}

--- a/src/marketing/blogPlugin.ts
+++ b/src/marketing/blogPlugin.ts
@@ -46,6 +46,17 @@ const CATEGORY_SLUGS = ['network-upgrades', 'events', 'technical', 'case-studies
 // authors, not posts.
 const DOC_FILE = /^[A-Z0-9_-]+\.md$/
 
+function getBlogPostFilenames(): string[] {
+  return fs
+    .readdirSync(BLOGS_DIR)
+    .filter((filename) => filename.endsWith('.md') && !DOC_FILE.test(filename))
+    .sort((a, b) => a.localeCompare(b))
+}
+
+export function getBlogPostSlugs(): string[] {
+  return getBlogPostFilenames().map((filename) => filename.replace(/\.md$/, ''))
+}
+
 export type RenderedPost = {
   slug: string
   title: string
@@ -130,7 +141,7 @@ async function renderPost(filename: string): Promise<RenderedPost> {
 
 // Reads + renders every post, newest first.
 async function loadRenderedPosts(): Promise<RenderedPost[]> {
-  const filenames = fs.readdirSync(BLOGS_DIR).filter((f) => f.endsWith('.md') && !DOC_FILE.test(f))
+  const filenames = getBlogPostFilenames()
 
   const posts = await Promise.all(filenames.map(renderPost))
   return posts.sort((a, b) => b.date.localeCompare(a.date))

--- a/vercel.json
+++ b/vercel.json
@@ -189,6 +189,237 @@
       "permanent": true
     },
     {
+      "source": "/guide/use-accounts/add-funds",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/getting-funds",
+      "permanent": true
+    },
+    {
+      "source": "/guide/use-accounts/authorize-access-keys",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/tempo-transaction#access-keys",
+      "permanent": true
+    },
+    {
+      "source": "/guide/use-accounts/batch-transactions",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/tempo-transaction#batch-calls",
+      "permanent": true
+    },
+    {
+      "source": "/guide/use-accounts/fee-sponsorship",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/payments/sponsor-user-fees",
+      "permanent": true
+    },
+    {
+      "source": "/guide/use-accounts/scheduled-transactions",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/tempo-transaction#scheduled-transactions",
+      "permanent": true
+    },
+    {
+      "source": "/guide/use-accounts/webauthn-p256-signatures",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/protocol/transactions/spec-tempo-transaction#signature-types",
+      "permanent": true
+    },
+    {
+      "source": "/sdk/typescript/server",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/server",
+      "permanent": true
+    },
+    {
+      "source": "/sdk/typescript/server/handlers",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/server",
+      "permanent": true
+    },
+    {
+      "source": "/sdk/typescript/server/handler.feePayer",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/server/relay-handler#feepayer",
+      "permanent": true
+    },
+    {
+      "source": "/accounts/server",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/server",
+      "permanent": true
+    },
+    {
+      "source": "/accounts/server/handler.feePayer",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/server/relay-handler#feepayer",
+      "permanent": true
+    },
+    {
+      "source": "/accounts/server/handler.relay",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/server/relay-handler",
+      "permanent": true
+    },
+    {
+      "source": "/learn/tempo/receive-policies",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/developers/docs/guide/payments/configure-receive-policies",
+      "permanent": true
+    },
+    {
+      "source": "/learn/use-cases/agentic-commerce",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/learn/blockchain-payments/",
+      "permanent": true
+    },
+    {
+      "source": "/learn/use-cases/embedded-finance",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/learn/stablecoin-payments/",
+      "permanent": true
+    },
+    {
+      "source": "/learn/use-cases/global-payouts",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/learn/global-payouts/",
+      "permanent": true
+    },
+    {
+      "source": "/learn/use-cases/microtransactions",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/learn/microtransactions/",
+      "permanent": true
+    },
+    {
+      "source": "/learn/use-cases/payroll",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/learn/stablecoin-payroll/",
+      "permanent": true
+    },
+    {
+      "source": "/learn/use-cases/remittances",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/learn/cross-border-payments/",
+      "permanent": true
+    },
+    {
+      "source": "/learn/use-cases/tokenized-deposits",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tempo.xyz/learn/tokenized-deposits/",
+      "permanent": true
+    },
+    {
+      "source": "/protocol/tips/tip-1028",
+      "has": [
+        {
+          "type": "host",
+          "value": "^(?:next\\.)?docs\\.tempo\\.xyz$"
+        }
+      ],
+      "destination": "https://tips.sh/1028",
+      "permanent": true
+    },
+    {
       "source": "/:section(api|guide|quickstart|protocol|sdk|cli|wallet|tools|ecosystem|changelog|partners)",
       "has": [
         {
@@ -488,6 +719,111 @@
     {
       "source": "/developers/docs/hosted-services/:path*",
       "destination": "/developers/docs/api",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/guide/use-accounts/add-funds",
+      "destination": "/developers/docs/guide/getting-funds",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/guide/use-accounts/authorize-access-keys",
+      "destination": "/developers/docs/guide/tempo-transaction#access-keys",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/guide/use-accounts/batch-transactions",
+      "destination": "/developers/docs/guide/tempo-transaction#batch-calls",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/guide/use-accounts/fee-sponsorship",
+      "destination": "/developers/docs/guide/payments/sponsor-user-fees",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/guide/use-accounts/scheduled-transactions",
+      "destination": "/developers/docs/guide/tempo-transaction#scheduled-transactions",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/guide/use-accounts/webauthn-p256-signatures",
+      "destination": "/developers/docs/protocol/transactions/spec-tempo-transaction#signature-types",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/sdk/typescript/server",
+      "destination": "/developers/docs/server",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/sdk/typescript/server/handlers",
+      "destination": "/developers/docs/server",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/sdk/typescript/server/handler.feePayer",
+      "destination": "/developers/docs/server/relay-handler#feepayer",
+      "permanent": true
+    },
+    {
+      "source": "/developers/accounts/server",
+      "destination": "/developers/docs/server",
+      "permanent": true
+    },
+    {
+      "source": "/developers/accounts/server/handler.feePayer",
+      "destination": "/developers/docs/server/relay-handler#feepayer",
+      "permanent": true
+    },
+    {
+      "source": "/developers/accounts/server/handler.relay",
+      "destination": "/developers/docs/server/relay-handler",
+      "permanent": true
+    },
+    {
+      "source": "/developers/learn/tempo/receive-policies",
+      "destination": "/developers/docs/guide/payments/configure-receive-policies",
+      "permanent": true
+    },
+    {
+      "source": "/developers/learn/use-cases/agentic-commerce",
+      "destination": "https://tempo.xyz/learn/blockchain-payments/",
+      "permanent": true
+    },
+    {
+      "source": "/developers/learn/use-cases/embedded-finance",
+      "destination": "https://tempo.xyz/learn/stablecoin-payments/",
+      "permanent": true
+    },
+    {
+      "source": "/developers/learn/use-cases/global-payouts",
+      "destination": "https://tempo.xyz/learn/global-payouts/",
+      "permanent": true
+    },
+    {
+      "source": "/developers/learn/use-cases/microtransactions",
+      "destination": "https://tempo.xyz/learn/microtransactions/",
+      "permanent": true
+    },
+    {
+      "source": "/developers/learn/use-cases/payroll",
+      "destination": "https://tempo.xyz/learn/stablecoin-payroll/",
+      "permanent": true
+    },
+    {
+      "source": "/developers/learn/use-cases/remittances",
+      "destination": "https://tempo.xyz/learn/cross-border-payments/",
+      "permanent": true
+    },
+    {
+      "source": "/developers/learn/use-cases/tokenized-deposits",
+      "destination": "https://tempo.xyz/learn/tokenized-deposits/",
+      "permanent": true
+    },
+    {
+      "source": "/developers/docs/protocol/tips/tip-1028",
+      "destination": "https://tips.sh/1028",
       "permanent": true
     },
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ import Icons from 'unplugin-icons/vite'
 import { defineConfig, loadEnv, type Plugin, type ResolvedConfig } from 'vite'
 import mkcert from 'vite-plugin-mkcert'
 import { vocs } from 'vocs/vite'
-import { blogPostsPlugin } from './src/marketing/blogPlugin'
+import { finalizeSitemap } from './src/lib/sitemap'
+import { blogPostsPlugin, getBlogPostSlugs } from './src/marketing/blogPlugin'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
@@ -220,7 +221,7 @@ function llmsFeedbackPreamble(): Plugin {
       ]
 
       await Promise.all(candidates.map(prependFeedbackNotice))
-      await removeTemplateRoutesFromSitemap(path.join(publicDir, 'sitemap.xml'))
+      await finalizeGeneratedSitemap(path.join(publicDir, 'sitemap.xml'))
     },
   }
 }
@@ -252,16 +253,14 @@ async function prependFeedbackNotice(filePath: string) {
   }
 }
 
-async function removeTemplateRoutesFromSitemap(filePath: string) {
+async function finalizeGeneratedSitemap(filePath: string) {
   try {
     const content = await fs.readFile(filePath, 'utf-8')
-    const filtered = content.replaceAll(
-      /<url>\s*<loc>[^<]*\/\[[^\]]+\][^<]*<\/loc>[\s\S]*?<\/url>\s*/g,
-      '',
-    )
-    if (filtered !== content) await fs.writeFile(filePath, filtered, 'utf-8')
-  } catch {
-    return
+    const finalized = finalizeSitemap(content, getBlogPostSlugs())
+    if (finalized !== content) await fs.writeFile(filePath, finalized, 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw error
   }
 }
 


### PR DESCRIPTION
## What changed

- Added explicit permanent redirects for 21 verified legacy docs paths on both `docs.tempo.xyz` and the public `/developers` mount.
- Preserved direct external canonical destinations, including the current Tempo use-case pages and TIP-1028 on `tips.sh`.
- Replaced unresolved sitemap template routes with the two real developer blog post URLs.
- Added regression coverage for redirect mirrors, ordering, absolute destinations, sitemap deduplication, and template removal.

## Why

Search Console surfaced migration leftovers where known legacy URLs redirected to missing pages. It also showed that developer blog detail pages were live but absent from the sitemap because the generated `[slug]` template was removed without adding concrete post paths.

The redirect set is conservative: every destination returns 200, every fragment target exists, and ambiguous or retired historical routes remain untouched.

## Validation

- Full test suite: 254 tests passed
- Focused routing and sitemap suite: 147 tests passed
- TypeScript and Biome checks passed
- Production build passed
- `vercel.json` and generated sitemap XML validated
- Generated production sitemap contains 200 unique canonical URLs, both blog posts exactly once, and no unresolved template routes
- Vercel preview confirmed exact 308 locations for an anchored docs move, TIP-1028, and an external use-case move
- All GitHub and Vercel checks passed