### PR TITLE
Remove conflicting Tempo entity aliases from docs schema

### DIFF
--- a/src/components/DocsJsonLd.test.tsx
+++ b/src/components/DocsJsonLd.test.tsx
@@ -49,19 +49,19 @@ describe('DocsJsonLd', () => {
     expect(website).toMatchObject({
       '@id': 'https://tempo.xyz/#website',
       name: 'Tempo',
-      alternateName: ['Tempo Blockchain', 'tempo.xyz'],
       url: 'https://tempo.xyz',
     })
+    expect(website).not.toHaveProperty('alternateName')
     expect(organization).toMatchObject({
       '@id': 'https://tempo.xyz/#organization',
       name: 'Tempo',
-      alternateName: ['Tempo Blockchain', 'tempo.xyz'],
       sameAs: expect.arrayContaining([
         'https://www.linkedin.com/company/tempo',
         'https://www.crunchbase.com/organization/tempo-24b7',
         'https://www.wikidata.org/wiki/Q140472934',
       ]),
     })
+    expect(organization).not.toHaveProperty('alternateName')
   })
 
   it.each([

--- a/src/components/MarketingJsonLd.test.tsx
+++ b/src/components/MarketingJsonLd.test.tsx
@@ -12,6 +12,8 @@ describe('MarketingJsonLd', () => {
       description: 'Developer resources for Tempo.',
     })
     const page = schema['@graph'].find((entry) => entry['@type'] === 'WebPage')
+    const website = schema['@graph'].find((entry) => entry['@type'] === 'WebSite')
+    const organization = schema['@graph'].find((entry) => entry['@type'] === 'Corporation')
 
     expect(page).toMatchObject({
       '@id': url,
@@ -22,5 +24,7 @@ describe('MarketingJsonLd', () => {
       about: { '@id': 'https://tempo.xyz/#organization' },
       publisher: { '@id': 'https://tempo.xyz/#organization' },
     })
+    expect(website).not.toHaveProperty('alternateName')
+    expect(organization).not.toHaveProperty('alternateName')
   })
 })

--- a/src/lib/tempo-entity.ts
+++ b/src/lib/tempo-entity.ts
@@ -6,8 +6,6 @@ export const TEMPO_WEBSITE_ID = `${TEMPO_ORIGIN}/#website`
 export const TEMPO_ENTITY_DESCRIPTION =
   'Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Tempo is built for stablecoin payments, global payouts, agentic payments, and enterprise settlement.'
 
-export const TEMPO_ALTERNATE_NAMES = ['Tempo Blockchain', 'tempo.xyz']
-
 export const TEMPO_SAME_AS = [
   'https://x.com/tempo',
   'https://twitter.com/tempo',
@@ -39,7 +37,6 @@ export function tempoOrganizationSchema() {
     '@type': 'Corporation',
     '@id': TEMPO_ORGANIZATION_ID,
     name: 'Tempo',
-    alternateName: TEMPO_ALTERNATE_NAMES,
     url: TEMPO_ORIGIN,
     logo: {
       '@type': 'ImageObject',
@@ -60,7 +57,6 @@ export function tempoWebsiteSchema() {
     '@type': 'WebSite',
     '@id': TEMPO_WEBSITE_ID,
     name: 'Tempo',
-    alternateName: TEMPO_ALTERNATE_NAMES,
     url: TEMPO_ORIGIN,
     description: TEMPO_ENTITY_DESCRIPTION,
     publisher: { '@id': TEMPO_ORGANIZATION_ID },


### PR DESCRIPTION
## What changed

- Remove `Tempo Blockchain` and `tempo.xyz` from the shared docs `Corporation` and `WebSite` `alternateName` output.
- Keep `Tempo` as the sole declared site and organization name.
- Update the docs and developer-marketing schema tests to require alternate names to remain absent.

## Why

The root `tempo.xyz` entity graph already declares `Tempo` without alternate names following #460, while the developer and docs surfaces still republish the two older aliases. That inconsistency creates competing site-name signals across the same canonical entity.

This change aligns all surfaces on `name: "Tempo"`. It does not remove the payments-first Layer 1 description, entity IDs, `sameAs` profiles, `knowsAbout` topics, or logo data.

Google reference: https://developers.google.com/search/docs/appearance/site-names

## Validation

- Full CI test suite passed
- Focused schema suite: 10 tests passed
- Type checking passed
- Production build passed
- Biome and `git diff --check` passed
- All GitHub and Vercel checks passed
