### PR TITLE
Fix mounted legacy account docs redirects

### DIFF
--- a/src/lib/docs-routing.test.ts
+++ b/src/lib/docs-routing.test.ts
@@ -35,6 +35,10 @@ function findRedirect(source: string) {
   return redirects.find((redirect) => redirect.source === source)
 }
 
+function findRedirectIndex(source: string) {
+  return vercelConfig.redirects.findIndex((redirect) => !redirect.has && redirect.source === source)
+}
+
 function matchesHostCondition(redirect: Redirect, host: string) {
   return (
     Array.isArray(redirect.has) &&
@@ -119,6 +123,20 @@ describe('docs routing redirects', () => {
         expect(redirect?.destination).toBe(developersProxyDestination(destination))
         if (!URL.canParse(destination)) expect(redirect?.destination).not.toMatch(/\/$/)
       }
+    })
+
+    it.each(
+      proxiedLegacyDocsRoutes.filter(({ source }) => source.startsWith('/accounts/')),
+    )('redirects mounted $source before the Accounts product catch-all', ({
+      source,
+      destination,
+    }) => {
+      expect(findRedirect(source)).toMatchObject({
+        source,
+        destination: docsRouteDestination(destination, 'production'),
+        permanent: true,
+      })
+      expect(findRedirectIndex(source)).toBeLessThan(findRedirectIndex('/accounts/:path*'))
     })
   })
 

--- a/vercel.json
+++ b/vercel.json
@@ -497,6 +497,21 @@
       "permanent": false
     },
     {
+      "source": "/accounts/server",
+      "destination": "https://tempo.xyz/developers/docs/server",
+      "permanent": true
+    },
+    {
+      "source": "/accounts/server/handler.feePayer",
+      "destination": "https://tempo.xyz/developers/docs/server/relay-handler#feepayer",
+      "permanent": true
+    },
+    {
+      "source": "/accounts/server/handler.relay",
+      "destination": "https://tempo.xyz/developers/docs/server/relay-handler",
+      "permanent": true
+    },
+    {
       "source": "/accounts",
       "destination": "https://accounts.tempo.xyz",
       "permanent": true


### PR DESCRIPTION
## What changed

- Add exact permanent redirects for the three historical account-server docs paths before the broad Accounts product redirect.
- Lock their ordering with regression tests so the production `/developers` mount cannot send them to `accounts.tempo.xyz`.

## Why

After #719 merged, the docs-host routes worked but the production proxy stripped `/developers` before evaluating docs redirects. The broad `/accounts/:path*` rule then won, sending these URLs to 404s:

- `/developers/accounts/server`
- `/developers/accounts/server/handler.feePayer`
- `/developers/accounts/server/handler.relay`

The exact rules now resolve directly to their canonical docs pages.

## Validation

- Full test suite: 257 tests passed
- Focused routing suite: 147 tests passed
- Production build passed and generated 451 files
- Type checking passed
- Biome and `git diff --check` passed on touched files
