### PR TITLE
Update T8 activation dates

### DIFF
--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -16,8 +16,8 @@ Release target: July 21, 2026.
 | Milestone | Date |
 |-----------|------|
 | Release target | July 21, 2026 |
-| Testnet rollout | July 23, 2026 |
-| Mainnet rollout | July 29, 2026 |
+| Testnet rollout | July 27, 2026 |
+| Mainnet rollout | July 30, 2026 |
 
 Node operators should wait for the T8 release announcement, then upgrade before the activation timestamp on each network. Exact activation timestamps will be added when the release is cut.
 


### PR DESCRIPTION
Updates the T8 rollout timeline to:

- Testnet: Monday, July 27, 2026
- Mainnet: Thursday, July 30, 2026

Prompted by: @Zygimantass