### PR TITLE
Update T8 release and rollout dates

### DIFF
--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.11.0 | Planned: Jul 21, 2026 | Testnet + Mainnet | Required release for T8; includes current committee state, FeeAMM policy exemptions, versioned Stablecoin DEX order storage, and DEX V2Order support. | <Badge variant="red">Required</Badge> |
+| v1.11.0 | Planned: Jul 22, 2026 | Testnet + Mainnet | Required release for T8; includes current committee state, FeeAMM policy exemptions, versioned Stablecoin DEX order storage, and DEX V2Order support. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.9.0](https://github.com/tempoxyz/tempo/releases/tag/v1.9.0) | Jun 15, 2026 | Testnet + Mainnet | Required for T6; adds account-level receive policies for safer TIP-20 deposits and admin access keys for smoother passkey, device, and delegated-key management. Operators were required to run this release before the T6 activation timestamp on each network. | <Badge variant="red">Required</Badge> |
@@ -43,7 +43,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | **Scope** | current committee state; FeeAMM policy exemptions; versioned Stablecoin DEX order storage; DEX V2Order support |
 | **References** | [current committee state specification](https://tips.sh/1070), [FeeAMM policy exemptions specification](https://tips.sh/1042), [versioned DEX order storage specification](https://tips.sh/1062) |
 | **Details** | [T8 network upgrade](/docs/protocol/upgrades/t8) |
-| **Planned release date** | July 21, 2026 |
+| **Planned release date** | July 22, 2026 |
 | **Testnet** | Planned: July 23, 2026 |
 | **Mainnet** | Planned: July 29, 2026 |
 | **Priority** | <Badge variant="red">Required</Badge> |

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -44,8 +44,8 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | **References** | [current committee state specification](https://tips.sh/1070), [FeeAMM policy exemptions specification](https://tips.sh/1042), [versioned DEX order storage specification](https://tips.sh/1062) |
 | **Details** | [T8 network upgrade](/docs/protocol/upgrades/t8) |
 | **Planned release date** | July 22, 2026 |
-| **Testnet** | Planned: July 23, 2026 |
-| **Mainnet** | Planned: July 29, 2026 |
+| **Testnet** | Planned: July 27, 2026 |
+| **Mainnet** | Planned: July 30, 2026 |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
 T8 is planned. Node operators should wait for the T8 release announcement, then upgrade before the activation timestamp on each network.

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -16,8 +16,8 @@ Release target: July 22, 2026.
 | Milestone | Date |
 |-----------|------|
 | Release target | July 22, 2026 |
-| Testnet rollout | July 23, 2026 |
-| Mainnet rollout | July 29, 2026 |
+| Testnet rollout | July 27, 2026 |
+| Mainnet rollout | July 30, 2026 |
 
 Node operators should wait for the T8 release announcement, then upgrade before the activation timestamp on each network. Exact activation timestamps will be added when the release is cut.
 

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -8,14 +8,14 @@ description: T8 network upgrade overview covering current committee state, FeeAM
 T8 focuses on clearer validator committee reads, FeeAMM policy behavior, and DEX order storage.
 
 :::info[T8 status]
-Release target: July 21, 2026.
+Release target: July 22, 2026.
 :::
 
 ## Timeline
 
 | Milestone | Date |
 |-----------|------|
-| Release target | July 21, 2026 |
+| Release target | July 22, 2026 |
 | Testnet rollout | July 23, 2026 |
 | Mainnet rollout | July 29, 2026 |
 
@@ -69,7 +69,7 @@ The T8-compatible release is not published yet.
 
 | Ecosystem | T8-compatible releases |
 |-----------|------------------------|
-| Node operators | v1.11.0 target release on July 21, 2026 |
+| Node operators | v1.11.0 target release on July 22, 2026 |
 
 Release notes and binaries will be linked here when v1.11.0 is cut.
 


### PR DESCRIPTION
## What changed

- Update the T8 release target to July 22, 2026.
- Update the planned T8 testnet rollout to July 27, 2026.
- Update the planned T8 mainnet rollout to July 30, 2026.
- Keep the T8 upgrade page and Network Upgrades and Releases table in sync.

## Why

The T8 schedule moved, so the docs should reflect the current planned release and rollout dates.

## Validation

- Confirmed the schedule rows in `src/pages/docs/protocol/upgrades/t8.mdx` and `src/pages/docs/guide/node/network-upgrades.mdx` match.
- No full build run; this is a copy-only date update.