### PR TITLE
Fix dynamic routes in generated sitemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@10.28.1",
   "scripts": {
     "dev": "node --env-file-if-exists=.env --import=tsx node_modules/vite/bin/vite.js",
-    "build": "node scripts/guard-vocs-config.mjs && pnpm run check:types && vite build",
+    "build": "node scripts/guard-vocs-config.mjs && pnpm run check:types && vite build && node --experimental-strip-types scripts/finalize-sitemap.ts",
     "check": "biome check --write --unsafe .",
     "check:types": "tsgo --project tsconfig.json --noEmit",
     "preview": "node dist/preview.js",

--- a/scripts/finalize-sitemap.ts
+++ b/scripts/finalize-sitemap.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { finalizeSitemap } from '../src/lib/sitemap.ts'
+import { getBlogPostSlugs } from '../src/marketing/blogPlugin.ts'
+
+const sitemapPath = path.resolve('dist/public/sitemap.xml')
+const sitemap = await fs.readFile(sitemapPath, 'utf-8')
+const finalized = finalizeSitemap(sitemap, getBlogPostSlugs())
+
+if (finalized !== sitemap) {
+  await fs.writeFile(sitemapPath, finalized, 'utf-8')
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,7 @@ import { defineConfig, loadEnv, type Plugin, type ResolvedConfig } from 'vite'
 import mkcert from 'vite-plugin-mkcert'
 import { vocs } from 'vocs/vite'
 import { canonicalizeGeneratedDeveloperLinks } from './src/lib/canonical-developer-links'
-import { finalizeSitemap } from './src/lib/sitemap'
-import { blogPostsPlugin, getBlogPostSlugs } from './src/marketing/blogPlugin'
+import { blogPostsPlugin } from './src/marketing/blogPlugin'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
@@ -235,7 +234,6 @@ function llmsFeedbackPreamble(): Plugin {
             [...new Set([...candidates, ...generatedPages])].map(canonicalizeGeneratedLinksInFile),
           )
         }
-        await finalizeGeneratedSitemap(path.join(publicDir, 'sitemap.xml'))
       },
     },
   }
@@ -293,17 +291,6 @@ async function canonicalizeGeneratedLinksInFile(filePath: string) {
     const content = await fs.readFile(filePath, 'utf-8')
     const canonical = canonicalizeGeneratedDeveloperLinks(content)
     if (canonical !== content) await fs.writeFile(filePath, canonical, 'utf-8')
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
-    throw error
-  }
-}
-
-async function finalizeGeneratedSitemap(filePath: string) {
-  try {
-    const content = await fs.readFile(filePath, 'utf-8')
-    const finalized = finalizeSitemap(content, getBlogPostSlugs())
-    if (finalized !== content) await fs.writeFile(filePath, finalized, 'utf-8')
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
     throw error


### PR DESCRIPTION
## Summary
- finalize the generated sitemap in an explicit post-build step
- remove dynamic route templates only after Vite and Vocs finish writing build output
- preserve canonical generated blog post URLs

## Validation
- `pnpm check:types`
- Biome check on changed files
- exercised the post-build script against a generated sitemap fixture and verified `[slug]` is removed and real blog URLs are added
- full local build was blocked by a timeout fetching the external OpenAPI specification

Prompted by: @juandolealt