### PR TITLE
fix: tolerate missing sitemap in e2e builds

### DIFF
--- a/scripts/finalize-sitemap.ts
+++ b/scripts/finalize-sitemap.ts
@@ -4,7 +4,17 @@ import { finalizeSitemap } from '../src/lib/sitemap.ts'
 import { getBlogPostSlugs } from '../src/marketing/blogPlugin.ts'
 
 const sitemapPath = path.resolve('dist/public/sitemap.xml')
-const sitemap = await fs.readFile(sitemapPath, 'utf-8')
+let sitemap: string
+
+try {
+  sitemap = await fs.readFile(sitemapPath, 'utf-8')
+} catch (error) {
+  if (process.env.VITE_E2E === 'true' && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+    process.exit(0)
+  }
+  throw error
+}
+
 const finalized = finalizeSitemap(sitemap, getBlogPostSlugs())
 
 if (finalized !== sitemap) {


### PR DESCRIPTION
## Motivation

E2E builds do not generate a sitemap, causing the post-build finalizer to fail.

## Summary

- Skip sitemap finalization when no sitemap is generated
- Preserve failures for other filesystem errors

## Key design considerations

- Production sitemap finalization remains unchanged