### PR TITLE
fix: include blog posts in developer search

### DIFF
--- a/src/marketing/app/_components/SearchDialog.tsx
+++ b/src/marketing/app/_components/SearchDialog.tsx
@@ -226,7 +226,7 @@ export default function SearchDialog({ open, onClose }: { open: boolean; onClose
     if (!query.trim()) {
       return (
         <div className="px-4 py-10 text-center font-sans text-[14px] text-foreground/45">
-          Start typing to search the docs…
+          Start typing to search docs and blog posts…
         </div>
       )
     }
@@ -280,7 +280,7 @@ export default function SearchDialog({ open, onClose }: { open: boolean; onClose
             aria-autocomplete="list"
             autoComplete="off"
             spellCheck={false}
-            placeholder="Search documentation…"
+            placeholder="Search docs and blog posts…"
             value={query}
             onChange={(event) => runQuery(event.target.value)}
             className="flex-1 bg-transparent font-sans text-[15px] text-foreground tracking-[0] outline-none placeholder:text-foreground/40"

--- a/src/marketing/blogPlugin.ts
+++ b/src/marketing/blogPlugin.ts
@@ -18,6 +18,8 @@ import type { Plugin } from 'vite'
 
 const VIRTUAL_ID = 'virtual:blog-posts'
 const RESOLVED_VIRTUAL_ID = `\0${VIRTUAL_ID}`
+const SEARCH_VIRTUAL_ID = 'virtual:blog-search-documents'
+const RESOLVED_SEARCH_VIRTUAL_ID = `\0${SEARCH_VIRTUAL_ID}`
 
 const BLOGS_DIR = path.resolve(process.cwd(), 'blogs')
 const PUBLIC_DIR = path.resolve(process.cwd(), 'public')
@@ -67,6 +69,10 @@ export type RenderedPost = {
   html: string
 }
 
+type SearchablePost = RenderedPost & {
+  searchText: string
+}
+
 // Markdown → HTML with Shiki syntax highlighting. Vesper is the closest
 // built-in theme to the site's muted dark palette; the pre background is
 // overridden to the surface token in CSS.
@@ -114,7 +120,7 @@ function parseFrontmatter(raw: string): { data: Record<string, string>; content:
   return { data, content: match[2] }
 }
 
-async function renderPost(filename: string): Promise<RenderedPost> {
+async function renderPost(filename: string): Promise<SearchablePost> {
   const slug = filename.replace(/\.md$/, '')
   const raw = fs.readFileSync(path.join(BLOGS_DIR, filename), 'utf8')
   const { data, content } = parseFrontmatter(raw)
@@ -136,11 +142,12 @@ async function renderPost(filename: string): Promise<RenderedPost> {
     category: data.category,
     featured: data.featured === 'true',
     html,
+    searchText: content,
   }
 }
 
 // Reads + renders every post, newest first.
-async function loadRenderedPosts(): Promise<RenderedPost[]> {
+async function loadRenderedPosts(): Promise<SearchablePost[]> {
   const filenames = getBlogPostFilenames()
 
   const posts = await Promise.all(filenames.map(renderPost))
@@ -159,11 +166,25 @@ export function blogPostsPlugin(): Plugin {
     name: 'tempo-blog-posts',
     resolveId(id) {
       if (id === VIRTUAL_ID) return RESOLVED_VIRTUAL_ID
+      if (id === SEARCH_VIRTUAL_ID) return RESOLVED_SEARCH_VIRTUAL_ID
     },
     async load(id) {
-      if (id !== RESOLVED_VIRTUAL_ID) return
+      if (id !== RESOLVED_VIRTUAL_ID && id !== RESOLVED_SEARCH_VIRTUAL_ID) return
       const posts = await getPosts()
-      return `export const posts = ${JSON.stringify(posts)}`
+      if (id === RESOLVED_SEARCH_VIRTUAL_ID) {
+        return `export const documents = ${JSON.stringify(
+          posts.map(({ slug, title, excerpt, category, searchText }) => ({
+            slug,
+            title,
+            excerpt,
+            category,
+            searchText,
+          })),
+        )}`
+      }
+      return `export const posts = ${JSON.stringify(
+        posts.map(({ searchText: _searchText, ...post }) => post),
+      )}`
     },
     configureServer(server) {
       const BLOG_ASSETS_DIR = path.join(PUBLIC_DIR, 'blog')
@@ -177,8 +198,10 @@ export function blogPostsPlugin(): Plugin {
         const mod = server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_ID)
         if (mod) {
           server.moduleGraph.invalidateModule(mod)
-          server.ws.send({ type: 'full-reload' })
         }
+        const searchMod = server.moduleGraph.getModuleById(RESOLVED_SEARCH_VIRTUAL_ID)
+        if (searchMod) server.moduleGraph.invalidateModule(searchMod)
+        if (mod || searchMod) server.ws.send({ type: 'full-reload' })
       }
       server.watcher.on('add', invalidate)
       server.watcher.on('change', invalidate)

--- a/src/marketing/next.d.ts
+++ b/src/marketing/next.d.ts
@@ -14,6 +14,16 @@ declare module 'virtual:blog-posts' {
   }[]
 }
 
+declare module 'virtual:blog-search-documents' {
+  export const documents: {
+    slug: string
+    title: string
+    excerpt: string
+    category: string
+    searchText: string
+  }[]
+}
+
 declare module 'next/link' {
   export { default } from './next-shims'
 }

--- a/src/marketing/search.ts
+++ b/src/marketing/search.ts
@@ -31,6 +31,11 @@ export type SearchResult = {
   terms?: string[]
 }
 
+type SearchIndexes = {
+  docs: MiniSearch<SearchResult>
+  blog: MiniSearch<SearchResult>
+}
+
 /**
  * Splits on whitespace, punctuation and camelCase/PascalCase, keeping both the
  * original and the sub-tokens. Copied verbatim from Vocs' tokenizer so query
@@ -77,13 +82,43 @@ const loadOptions: Options<SearchResult> = {
   tokenize,
 }
 
-let indexPromise: Promise<MiniSearch<SearchResult>> | null = null
+let indexPromise: Promise<SearchIndexes> | null = null
+
+function createBlogIndex(
+  documents: (SearchResult & { searchText: string })[],
+): MiniSearch<SearchResult> {
+  const index = new MiniSearch<SearchResult>({
+    fields: ['title', 'excerpt', 'searchText', 'category'],
+    storeFields,
+    tokenize,
+  })
+  index.addAll(documents)
+  return index
+}
 
 /** Loads (and caches) the MiniSearch index that Vocs built. */
-export function loadSearchIndex(): Promise<MiniSearch<SearchResult>> {
+export function loadSearchIndex(): Promise<SearchIndexes> {
   if (!indexPromise) {
-    indexPromise = getSearchIndex()
-      .then((json) => MiniSearch.loadJSON<SearchResult>(json, loadOptions))
+    indexPromise = Promise.all([
+      getSearchIndex(),
+      import('virtual:blog-search-documents').then(({ documents }) => documents),
+    ])
+      .then(([json, documents]) => ({
+        docs: MiniSearch.loadJSON<SearchResult>(json, loadOptions),
+        blog: createBlogIndex(
+          documents.map((post) => ({
+            id: `blog:${post.slug}`,
+            href: `/blog/${post.slug}`,
+            title: post.title,
+            titles: [],
+            text: post.excerpt,
+            excerpt: post.excerpt,
+            category: 'Blog',
+            type: 'page',
+            searchText: post.searchText,
+          })),
+        ),
+      }))
       .catch((error) => {
         // Reset so a later open can retry rather than caching the failure.
         indexPromise = null
@@ -93,9 +128,18 @@ export function loadSearchIndex(): Promise<MiniSearch<SearchResult>> {
   return indexPromise
 }
 
-export function searchDocs(index: MiniSearch<SearchResult>, query: string): SearchResult[] {
+export function searchDocs(index: SearchIndexes, query: string): SearchResult[] {
   if (!query.trim()) return []
-  return index
-    .search(query, { ...searchOptions, tokenize })
+  return [
+    ...index.docs.search(query, { ...searchOptions, tokenize }),
+    ...index.blog.search(query, {
+      combineWith: 'OR',
+      fuzzy: 0.1,
+      prefix: false,
+      boost: { title: 5, excerpt: 3, category: 2, searchText: 1 },
+      tokenize,
+    }),
+  ]
+    .sort((a, b) => b.score - a.score)
     .slice(0, 20) as unknown as SearchResult[]
 }


### PR DESCRIPTION
## Summary
- add a lazily loaded MiniSearch index for published blog posts
- merge blog and docs results in the developer search dialog
- update search copy to reflect both content types

## Validation
- `pnpm check:types`
- `pnpm exec biome check` on changed files
- test/build startup reached Vocs indexing but was blocked fetching `https://api.tempo.xyz/openapi.json` from the sandbox

Prompted by: @snario