### PR TITLE
feat(blog): add floating article navigation

### DIFF
--- a/scripts/finalize-sitemap.ts
+++ b/scripts/finalize-sitemap.ts
@@ -9,7 +9,11 @@ let sitemap: string
 try {
   sitemap = await fs.readFile(sitemapPath, 'utf-8')
 } catch (error) {
-  if (process.env.VITE_E2E === 'true' && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+  const isMissingSitemap = (error as NodeJS.ErrnoException).code === 'ENOENT'
+  const canSkipMissingSitemap =
+    process.env.VITE_E2E === 'true' || process.env.VERCEL_ENV !== 'production'
+
+  if (isMissingSitemap && canSkipMissingSitemap) {
     process.exit(0)
   }
   throw error

--- a/src/marketing/app/blog/[slug]/page.tsx
+++ b/src/marketing/app/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Footer from '../../_components/Footer'
 import Header from '../../_components/Header'
 import Reveal from '../../_components/Reveal'
 import { developersPath } from '../../_lib/developersPaths'
+import MicroHeader from '../_components/MicroHeader'
 import { categoryBySlug, formatDate, isNew } from '../_lib/categories'
 import { getPost } from '../_lib/posts'
 
@@ -35,8 +36,12 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
     <main className="min-h-screen w-full bg-surface-page">
       <div className="mx-auto w-full max-w-7xl border-line border-x bg-surface-shell">
         <Header />
+        <MicroHeader
+          title={post.title}
+          links={[{ href: developersPath('/blog'), label: 'Blog' }]}
+        />
 
-        <article className="mx-auto w-full max-w-[760px] px-5 pt-14 lg:pt-20">
+        <article className="mx-auto w-full max-w-[760px] px-5 pt-14 lg:pt-20" data-blog-article>
           <Reveal>
             <Link
               href={developersPath('/blog')}
@@ -64,7 +69,10 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
               )}
             </div>
 
-            <h1 className="mt-5 font-sans text-[clamp(2rem,5vw,3rem)] text-foreground leading-[1.1] tracking-[-0.02em] antialiased">
+            <h1
+              className="mt-5 font-sans text-[clamp(2rem,5vw,3rem)] text-foreground leading-[1.1] tracking-[-0.02em] antialiased"
+              data-blog-title
+            >
               {post.title}
             </h1>
 
@@ -77,7 +85,7 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
               HTML at build time, so raw HTML injection here is trusted. */}
           <Reveal delay={100} className="blog-prose mt-12 border-line border-t pt-10">
             {/* biome-ignore lint/security/noDangerouslySetInnerHtml: trusted build-time markdown */}
-            <div dangerouslySetInnerHTML={{ __html: post.html }} />
+            <div data-blog-content dangerouslySetInnerHTML={{ __html: post.html }} />
           </Reveal>
         </article>
 

--- a/src/marketing/app/blog/[slug]/page.tsx
+++ b/src/marketing/app/blog/[slug]/page.tsx
@@ -36,10 +36,7 @@ export default function BlogPostPage({ params }: { params: { slug: string } }) {
     <main className="min-h-screen w-full bg-surface-page">
       <div className="mx-auto w-full max-w-7xl border-line border-x bg-surface-shell">
         <Header />
-        <MicroHeader
-          title={post.title}
-          links={[{ href: developersPath('/blog'), label: 'Blog' }]}
-        />
+        <MicroHeader title={post.title} />
 
         <article className="mx-auto w-full max-w-[760px] px-5 pt-14 lg:pt-20" data-blog-article>
           <Reveal>

--- a/src/marketing/app/blog/_components/MicroHeader.css
+++ b/src/marketing/app/blog/_components/MicroHeader.css
@@ -1,0 +1,368 @@
+.blog-micro-header {
+  --blog-micro-ease: cubic-bezier(0.23, 1, 0.32, 1);
+  position: fixed;
+  bottom: 14px;
+  left: 50%;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  height: 40px;
+  max-width: calc(100vw - 32px);
+  padding: 0 6px;
+  transform: translateX(-50%);
+  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-shell) 84%, transparent);
+  box-shadow:
+    0 12px 32px rgb(0 0 0 / 28%),
+    0 3px 10px rgb(0 0 0 / 20%);
+  color: var(--foreground);
+  font-family: var(--font-pilat-book), ui-sans-serif, system-ui, sans-serif;
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+}
+
+.blog-micro-segment {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex: none;
+  align-items: center;
+  height: 28px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 999px;
+  background: none;
+  color: color-mix(in srgb, var(--foreground) 78%, transparent);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 400;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    color 200ms ease,
+    transform 160ms var(--blog-micro-ease);
+}
+
+.blog-micro-segment:hover {
+  color: var(--foreground);
+}
+
+.blog-micro-segment:active {
+  transform: scale(0.96);
+}
+
+.blog-micro-segment:focus-visible,
+.blog-micro-menu button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--foreground) 55%, transparent);
+  outline-offset: 1px;
+}
+
+.blog-micro-wash {
+  position: absolute;
+  top: calc(50% - 14px);
+  left: -1px;
+  height: 28px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--foreground) 8%, transparent);
+  pointer-events: none;
+  transition: opacity 180ms ease;
+}
+
+.blog-micro-title {
+  display: inline-block;
+  max-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  white-space: nowrap;
+  transition:
+    max-width 320ms var(--blog-micro-ease),
+    opacity 220ms ease;
+}
+
+.blog-micro-title[data-shown] {
+  max-width: min(620px, 62vw);
+  opacity: 1;
+}
+
+.blog-micro-top {
+  padding: 0 10px;
+  color: color-mix(in srgb, var(--foreground) 48%, transparent);
+}
+
+.blog-micro-crumbs {
+  display: flex;
+  align-items: center;
+}
+
+.blog-micro-crumb {
+  overflow: hidden;
+}
+
+.blog-micro-crumb-side {
+  display: block;
+  max-width: 130px;
+  padding: 0 8px;
+  overflow: hidden;
+  color: color-mix(in srgb, var(--foreground) 42%, transparent);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition:
+    max-width 280ms var(--blog-micro-ease),
+    color 200ms ease;
+}
+
+.blog-micro-crumb-side:hover {
+  color: color-mix(in srgb, var(--foreground) 76%, transparent);
+}
+
+.blog-micro-crumb-current {
+  max-width: min(280px, 34vw);
+  color: color-mix(in srgb, var(--foreground) 80%, transparent);
+  font-weight: 600;
+  transition:
+    max-width 280ms var(--blog-micro-ease),
+    transform 160ms var(--blog-micro-ease);
+}
+
+.blog-micro-chevron {
+  flex: none;
+  margin-left: 7px;
+  color: color-mix(in srgb, var(--foreground) 42%, transparent);
+  transition: transform 200ms var(--blog-micro-ease);
+}
+
+.blog-micro-crumb-current[aria-expanded="true"] .blog-micro-chevron {
+  transform: rotate(180deg);
+}
+
+.blog-micro-crumb-separator {
+  flex: none;
+  color: color-mix(in srgb, var(--foreground) 30%, transparent);
+}
+
+.blog-micro-live-label,
+.blog-micro-label-swap {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  animation: blog-micro-label-swap 320ms var(--blog-micro-ease);
+}
+
+.blog-micro-crumbs[data-direction="1"] {
+  --blog-micro-swap-x: 32px;
+}
+
+.blog-micro-crumbs[data-direction="-1"] {
+  --blog-micro-swap-x: -32px;
+}
+
+@keyframes blog-micro-label-swap {
+  from {
+    opacity: 0;
+    filter: blur(3px);
+    transform: translate(var(--blog-micro-swap-x, 0), 2px);
+  }
+}
+
+.blog-micro-readtime-slot {
+  order: 1;
+  display: inline-flex;
+  align-items: center;
+  max-width: 0;
+  overflow: hidden;
+  transition: max-width 420ms var(--blog-micro-ease);
+}
+
+.blog-micro-readtime-slot[data-shown] {
+  max-width: 72px;
+}
+
+.blog-micro-segment.blog-micro-readtime {
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--foreground) 5%, transparent);
+  color: color-mix(in srgb, var(--foreground) 76%, transparent);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: default;
+  opacity: 0;
+  transform: scale(0.9);
+  transition:
+    opacity 300ms ease,
+    transform 420ms var(--blog-micro-ease);
+}
+
+.blog-micro-readtime-slot[data-shown] .blog-micro-readtime {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.blog-micro-segment.blog-micro-readtime:active {
+  transform: scale(1);
+}
+
+.blog-micro-readtime-number {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+
+.blog-micro-readtime-ring {
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.blog-micro-menu {
+  position: fixed;
+  bottom: 64px;
+  left: 50%;
+  z-index: 59;
+  display: flex;
+  flex-direction: column;
+  min-width: 250px;
+  max-width: min(360px, calc(100vw - 32px));
+  max-height: min(420px, 62vh);
+  padding: 6px;
+  overflow-y: auto;
+  transform: translateX(-50%);
+  transform-origin: bottom center;
+  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--surface-shell) 90%, transparent);
+  box-shadow: 0 18px 46px rgb(0 0 0 / 28%);
+  font-family: var(--font-pilat-book), ui-sans-serif, system-ui, sans-serif;
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+  animation: blog-micro-menu-in 200ms var(--blog-micro-ease);
+}
+
+@keyframes blog-micro-menu-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(4px) scale(0.97);
+  }
+}
+
+.blog-micro-menu button {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 13px;
+  background: none;
+  color: color-mix(in srgb, var(--foreground) 76%, transparent);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease;
+}
+
+.blog-micro-menu button:hover,
+.blog-micro-menu button:focus-visible {
+  background: color-mix(in srgb, var(--foreground) 8%, transparent);
+  color: var(--foreground);
+}
+
+.blog-micro-menu button[data-active] {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.blog-micro-menu-tick {
+  flex: none;
+  width: 14px;
+  height: 2px;
+  background: color-mix(in srgb, var(--foreground) 25%, transparent);
+  transition: background-color 150ms ease;
+}
+
+.blog-micro-menu button[data-active] .blog-micro-menu-tick {
+  background: var(--foreground);
+}
+
+.blog-micro-menu-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.blog-prose h2 {
+  scroll-margin-top: 24px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .blog-micro-crumb-side:hover {
+    max-width: 340px;
+  }
+
+  .blog-micro-crumb-current:hover {
+    max-width: min(460px, 50vw);
+  }
+}
+
+@media (max-width: 900px) {
+  .blog-micro-crumb-side,
+  .blog-micro-crumb-separator {
+    display: none;
+  }
+
+  .blog-micro-title[data-shown] {
+    max-width: min(420px, 58vw);
+  }
+
+  .blog-micro-crumb-current {
+    max-width: min(250px, 43vw);
+  }
+}
+
+@media (max-width: 540px) {
+  .blog-micro-header {
+    bottom: max(10px, env(safe-area-inset-bottom));
+    max-width: calc(100vw - 20px);
+  }
+
+  .blog-micro-title[data-shown] {
+    max-width: 58vw;
+  }
+
+  .blog-micro-top {
+    padding: 0 8px;
+  }
+
+  .blog-micro-crumb-current {
+    max-width: 42vw;
+    padding-right: 10px;
+    padding-left: 10px;
+  }
+
+  .blog-micro-menu {
+    bottom: calc(max(10px, env(safe-area-inset-bottom)) + 50px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blog-micro-title,
+  .blog-micro-readtime-slot,
+  .blog-micro-header .blog-micro-readtime-slot .blog-micro-readtime,
+  .blog-micro-crumb-side,
+  .blog-micro-crumb-current {
+    transition: none;
+  }
+
+  .blog-micro-live-label,
+  .blog-micro-label-swap,
+  .blog-micro-menu {
+    animation: none;
+  }
+}

--- a/src/marketing/app/blog/_components/MicroHeader.css
+++ b/src/marketing/app/blog/_components/MicroHeader.css
@@ -127,6 +127,14 @@
     transform 160ms var(--blog-micro-ease);
 }
 
+.blog-micro-post-title {
+  cursor: default;
+}
+
+.blog-micro-post-title:active {
+  transform: none;
+}
+
 .blog-micro-chevron {
   flex: none;
   margin-left: 7px;

--- a/src/marketing/app/blog/_components/MicroHeader.tsx
+++ b/src/marketing/app/blog/_components/MicroHeader.tsx
@@ -397,16 +397,23 @@ export default function MicroHeader({ title, links }: { title: string; links: Mi
           }}
         />
 
-        {links.map((link) => (
-          <Link
-            key={link.href}
-            href={link.href}
-            className="blog-micro-segment"
-            onMouseEnter={moveWash}
-          >
-            {link.label}
-          </Link>
-        ))}
+        <span
+          className="blog-micro-title"
+          data-shown={expanded || undefined}
+          aria-hidden={expanded ? undefined : true}
+        >
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="blog-micro-segment"
+              tabIndex={expanded ? undefined : -1}
+              onMouseEnter={moveWash}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </span>
 
         {readMinutes > 0 && (
           <span className="blog-micro-readtime-slot" data-shown={readTimeShown || undefined}>
@@ -443,7 +450,7 @@ export default function MicroHeader({ title, links }: { title: string; links: Mi
           </button>
         </span>
 
-        <span className="blog-micro-title" data-shown={expanded || undefined}>
+        <span className="blog-micro-title" data-shown>
           <span className="blog-micro-crumbs" data-direction={direction}>
             {previousSection && (
               <>

--- a/src/marketing/app/blog/_components/MicroHeader.tsx
+++ b/src/marketing/app/blog/_components/MicroHeader.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Link from 'next/link'
 import {
   type CSSProperties,
   type MouseEvent as ReactMouseEvent,
@@ -10,11 +9,6 @@ import {
   useState,
 } from 'react'
 import './MicroHeader.css'
-
-type MicroHeaderLink = {
-  href: string
-  label: string
-}
 
 type Section = {
   id: string
@@ -110,7 +104,7 @@ function ProgressRing({
  * It tracks the article's H2 sections and keeps reading progress available
  * after the primary site navigation has scrolled away.
  */
-export default function MicroHeader({ title, links }: { title: string; links: MicroHeaderLink[] }) {
+export default function MicroHeader({ title }: { title: string }) {
   const ringId = useId().replace(/:/g, '')
   const [expanded, setExpanded] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
@@ -398,21 +392,10 @@ export default function MicroHeader({ title, links }: { title: string; links: Mi
         />
 
         <span
-          className="blog-micro-title"
-          data-shown={expanded || undefined}
-          aria-hidden={expanded ? undefined : true}
+          className="blog-micro-segment blog-micro-crumb blog-micro-crumb-current blog-micro-post-title"
+          title={title}
         >
-          {links.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="blog-micro-segment"
-              tabIndex={expanded ? undefined : -1}
-              onMouseEnter={moveWash}
-            >
-              {link.label}
-            </Link>
-          ))}
+          <span className="blog-micro-live-label">{title}</span>
         </span>
 
         {readMinutes > 0 && (
@@ -450,7 +433,7 @@ export default function MicroHeader({ title, links }: { title: string; links: Mi
           </button>
         </span>
 
-        <span className="blog-micro-title" data-shown>
+        <span className="blog-micro-title" data-shown={activeIndex >= 0 || undefined}>
           <span className="blog-micro-crumbs" data-direction={direction}>
             {previousSection && (
               <>

--- a/src/marketing/app/blog/_components/MicroHeader.tsx
+++ b/src/marketing/app/blog/_components/MicroHeader.tsx
@@ -1,0 +1,542 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react'
+import './MicroHeader.css'
+
+type MicroHeaderLink = {
+  href: string
+  label: string
+}
+
+type Section = {
+  id: string
+  title: string
+}
+
+function sectionSlug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
+function ProgressRing({
+  width: boxWidth,
+  height: boxHeight,
+  progress,
+  uid,
+  className,
+  glow = 3.5,
+  style,
+}: {
+  width: number
+  height: number
+  progress: number
+  uid: string
+  className: string
+  glow?: number
+  style?: CSSProperties
+}) {
+  const strokeWidth = 1.5
+  const width = boxWidth - strokeWidth
+  const height = boxHeight - strokeWidth
+  const radius = height / 2
+  const straight = Math.max(0, width - 2 * radius)
+  const perimeter = 2 * straight + 2 * Math.PI * radius
+  const startOffset = (straight / 2 / perimeter) * 100
+  const visible = progress * 100
+  const dash = `${visible} ${Math.max(0, 100 - visible) + 0.5}`
+  const shared = {
+    x: strokeWidth / 2,
+    y: strokeWidth / 2,
+    width,
+    height,
+    rx: radius,
+    pathLength: 100,
+    fill: 'none',
+    stroke: `url(#${uid}-ink)`,
+    strokeLinecap: 'round' as const,
+    strokeDasharray: dash,
+    strokeDashoffset: -startOffset,
+  }
+
+  return (
+    <svg className={className} width={boxWidth} height={boxHeight} style={style} aria-hidden="true">
+      <defs>
+        <linearGradient id={`${uid}-ink`} x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0%" stopColor="#b87333" />
+          <stop offset="100%" stopColor="#4682b4" />
+        </linearGradient>
+        <filter id={`${uid}-glow`} x="-60%" y="-60%" width="220%" height="220%">
+          <feGaussianBlur stdDeviation={glow} />
+        </filter>
+        <mask
+          id={`${uid}-mask`}
+          maskUnits="userSpaceOnUse"
+          x={-24}
+          y={-24}
+          width={boxWidth + 48}
+          height={boxHeight + 48}
+        >
+          <rect x={-24} y={-24} width={boxWidth + 48} height={boxHeight + 48} fill="#fff" />
+          <rect
+            x={strokeWidth / 2}
+            y={strokeWidth / 2}
+            width={width}
+            height={height}
+            rx={radius}
+            fill="#000"
+          />
+        </mask>
+      </defs>
+      <g mask={`url(#${uid}-mask)`}>
+        <rect {...shared} strokeWidth={3.5} opacity={0.85} filter={`url(#${uid}-glow)`} />
+      </g>
+      <rect {...shared} strokeWidth={strokeWidth} />
+    </svg>
+  )
+}
+
+/**
+ * Floating blog navigation adapted from tanishq.xyz's engineering MicroHeader.
+ * It tracks the article's H2 sections and keeps reading progress available
+ * after the primary site navigation has scrolled away.
+ */
+export default function MicroHeader({ title, links }: { title: string; links: MicroHeaderLink[] }) {
+  const ringId = useId().replace(/:/g, '')
+  const [expanded, setExpanded] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [sections, setSections] = useState<Section[]>([])
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const [progress, setProgress] = useState(0)
+  const [readMinutes, setReadMinutes] = useState(0)
+  const [readTimeShown, setReadTimeShown] = useState(false)
+  const [direction, setDirection] = useState(0)
+  const [readBox, setReadBox] = useState({ x: 0, y: 0, width: 0, height: 0 })
+  const [wash, setWash] = useState({ x: 0, width: 0, visible: false })
+
+  const rootRef = useRef<HTMLElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const readTimeRef = useRef<HTMLSpanElement>(null)
+  const hoveredElementRef = useRef<HTMLElement | null>(null)
+  const washFrameRef = useRef(0)
+  const washRunningRef = useRef(false)
+  const shownWashRef = useRef({ x: 0, width: 0 })
+  const navigationLockRef = useRef(0)
+  const lastIndexRef = useRef(-1)
+
+  useEffect(() => {
+    if (activeIndex === lastIndexRef.current) return
+    setDirection(activeIndex > lastIndexRef.current ? 1 : -1)
+    lastIndexRef.current = activeIndex
+  }, [activeIndex])
+
+  useEffect(() => {
+    const header = rootRef.current
+    if (!header) return
+
+    const measure = () => {
+      const readTime = readTimeRef.current
+      if (!readTime) return
+      const readTimeRect = readTime.getBoundingClientRect()
+      const headerRect = header.getBoundingClientRect()
+      setReadBox({
+        x: readTimeRect.left - headerRect.left,
+        y: readTimeRect.top - headerRect.top,
+        width: readTimeRect.width,
+        height: readTimeRect.height,
+      })
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(header)
+    if (readTimeRef.current) observer.observe(readTimeRef.current)
+    return () => observer.disconnect()
+  }, [readMinutes, readTimeShown])
+
+  useEffect(() => {
+    const content = document.querySelector<HTMLElement>('[data-blog-content]')
+    if (!content) return
+
+    let revealFrame = 0
+    const syncContent = () => {
+      const usedIds = new Set<string>()
+      const headings = Array.from(content.querySelectorAll<HTMLHeadingElement>('h2'))
+      const nextSections = headings.map((heading, index) => {
+        const baseId =
+          heading.id || sectionSlug(heading.textContent ?? '') || `section-${index + 1}`
+        let id = baseId
+        let suffix = 2
+        while (usedIds.has(id)) {
+          id = `${baseId}-${suffix}`
+          suffix += 1
+        }
+        usedIds.add(id)
+        heading.id = id
+        return { id, title: heading.textContent?.trim() || `Section ${index + 1}` }
+      })
+      setSections(nextSections)
+
+      const words = content.textContent?.trim().match(/\S+/g)?.length ?? 0
+      const minutes = words > 0 ? Math.max(1, Math.round(words / 220)) : 0
+      setReadMinutes(minutes)
+      if (minutes > 0 && !revealFrame) {
+        revealFrame = requestAnimationFrame(() => setReadTimeShown(true))
+      }
+    }
+
+    syncContent()
+    const observer = new MutationObserver(syncContent)
+    observer.observe(content, { childList: true, subtree: true })
+    return () => {
+      observer.disconnect()
+      cancelAnimationFrame(revealFrame)
+    }
+  }, [title])
+
+  useEffect(() => {
+    const article = document.querySelector<HTMLElement>('[data-blog-article]')
+    const titleElement = document.querySelector<HTMLElement>('[data-blog-title]')
+    if (!article || !titleElement) return
+
+    let measureFrame = 0
+    let progressFrame = 0
+    let shownProgress = 0
+    let targetProgress = 0
+
+    const animateProgress = () => {
+      const next = shownProgress + (targetProgress - shownProgress) * 0.14
+      if (Math.abs(targetProgress - next) < 0.0008) {
+        shownProgress = targetProgress
+        setProgress(shownProgress)
+        progressFrame = 0
+        return
+      }
+      shownProgress = next
+      setProgress(shownProgress)
+      progressFrame = requestAnimationFrame(animateProgress)
+    }
+
+    const measure = () => {
+      measureFrame = 0
+      const titleHasPassed = titleElement.getBoundingClientRect().bottom <= 70
+      setExpanded(titleHasPassed)
+
+      const articleRect = article.getBoundingClientRect()
+      const articleTop = window.scrollY + articleRect.top
+      const progressEnd = Math.max(
+        articleTop + 1,
+        articleTop + articleRect.height - window.innerHeight * 0.72,
+      )
+      targetProgress = Math.max(
+        0,
+        Math.min(1, (window.scrollY - articleTop) / (progressEnd - articleTop)),
+      )
+      if (!progressFrame) progressFrame = requestAnimationFrame(animateProgress)
+
+      if (Date.now() < navigationLockRef.current) return
+      const headings = Array.from(
+        document.querySelectorAll<HTMLHeadingElement>('[data-blog-content] h2'),
+      )
+      headings.forEach((heading, index) => {
+        const section = sections[index]
+        if (section) heading.id = section.id
+      })
+      let nextIndex = -1
+      for (let index = 0; index < headings.length; index += 1) {
+        if (headings[index].getBoundingClientRect().top <= 150) nextIndex = index
+      }
+
+      const pageBottom =
+        window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 8
+      if (pageBottom && headings.length > 0) nextIndex = headings.length - 1
+      setActiveIndex(nextIndex)
+    }
+
+    const scheduleMeasure = () => {
+      if (!measureFrame) measureFrame = requestAnimationFrame(measure)
+    }
+
+    measure()
+    window.addEventListener('scroll', scheduleMeasure, { passive: true })
+    window.addEventListener('resize', scheduleMeasure)
+    return () => {
+      window.removeEventListener('scroll', scheduleMeasure)
+      window.removeEventListener('resize', scheduleMeasure)
+      cancelAnimationFrame(measureFrame)
+      cancelAnimationFrame(progressFrame)
+    }
+  }, [sections.length])
+
+  useEffect(() => {
+    if (!menuOpen) return
+
+    const closeOnOutsidePointer = (event: PointerEvent) => {
+      const target = event.target as Node
+      if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) {
+        setMenuOpen(false)
+      }
+    }
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMenuOpen(false)
+    }
+
+    document.addEventListener('pointerdown', closeOnOutsidePointer)
+    document.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsidePointer)
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [menuOpen])
+
+  const washTarget = () => {
+    const hoveredElement = hoveredElementRef.current
+    const header = rootRef.current
+    if (!hoveredElement || !header) return null
+
+    const segmentRect = hoveredElement.getBoundingClientRect()
+    const headerRect = header.getBoundingClientRect()
+    return { x: segmentRect.left - headerRect.left, width: segmentRect.width }
+  }
+
+  const followWash = (snap: boolean) => {
+    if (snap) {
+      const target = washTarget()
+      if (target) shownWashRef.current = target
+    }
+    if (washRunningRef.current) return
+
+    washRunningRef.current = true
+    const tick = () => {
+      const target = washTarget()
+      if (!hoveredElementRef.current || !target) {
+        washRunningRef.current = false
+        return
+      }
+
+      const shown = shownWashRef.current
+      const next = {
+        x: shown.x + (target.x - shown.x) * 0.28,
+        width: shown.width + (target.width - shown.width) * 0.28,
+      }
+      shownWashRef.current = next
+      setWash({ ...next, visible: true })
+      washFrameRef.current = requestAnimationFrame(tick)
+    }
+    washFrameRef.current = requestAnimationFrame(tick)
+  }
+
+  const moveWash = (event: ReactMouseEvent<HTMLElement>) => {
+    const shouldSnap = hoveredElementRef.current === null
+    hoveredElementRef.current = event.currentTarget
+    followWash(shouldSnap)
+  }
+
+  useEffect(() => () => cancelAnimationFrame(washFrameRef.current), [])
+
+  const prefersReducedMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  const backToTop = () => {
+    setMenuOpen(false)
+    window.scrollTo({ top: 0, behavior: prefersReducedMotion() ? 'auto' : 'smooth' })
+  }
+
+  const jumpToSection = (id: string) => {
+    setMenuOpen(false)
+    const index = sections.findIndex((section) => section.id === id)
+    if (index >= 0) setActiveIndex(index)
+    navigationLockRef.current = Date.now() + 900
+    const headings = Array.from(
+      document.querySelectorAll<HTMLHeadingElement>('[data-blog-content] h2'),
+    )
+    const heading = document.getElementById(id) ?? (index >= 0 ? headings[index] : null)
+    if (heading) heading.id = id
+    heading?.scrollIntoView({
+      behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+      block: 'start',
+    })
+  }
+
+  const currentTitle = activeIndex >= 0 ? sections[activeIndex]?.title : title
+  const previousSection = activeIndex > 0 ? sections[activeIndex - 1] : null
+  const nextSection = activeIndex < sections.length - 1 ? sections[activeIndex + 1] : null
+  const remainingMinutes = readMinutes * (1 - progress)
+  const readLabel =
+    progress >= 0.999 ? 'Done' : remainingMinutes < 1 ? '<1m' : `${Math.ceil(remainingMinutes)}m`
+  const readAria = progress >= 0.999 ? 'Finished reading' : `About ${readLabel} left to read`
+
+  return (
+    <>
+      <nav
+        className="blog-micro-header"
+        data-expanded={expanded || undefined}
+        aria-label="Article navigation"
+        ref={rootRef}
+        onMouseLeave={() => {
+          hoveredElementRef.current = null
+          washRunningRef.current = false
+          setWash((currentWash) => ({ ...currentWash, visible: false }))
+        }}
+      >
+        <span
+          className="blog-micro-wash"
+          aria-hidden="true"
+          style={{
+            transform: `translateX(${wash.x}px)`,
+            width: wash.width,
+            opacity: wash.visible ? 1 : 0,
+          }}
+        />
+
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="blog-micro-segment"
+            onMouseEnter={moveWash}
+          >
+            {link.label}
+          </Link>
+        ))}
+
+        {readMinutes > 0 && (
+          <span className="blog-micro-readtime-slot" data-shown={readTimeShown || undefined}>
+            <span
+              className="blog-micro-segment blog-micro-readtime"
+              ref={readTimeRef}
+              role="timer"
+              aria-label={readAria}
+              title="Reading time left"
+            >
+              <span className="blog-micro-readtime-number">{readLabel}</span>
+            </span>
+          </span>
+        )}
+
+        <span className="blog-micro-title" data-shown={expanded || undefined}>
+          <button
+            type="button"
+            className="blog-micro-segment blog-micro-top"
+            aria-label="Back to top"
+            onMouseEnter={moveWash}
+            onClick={backToTop}
+          >
+            <svg viewBox="0 0 12 12" width="11" height="11" aria-hidden="true">
+              <path
+                d="M 6 10.5 L 6 2 M 2.5 5.5 L 6 2 L 9.5 5.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </span>
+
+        <span className="blog-micro-title" data-shown={expanded || undefined}>
+          <span className="blog-micro-crumbs" data-direction={direction}>
+            {previousSection && (
+              <>
+                <button
+                  type="button"
+                  className="blog-micro-segment blog-micro-crumb blog-micro-crumb-side"
+                  aria-label={`Previous section: ${previousSection.title}`}
+                  onMouseEnter={moveWash}
+                  onClick={() => jumpToSection(previousSection.id)}
+                >
+                  <span key={previousSection.id} className="blog-micro-label-swap">
+                    {previousSection.title}
+                  </span>
+                </button>
+                <span className="blog-micro-crumb-separator" aria-hidden="true">
+                  ›
+                </span>
+              </>
+            )}
+
+            <button
+              type="button"
+              className="blog-micro-segment blog-micro-crumb blog-micro-crumb-current"
+              aria-label="Article sections"
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              onMouseEnter={moveWash}
+              onClick={() => setMenuOpen((currentOpen) => !currentOpen)}
+            >
+              <span key={currentTitle} className="blog-micro-live-label">
+                {currentTitle}
+              </span>
+              <svg
+                className="blog-micro-chevron"
+                viewBox="0 0 10 6"
+                width="9"
+                height="6"
+                aria-hidden="true"
+              >
+                <path d="M 1 1 L 5 5 L 9 1" fill="none" stroke="currentColor" strokeWidth="1.4" />
+              </svg>
+            </button>
+
+            {nextSection && (
+              <>
+                <span className="blog-micro-crumb-separator" aria-hidden="true">
+                  ›
+                </span>
+                <button
+                  type="button"
+                  className="blog-micro-segment blog-micro-crumb blog-micro-crumb-side"
+                  aria-label={`Next section: ${nextSection.title}`}
+                  onMouseEnter={moveWash}
+                  onClick={() => jumpToSection(nextSection.id)}
+                >
+                  <span key={nextSection.id} className="blog-micro-label-swap">
+                    {nextSection.title}
+                  </span>
+                </button>
+              </>
+            )}
+          </span>
+        </span>
+
+        {readBox.width > 0 && progress > 0.008 && (
+          <ProgressRing
+            className="blog-micro-readtime-ring"
+            uid={`${ringId}-readtime-progress`}
+            width={readBox.width}
+            height={readBox.height}
+            progress={progress}
+            glow={3}
+            style={{ transform: `translate(${readBox.x}px, ${readBox.y}px)` }}
+          />
+        )}
+      </nav>
+
+      {menuOpen && sections.length > 0 && (
+        <div className="blog-micro-menu" role="menu" aria-label="Article sections" ref={menuRef}>
+          {sections.map((section, index) => (
+            <button
+              key={section.id}
+              type="button"
+              role="menuitem"
+              data-active={index === activeIndex || undefined}
+              onClick={() => jumpToSection(section.id)}
+            >
+              <span className="blog-micro-menu-tick" aria-hidden="true" />
+              <span className="blog-micro-menu-label">{section.title}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/marketing/app/blog/_components/MicroHeader.tsx
+++ b/src/marketing/app/blog/_components/MicroHeader.tsx
@@ -72,8 +72,8 @@ function ProgressRing({
     <svg className={className} width={boxWidth} height={boxHeight} style={style} aria-hidden="true">
       <defs>
         <linearGradient id={`${uid}-ink`} x1="0" y1="0" x2="1" y2="0">
-          <stop offset="0%" stopColor="#b87333" />
-          <stop offset="100%" stopColor="#4682b4" />
+          <stop offset="0%" stopColor="var(--vocs-color-accent)" stopOpacity={0.42} />
+          <stop offset="100%" stopColor="var(--vocs-color-accent)" />
         </linearGradient>
         <filter id={`${uid}-glow`} x="-60%" y="-60%" width="220%" height="220%">
           <feGaussianBlur stdDeviation={glow} />


### PR DESCRIPTION
## Summary

- add a bottom-anchored MicroHeader to every published blog post
- show reading time, progress, active-section breadcrumbs, and previous/next section navigation
- add an upward-opening section menu with responsive and reduced-motion behavior
- keep heading IDs synchronized when rendered Markdown is refreshed during hydration

## Testing

- pnpm exec biome check (MicroHeader TSX/CSS and blog layout)
- pnpm check:types
- desktop and mobile browser verification, including section tracking, progress, menu navigation, and safe-area placement
- pnpm build: Vite compilation and SSG completed (457 files); the wrapper exits in finalize-sitemap.ts because dist/public/sitemap.xml is absent