### PR TITLE
Update T8 docs for published v1.11.0 release

### DIFF
--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.11.0 | Planned: Jul 22, 2026 | Testnet + Mainnet | Required release for T8; includes current committee state, FeeAMM policy exemptions, versioned Stablecoin DEX order storage, and DEX V2Order support. | <Badge variant="red">Required</Badge> |
+| [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8; schedules activation for July 27 on testnet and July 30 on mainnet. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.9.0](https://github.com/tempoxyz/tempo/releases/tag/v1.9.0) | Jun 15, 2026 | Testnet + Mainnet | Required for T6; adds account-level receive policies for safer TIP-20 deposits and admin access keys for smoother passkey, device, and delegated-key management. Operators were required to run this release before the T6 activation timestamp on each network. | <Badge variant="red">Required</Badge> |
@@ -40,15 +40,15 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | | |
 |---|---|
-| **Scope** | current committee state; FeeAMM policy exemptions; versioned Stablecoin DEX order storage; DEX V2Order support |
-| **References** | [current committee state specification](https://tips.sh/1070), [FeeAMM policy exemptions specification](https://tips.sh/1042), [versioned DEX order storage specification](https://tips.sh/1062) |
+| **Scope** | current committee state; FeeAMM policy exemptions; versioned Stablecoin DEX order storage; DEX V2Order support; final TIP-20 rewards deprecation |
+| **References** | [current committee state specification](https://tips.sh/1070), [FeeAMM policy exemptions specification](https://tips.sh/1042), [versioned DEX order storage specification](https://tips.sh/1062), [TIP-20 rewards deprecation](https://tips.sh/1075), [V2 DEX order storage](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1087.md) |
 | **Details** | [T8 network upgrade](/docs/protocol/upgrades/t8) |
-| **Planned release date** | July 22, 2026 |
-| **Testnet** | Planned: July 27, 2026 |
-| **Mainnet** | Planned: July 30, 2026 |
+| **Release** | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) |
+| **Testnet** | Scheduled: July 27, 2026 16:00 CEST (unix: 1785160800) |
+| **Mainnet** | Scheduled: July 30, 2026 16:00 CEST (unix: 1785420000) |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
-T8 is planned. Node operators should wait for the T8 release announcement, then upgrade before the activation timestamp on each network.
+T8 is scheduled for testnet and mainnet. Node operators should run [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) before the activation timestamp on each network to stay synced.
 
 ---
 

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -1,33 +1,34 @@
 ---
 title: T8 Network Upgrade
-description: T8 network upgrade overview covering current committee state, FeeAMM policy behavior, and DEX order storage.
+description: T8 network upgrade overview covering current committee state, FeeAMM policy behavior, DEX order storage, and the final TIP-20 rewards shutdown.
 ---
 
 # T8 Network Upgrade
 
-T8 focuses on clearer validator committee reads, FeeAMM policy behavior, and DEX order storage.
+T8 focuses on clearer validator committee reads, FeeAMM policy behavior, DEX order storage, and the final TIP-20 rewards shutdown.
 
 :::info[T8 status]
-Release target: July 22, 2026.
+Release [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) is published and required for T8. T8 is scheduled for testnet on July 27, 2026 and mainnet on July 30, 2026.
 :::
 
 ## Timeline
 
-| Milestone | Date |
-|-----------|------|
-| Release target | July 22, 2026 |
-| Testnet rollout | July 27, 2026 |
-| Mainnet rollout | July 30, 2026 |
+| Milestone | Date | Timestamp |
+|-----------|------|-----------|
+| Release published | July 22, 2026 | - |
+| Testnet activation | July 27, 2026 16:00 CEST (14:00 UTC) | 1785160800 |
+| Mainnet activation | July 30, 2026 16:00 CEST (14:00 UTC) | 1785420000 |
 
-Node operators should wait for the T8 release announcement, then upgrade before the activation timestamp on each network. Exact activation timestamps will be added when the release is cut.
+Node operators should run [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) before the activation timestamp on each network. Nodes that are not updated before activation will fall out of sync.
 
 ## Overview
 
-T8 focuses on three infrastructure-facing changes:
+T8 focuses on four infrastructure-facing changes:
 
 - **Canonical current committee reads.** Contracts and offchain tools can query the committee that consensus is actually using for the current epoch.
 - **Cleaner fee collection behavior.** Fee collection avoids a redundant FeeManager policy check while public AMM actions remain policy-controlled.
 - **DEX order storage updates.** New DEX orders use versioned storage, existing orders remain readable, and the Stablecoin DEX supports the compact V2Order layout.
+- **Rewards cleanup.** T8 completes the TIP-20 rewards shutdown that began in T7. Settled rewards remain claimable, but ordinary balance changes no longer checkpoint rewards after T8.
 
 ## Features
 
@@ -61,17 +62,28 @@ The public `getOrder(uint128)` shape stays compatible. Indexers that reconstruct
 
 The Stablecoin DEX also supports a compact V2Order layout. V2Order stores an orderbook index instead of repeating the full book key on each order.
 
+For raw-storage tooling, the main savings are structural: version-1 order records reduce active order storage from six slots to four, and version-2 indexed order records reduce indexed orders from four slots to three.
+
 Read the versioned order storage specification [here](https://tips.sh/1062).
+
+### TIP-20 rewards final shutdown
+
+T8 completes the reward shutdown that started in T7. After T8 activation, ordinary balance-changing paths such as transfers, mints, burns, and fee refunds stop checkpointing reward accumulators.
+
+Rewards that were settled before T8 remain claimable. Lazy rewards that were not checkpointed before activation are forfeited, so rewards integrations should not rely on a post-T8 transfer or balance change to settle older lazy accruals.
+
+Read the rewards deprecation specification [here](https://tips.sh/1075).
 
 ## Compatible releases
 
-The T8-compatible release is not published yet.
+The T8-compatible release is published.
 
 | Ecosystem | T8-compatible releases |
 |-----------|------------------------|
-| Node operators | v1.11.0 target release on July 22, 2026 |
+| Node operators | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) |
+| Rust SDK crates | `tempo-alloy@1.10.1`, `tempo-primitives@1.10.1`, `tempo-contracts@1.10.1`, `tempo-chainspec@1.10.1`, `tempo-hardfork@1.10.1` |
 
-Release notes and binaries will be linked here when v1.11.0 is cut.
+Release notes and binaries are available in the [v1.11.0 release](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0).
 
 ## Integration impact
 
@@ -94,6 +106,12 @@ Release notes and binaries will be linked here when v1.11.0 is cut.
 
 - Event-driven order indexing should continue to work.
 - `getOrder(uint128)` remains ABI-compatible.
-- Raw storage readers must support both legacy version `0` orders and new version `1` orders.
+- Raw storage readers must support legacy version `0` orders, compact version `1` orders, and indexed version `2` orders.
 - Mixed-version order lists are expected, so storage tooling should update each order according to that order's own version.
-- Tooling that reads raw DEX storage should also account for V2Order support.
+- Existing orderbooks are not automatically scanned or migrated to indexed storage. They continue writing version-1 orders until offchain migration tooling supplies the verified index through `setBookIndex(uint32)`.
+
+### For TIP-20 rewards integrations
+
+- Rewards settled before T8 remain claimable.
+- Ordinary balance changes stop checkpointing reward accumulators after T8.
+- Do not rely on a post-T8 transfer, mint, burn, or fee refund to settle older lazy rewards.


### PR DESCRIPTION
## What changed

- Update the T8 upgrade page now that `v1.11.0` is published and required for T8.
- Replace release-target language with a linked published release and exact activation timestamps.
- Remove the old target release date row from the Network Upgrades and Releases page and add the `v1.11.0` release link.
- Fold in the final TIP-20 rewards shutdown and V2 DEX order storage details from the release notes.
- Add the SDK crate versions listed in the `v1.11.0` release notes.

## Why

The T8 node release is now published, so docs should point operators to the required release and use the final schedule from the release notes.

## Source

- https://github.com/tempoxyz/tempo/releases/tag/v1.11.0

## Validation

- Ran `pnpm build` successfully.