### PR TITLE
Remove T8 release-published timeline row

### DIFF
--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -15,7 +15,6 @@ Release [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) is pub
 
 | Milestone | Date | Timestamp |
 |-----------|------|-----------|
-| Release published | July 22, 2026 | - |
 | Testnet activation | July 27, 2026 16:00 CEST (14:00 UTC) | 1785160800 |
 | Mainnet activation | July 30, 2026 16:00 CEST (14:00 UTC) | 1785420000 |
 


### PR DESCRIPTION
## What changed

- Remove the `Release published` row from the T8 timeline table.
- Keep the testnet and mainnet activation rows as the only timeline milestones.

## Why

The release is already linked in the status callout and compatible release section, so the timeline can stay focused on activation dates.

## Validation

- Confirmed the diff is one row removed from `src/pages/docs/protocol/upgrades/t8.mdx`.
- No full build run; this is a one-line Markdown table cleanup.