### PR TITLE
Add Rio, MoonPay, Chainlink to Ecosystem docs

### DIFF
--- a/src/pages/docs/ecosystem/data-analytics.mdx
+++ b/src/pages/docs/ecosystem/data-analytics.mdx
@@ -31,12 +31,13 @@ Artemis also maintains a cross-chain stablecoin dashboard covering major USD-peg
 
 Chainlink supports Tempo through:
 
+- **Price Feeds:** Chainlink Price Feeds provide decentralized market data onchain for lending markets, FX, tokenized assets, stablecoins, and risk-management applications. View the live feeds and contract addresses in the [Chainlink Price Feed directory](https://docs.chain.link/data-feeds/price-feeds/addresses?network=tempo).
 - **Cross-Chain Interoperability Protocol (CCIP):** A secure interoperability layer for sending messages and value across chains, enabling cross-chain user flows and multi-chain architectures.  
 Explore CCIP in the [Chainlink CCIP docs](https://docs.chain.link/ccip).
 - **Data Streams:** Chainlink Data Streams delivers low-latency market data offchain, which can be verified onchain. This pull-based design gives dApps on-demand access to high-frequency market data backed by decentralized, fault-tolerant, and transparent infrastructure—an improvement over traditional push-based oracles that update only at fixed intervals or price thresholds.  
 View the Chainlink Data Stream deployed on Tempo [here](https://explore.tempo.xyz/address/0x72790f9eB82db492a7DDb6d2af22A270Dcc3Db64?tab=contract).
 
-Developers can explore CCIP, Data Streams, and the full Chainlink platform through the [Chainlink Developer Docs](https://docs.chain.link/).
+Developers can explore Price Feeds, CCIP, Data Streams, and the full Chainlink platform through the [Chainlink Developer Docs](https://docs.chain.link/).
 
 ## Chronicle
 

--- a/src/pages/docs/ecosystem/orchestration.mdx
+++ b/src/pages/docs/ecosystem/orchestration.mdx
@@ -43,6 +43,18 @@ For EUR and GBP, Hercle also supports pay-ins, payouts, and stablecoin on-ramps 
 
 [Check supported corridors](https://www.hercle.com/corridor-checker/) or [contact Hercle](https://www.hercle.com/contact/) to get started.
 
+## MoonPay
+
+[MoonPay](https://www.moonpay.com/business/ramps) provides global on-ramp and off-ramp infrastructure for applications that need to move users between fiat currencies and stablecoins. Teams can integrate MoonPay Ramps through a widget, SDK, or API, with payment methods, identity verification, fraud protection, and compliance built into the flow.
+
+Explore the [MoonPay developer docs](https://dev.moonpay.com/) to get started.
+
+## Rio
+
+[Rio](https://www.rio.trade/stablecoin-fx) provides stablecoin FX infrastructure for converting between fiat currencies and stablecoins. Its real-time execution engine and integration APIs help platforms embed FX conversion and settle transactions onchain.
+
+[Contact Rio](https://www.rio.trade/stablecoin-fx) to discuss an integration.
+
 ## UR
 
 [UR](https://ur.app/partners/tempo) provides infrastructure that connects stablecoin settlement with fiat rails for platforms building global financial services.


### PR DESCRIPTION
Summary:
- document MoonPay ramp infrastructure
- document Rio stablecoin FX infrastructure

Validation:
- pnpm check:types

Note: pnpm build reached the external fetch stage but timed out on a network request.

Prompted by: @juandolealt