### PR TITLE
fix: preserve activation for passkey sign-in

### DIFF
--- a/e2e/deposit-to-zone.test.ts
+++ b/e2e/deposit-to-zone.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test'
+
+test('deposit-to-zone guide creates a passkey account', async ({ page }) => {
+  const client = await page.context().newCDPSession(page)
+  await client.send('WebAuthn.enable')
+  const { authenticatorId } = await client.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+    },
+  })
+
+  try {
+    await page.goto('/docs/guide/private-zones/deposit-to-a-zone')
+
+    const accountStep = page
+      .locator('[data-active][data-completed]')
+      .filter({ hasText: 'Create or use a passkey account on the public chain.' })
+      .first()
+    await accountStep.getByRole('button', { name: 'Sign up' }).click()
+
+    await expect(accountStep.getByRole('button', { name: 'Sign out' })).toBeVisible()
+  } finally {
+    await client.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId }).catch(() => {})
+  }
+})

--- a/src/components/guides/EmbedPasskeys.tsx
+++ b/src/components/guides/EmbedPasskeys.tsx
@@ -42,10 +42,9 @@ export function EmbedPasskeys() {
 
 export function SignInButtons() {
   const connect = useConnect()
-  const disconnect = useDisconnect()
   const hydrated = useHydrated()
   const connector = useWebAuthnConnector()
-  const busy = connect.isPending || disconnect.isPending
+  const busy = connect.isPending
   const isE2E = import.meta.env.VITE_E2E === 'true'
 
   if (!hydrated || !connector)
@@ -66,8 +65,8 @@ export function SignInButtons() {
     <div className="flex gap-1">
       <Button
         variant="accent"
-        onClick={async () => {
-          await disconnect.disconnectAsync().catch(() => {})
+        onClick={() => {
+          // Start WebAuthn synchronously so the browser preserves transient user activation.
           connect.connect({
             connector,
             ...(isE2E
@@ -86,8 +85,8 @@ export function SignInButtons() {
       </Button>
       <Button
         variant="default"
-        onClick={async () => {
-          await disconnect.disconnectAsync().catch(() => {})
+        onClick={() => {
+          // Start WebAuthn synchronously so the browser preserves transient user activation.
           connect.connect({ connector })
         }}
         type="button"


### PR DESCRIPTION
## Summary

- Start passkey registration and authentication directly from the click handler.
- Preserve the browser transient user-activation window required by WebAuthn.

## Validation

- `pnpm check:types`
- `CI=true pnpm test` *(blocked during Vite startup because the remote OpenAPI spec fetch failed)*

Prompted by: @alexrisch