### PR TITLE
docs: fix broken anchor links

### DIFF
--- a/src/pages/docs/guide/issuance/create-a-stablecoin.mdx
+++ b/src/pages/docs/guide/issuance/create-a-stablecoin.mdx
@@ -43,7 +43,7 @@ Ensure that you have set up your project with Wagmi, a Tempo chain config, and a
 Before we send off a transaction to deploy our stablecoin to the Tempo testnet, we need to make sure our account is funded with a stablecoin to cover the transaction fee. 
 
 As we have configured our project to use `AlphaUSD` (`0x20c000…0001`) 
-as the [default fee token](/docs/quickstart/integrate-tempo#default-fee-token), we will need to add some `AlphaUSD` to our account.
+as the [default fee token](/docs/quickstart/evm-compatibility#consideration-1-setting-a-user-default-fee-token), we will need to add some `AlphaUSD` to our account.
 
 Luckily, the built-in Tempo testnet faucet supports funding accounts with `AlphaUSD`.
 

--- a/src/pages/docs/guide/issuance/manage-stablecoin.mdx
+++ b/src/pages/docs/guide/issuance/manage-stablecoin.mdx
@@ -22,7 +22,7 @@ import { Cards, Card } from 'vocs'
 
 Configure your stablecoin's permissions, supply limits, and compliance policies after deployment. This guide covers granting roles to manage token operations, setting supply caps, configuring transfer policies, and controlling token transfers through pause/unpause functionality.
 
-TIP-20 tokens use a role-based access control system that allows you to delegate different administrative functions to different addresses. For detailed information about the role system, see the [TIP-20 specification](/docs/protocol/tip20/spec#role-based-access-control).
+TIP-20 tokens use a role-based access control system that allows you to delegate different administrative functions to different addresses. For detailed information about the role system, see the [TIP-20 specification](/docs/protocol/tip20/spec#tip-20-roles).
 
 ## Stablecoin management steps
 
@@ -638,7 +638,7 @@ Ensure pause and unpause roles are assigned to trusted addresses and that your t
 <Cards>
   <Card
     description="Learn about the role-based access control system and all available roles"
-    to="/docs/protocol/tip20/spec#role-based-access-control"
+    to="/docs/protocol/tip20/spec#tip-20-roles"
     icon="lucide:shield"
     title="Role-Based Access Control"
   />

--- a/src/pages/docs/guide/issuance/use-for-fees.mdx
+++ b/src/pages/docs/guide/issuance/use-for-fees.mdx
@@ -311,7 +311,7 @@ Regularly check your token's fee pool reserves to ensure users can consistently 
 
 Keep sufficient validator token reserves in your fee pool to handle expected transaction volume. Consider your user base size and typical transaction frequency when determining reserve levels.
 
-As fees accrue in your token, the pool will run low on validator tokens and need to be rebalanced. Use [`rebalanceSwap`](/docs/guide/stablecoin-dex/managing-fee-liquidity#rebalance-liquidity) to replenish validator token reserves when they become depleted.
+As fees accrue in your token, the pool will run low on validator tokens and need to be rebalanced. Use [`rebalanceSwap`](/docs/guide/stablecoin-dex/managing-fee-liquidity#rebalance-pools) to replenish validator token reserves when they become depleted.
 
 ### Test before launch
 

--- a/src/pages/docs/guide/stablecoin-dex/providing-liquidity.mdx
+++ b/src/pages/docs/guide/stablecoin-dex/providing-liquidity.mdx
@@ -198,7 +198,7 @@ For more details on querying orders, see the [`Hooks.dex.useOrder`](https://wagm
 
 Cancel an order using its order ID.
 
-When you cancel an order, any remaining funds are credited to your exchange balance (not directly to your wallet). To move funds back to your wallet, you can [withdraw them to your wallet](/docs/protocol/exchange/exchange-balance#withdrawing-funds).
+When you cancel an order, any remaining funds are credited to your exchange balance (not directly to your wallet). To move funds back to your wallet, you can [withdraw them to your wallet](/docs/protocol/exchange/exchange-balance#withdrawing-from-the-dex).
 
 <Demo.Container name="Place and Cancel an Order" footerVariant="source" src="tempoxyz/examples/tree/main/examples/exchange">
   <Connect stepNumber={1} />

--- a/src/pages/docs/protocol/tip20/overview.mdx
+++ b/src/pages/docs/protocol/tip20/overview.mdx
@@ -98,13 +98,13 @@ Tempo has dedicated payment lanes: reserved blockspace for payment TIP-20 transa
 
 ### Role-Based Access Control (RBAC)
 
-TIP-20 includes a built-in [RBAC system](/docs/protocol/tip403/spec#tip-20-token-roles) that separates administrative responsibilities:
+TIP-20 includes a built-in [RBAC system](/docs/protocol/tip20/spec#tip-20-roles) that separates administrative responsibilities:
 
 - **ISSUER_ROLE**: Grants permission to mint and burn tokens, enabling controlled token issuance
 - **PAUSE_ROLE** / **UNPAUSE_ROLE**: Allows pausing and unpausing token transfers for emergency controls
 - **BURN_BLOCKED_ROLE**: Permits burning tokens from blocked addresses (e.g., for compliance actions)
 
-Roles can be granted, revoked, and delegated without custom contract changes. This enables issuers to separate operational roles (e.g., who can mint) from administrative roles (e.g., who can pause). Learn more in the [TIP-20 specification](/docs/protocol/tip20/spec#roles).
+Roles can be granted, revoked, and delegated without custom contract changes. This enables issuers to separate operational roles (e.g., who can mint) from administrative roles (e.g., who can pause). Learn more in the [TIP-20 specification](/docs/protocol/tip20/spec#tip-20-roles).
 
 ### Tempo Policy Registry (TIP-403)
 

--- a/src/pages/docs/protocol/tips/tip-1007.mdx
+++ b/src/pages/docs/protocol/tips/tip-1007.mdx
@@ -50,7 +50,7 @@ interface IFeeManager {
 
 ### Fee Token Resolution
 
-The fee token returned by `getFeeToken()` is the same token that was resolved by the protocol during transaction validation, following the [fee token preference rules](/docs/protocol/fees/spec-fee#fee-token-resolution).
+The fee token returned by `getFeeToken()` is the same token that was resolved by the protocol during transaction validation, following the [fee token preference rules](/docs/protocol/fees/spec-fee#fee-token-preferences).
 
 ### Storage
 

--- a/src/pages/docs/quickstart/connection-details.mdx
+++ b/src/pages/docs/quickstart/connection-details.mdx
@@ -19,7 +19,7 @@ Click on your browser wallet below to automatically connect it to the Tempo netw
 <ConnectWallet network="mainnet" />
 
 :::warning
-Note that on some wallets, you might see an unusually high "balance". This is because, historically, blockchain wallets have always assumed that a blockchain has a "native gas token". On Tempo, there is no native gas token, and so the value shown is a placeholder. See [EVM Differences](/docs/quickstart/evm-compatibility#handling-eth-balance-checks) for more information on this quirk.
+Note that on some wallets, you might see an unusually high "balance". This is because, historically, blockchain wallets have always assumed that a blockchain has a "native gas token". On Tempo, there is no native gas token, and so the value shown is a placeholder. See [EVM Differences](/docs/quickstart/evm-compatibility#handling-eth-native-token-balance-checks) for more information on this quirk.
 :::
 
 ## Connect via CLI

--- a/src/pages/docs/quickstart/developer-tools.mdx
+++ b/src/pages/docs/quickstart/developer-tools.mdx
@@ -98,7 +98,7 @@ Get started with the [Squid docs](https://docs.squidrouter.com/) or try the [bri
 
 [TIDX](/docs/api/indexer-api) is Tempo's hosted indexer for querying blocks, transactions, logs, token balances, and decoded events through SQL. Use the public mainnet endpoint at `https://indexer.tempo.xyz` or the testnet endpoint at `https://indexer.testnet.tempo.xyz`.
 
-The hosted indexer powers explorer-style reads and supports ClickHouse-backed analytical queries for expensive reads like holder lists and token activity. Try the [interactive TIDX example](/docs/api/indexer-api#interactive-tidx-sql-example) or read the [TIDX README](https://github.com/tempoxyz/tidx) to run your own indexer.
+The hosted indexer powers explorer-style reads and supports ClickHouse-backed analytical queries for expensive reads like holder lists and token activity. Try the [interactive TIDX example](/docs/api/indexer-api#interactive-example) or read the [TIDX README](https://github.com/tempoxyz/tidx) to run your own indexer.
 
 ### Allium
 

--- a/src/pages/docs/quickstart/evm-compatibility.mdx
+++ b/src/pages/docs/quickstart/evm-compatibility.mdx
@@ -90,7 +90,7 @@ If the user is calling a contract that is not a TIP-20 token, the EVM transactio
 
 On the Tempo Testnet, pathUSD is available from the [faucet](/docs/quickstart/faucet).
 
-If a wallet wants to submit a non-TIP20 transaction without having to submit the above transaction, we recommend investing in using [Tempo Transactions](/docs/quickstart/integrate-tempo#tempo-transactions) instead.
+If a wallet wants to submit a non-TIP20 transaction without having to submit the above transaction, we recommend investing in using [Tempo Transactions](/docs/guide/tempo-transaction) instead.
 
 ## VM Layer Differences
 


### PR DESCRIPTION
## What was wrong

Ten internal links pointed to anchors that don't exist on their target pages. Since the target heading isn't there, these links silently land at the top of the page instead of the intended section. Most are headings that were renamed at some point after the link was written (e.g. "Handling ETH Balance Checks" → "Handling ETH (Native Token) Balance Checks"); a couple pointed at the wrong page entirely.

## Fixes

| File | Old target | New target |
|---|---|---|
| `protocol/tip20/overview.mdx` (line ~101) | `/docs/protocol/tip403/spec#tip-20-token-roles` | `/docs/protocol/tip20/spec#tip-20-roles` |
| `protocol/tip20/overview.mdx` (line ~107) | `/docs/protocol/tip20/spec#roles` | `/docs/protocol/tip20/spec#tip-20-roles` |
| `protocol/tips/tip-1007.mdx` | `/docs/protocol/fees/spec-fee#fee-token-resolution` | `/docs/protocol/fees/spec-fee#fee-token-preferences` |
| `quickstart/connection-details.mdx` | `/docs/quickstart/evm-compatibility#handling-eth-balance-checks` | `/docs/quickstart/evm-compatibility#handling-eth-native-token-balance-checks` |
| `quickstart/developer-tools.mdx` | `/docs/api/indexer-api#interactive-tidx-sql-example` | `/docs/api/indexer-api#interactive-example` |
| `quickstart/evm-compatibility.mdx` | `/docs/quickstart/integrate-tempo#tempo-transactions` | `/docs/guide/tempo-transaction` |
| `guide/issuance/manage-stablecoin.mdx` (prose + `<Card to=...>`, 2 occurrences) | `/docs/protocol/tip20/spec#role-based-access-control` | `/docs/protocol/tip20/spec#tip-20-roles` |
| `guide/issuance/use-for-fees.mdx` | `/docs/guide/stablecoin-dex/managing-fee-liquidity#rebalance-liquidity` | `/docs/guide/stablecoin-dex/managing-fee-liquidity#rebalance-pools` |
| `guide/stablecoin-dex/providing-liquidity.mdx` | `/docs/protocol/exchange/exchange-balance#withdrawing-funds` | `/docs/protocol/exchange/exchange-balance#withdrawing-from-the-dex` |
| `guide/issuance/create-a-stablecoin.mdx` | `/docs/quickstart/integrate-tempo#default-fee-token` | `/docs/quickstart/evm-compatibility#consideration-1-setting-a-user-default-fee-token` |

Two items worth calling out explicitly:

- **`protocol/tip20/overview.mdx` line ~101** — the old link (`/docs/protocol/tip403/spec#tip-20-token-roles`) pointed at the *TIP-403* spec, but the surrounding sentence ("TIP-20 includes a built-in RBAC system that separates administrative responsibilities: ISSUER_ROLE, PAUSE_ROLE/UNPAUSE_ROLE, BURN_BLOCKED_ROLE...") is describing TIP-20's own role system, word-for-word matching the `## TIP-20 Roles` section in the *TIP-20* spec. The next section on the page (`### Tempo Policy Registry (TIP-403)`) is a separate, later topic. I changed the target page, not just the anchor, to `/docs/protocol/tip20/spec#tip-20-roles`.
- **`guide/issuance/create-a-stablecoin.mdx`** — the old anchor (`#default-fee-token`) doesn't exist anywhere on `integrate-tempo`. The sentence is "As we have configured our project to use `AlphaUSD`... as the default fee token" — a how-to statement about setting the fee token, not the abstract resolution algorithm. `evm-compatibility.mdx` has `#### Consideration 1: Setting a user default fee token`, whose own text says "the simplest way to specify the fee token for a user is to set the user default fee token" — a direct match. I used that instead of the alternative candidate (`spec-fee#fee-token-preferences`, which documents the resolution algorithm and is already linked separately from `evm-compatibility.mdx` itself). Flagging this one since it required judgment rather than a 1:1 heading-rename — happy to point it elsewhere if a maintainer disagrees with the read.

## Verification

Used a script that resolves each page's heading set (including headings pulled in via imported `.mdx` snippets) and slugifies them with github-slugger semantics (lowercase, punctuation dropped, spaces → hyphens), then flags every internal `[text](/path#anchor)` and `to="/path#anchor"` link whose anchor isn't in its target page's heading set.

- **Before:** 10 broken anchors across 9 files (`manage-stablecoin.mdx` has the same broken anchor twice — once in prose, once in a `<Card>`).
- **After:** 0 broken anchors.

Also ran `pnpm check:types` (`tsgo --noEmit`) — clean. `pnpm build` fails, but only at the `vocs:llms` plugin's OpenAPI-spec network fetch step (`ConnectTimeoutError` reaching an external host) — unrelated to this change and a pre-existing environment/network constraint, not something a content-only anchor fix touches. `.mdx` files are excluded from this repo's biome config, so there's no lint/format step that applies to prose content either.

Closes nothing (no tracking issue — found by scanning the repo, per your instructions).
