### PR TITLE
fix: expose the changelog fallback in Markdown

### DIFF
--- a/scripts/check-markdown-components.mjs
+++ b/scripts/check-markdown-components.mjs
@@ -42,11 +42,19 @@ if (files.length === 0)
 
 const llmsFile = resolve('dist/public/llms-full.txt')
 const generatedFiles = [...files, llmsFile]
+const hiddenChangelogFallbacks = []
 const unresolvedIncludes = []
 for (const file of generatedFiles) {
   const content = await readFile(file, 'utf8')
+  if (hasHiddenChangelogFallback(content)) hiddenChangelogFallbacks.push(file)
   const count = content.match(/\[!include /g)?.length ?? 0
   if (count > 0) unresolvedIncludes.push({ count, file })
+}
+
+if (hiddenChangelogFallbacks.length > 0) {
+  console.error('Generated Markdown changelog fallback audit failed.')
+  for (const file of hiddenChangelogFallbacks) console.error(`- ${file}: hidden changelog fallback`)
+  process.exit(1)
 }
 
 if (unresolvedIncludes.length > 0) {
@@ -94,6 +102,16 @@ if (
 console.log(
   'Markdown output audit passed (no unresolved components, includes, executable MDX, or presentation-only elements).',
 )
+
+function hasHiddenChangelogFallback(content) {
+  let found = false
+  const tree = unified().use(remarkParse).parse(content)
+  visit(tree, (node) => {
+    if (node.type === 'html' && node.value?.trim() === '<!-- changelog unavailable -->')
+      found = true
+  })
+  return found
+}
 
 function maskHtmlComments(content) {
   const ranges = []

--- a/src/lib/markdown-output.test.ts
+++ b/src/lib/markdown-output.test.ts
@@ -146,6 +146,27 @@ export const data = [{ label: 'Example' }]
     expect(output).toContain('<title>Browser title</title>')
   })
 
+  test('turns an unavailable changelog into a visible release link', async () => {
+    const output = await renderMarkdown(`
+# Changelog
+
+<!-- changelog unavailable -->
+`)
+
+    expect(output).toContain('Release notes could not be loaded.')
+    expect(output).toContain(
+      '[View Tempo releases on GitHub.](https://github.com/tempoxyz/tempo/releases)',
+    )
+    expect(output).not.toContain('<!-- changelog unavailable -->')
+
+    const example = await renderMarkdown(`
+\`\`\`md
+<!-- changelog unavailable -->
+\`\`\`
+`)
+    expect(example).toContain('<!-- changelog unavailable -->')
+  })
+
   test('expands code includes and removes region markers', async () => {
     const output = await render(`
 \`\`\`ts
@@ -237,6 +258,16 @@ async function render(source: string) {
     await unified()
       .use(remarkParse)
       .use(remarkMdx)
+      .use(plainMarkdownComponents)
+      .use(remarkStringify)
+      .process(source),
+  )
+}
+
+async function renderMarkdown(source: string) {
+  return String(
+    await unified()
+      .use(remarkParse)
       .use(plainMarkdownComponents)
       .use(remarkStringify)
       .process(source),

--- a/src/lib/markdown-output.ts
+++ b/src/lib/markdown-output.ts
@@ -42,6 +42,7 @@ type MarkdownNode = {
 
 const openApiSpecUrl = 'https://api.tempo.xyz/openapi.json'
 const presentationOnlyElements = new Set(['meta', 'script', 'style', 'title'])
+const tempoReleasesUrl = 'https://github.com/tempoxyz/tempo/releases'
 
 const interactiveDescriptions: Record<string, string> = {
   ConnectWallet: 'Connect a wallet in the interactive web page.',
@@ -133,6 +134,13 @@ function rewriteNode(
   getSnippet: (fileName: string) => string | undefined,
 ): MarkdownNode[] {
   if (node.type === 'mdxjsEsm') return []
+  if (node.type === 'html' && node.value?.trim() === '<!-- changelog unavailable -->')
+    return [
+      paragraph([
+        text('Release notes could not be loaded. '),
+        link('View Tempo releases on GitHub.', tempoReleasesUrl),
+      ]),
+    ]
 
   if (node.type !== 'mdxJsxFlowElement' && node.type !== 'mdxJsxTextElement') {
     if (node.type === 'code' && node.value) node.value = inlineCodeSnippets(node.value, getSnippet)


### PR DESCRIPTION
## What changed

When release data is unavailable during a build, generated Markdown now shows a short message with a link to Tempo's GitHub releases instead of an HTML comment.

The post-build audit also rejects the hidden fallback if it reaches a `.md` page or `llms-full.txt`. It checks the Markdown node rather than raw text, so the same marker remains valid inside a fenced example.

## Why

Vocs represents a failed changelog fetch as `<!-- changelog unavailable -->`. That is invisible to a Markdown reader, so the generated changelog appears empty.

Converting that exact marker gives agents a useful canonical source without changing the authored page or the human-rendered site.

## Validation

- `env CI=true pnpm test` — 301 tests passed
- `env CI=true VITE_USE_HTTP=true NODE_OPTIONS=--max-old-space-size=4096 pnpm build`
- `pnpm run check:markdown`
- `./node_modules/.bin/biome check src/lib/markdown-output.ts src/lib/markdown-output.test.ts scripts/check-markdown-components.mjs`
