### PR TITLE
fix: tempo batch payment examples

### DIFF
--- a/src/pages/docs/guide/payments/send-a-payment.mdx
+++ b/src/pages/docs/guide/payments/send-a-payment.mdx
@@ -708,16 +708,13 @@ Send multiple payments in a single transaction using batch transactions:
     import { Abis } from 'viem/tempo'
     import { client } from './viem.config'
 
-    const token = '0x20c0000000000000000000000000000000000001'
-    const recipients = [
-      '0x742d35cc6634c0532925a3b844bc9e7595f0bebb',
-      '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+    const token = '0x20c0000000000000000000000000000000000001' as const
+    const payments = [
+      { to: '0x742d35cc6634c0532925a3b844bc9e7595f0bebb', amount: parseUnits('100', 6) },
+      { to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8', amount: parseUnits('50', 6) },
     ] as const
-    const amount = parseUnits('100', 6)
 
-    await client.faucet.fundSync({ account: client.account })
-
-    const calls = recipients.map((to) => ({ // [!code hl]
+    const calls = payments.map(({ to, amount }) => ({ // [!code hl]
       to: token, // [!code hl]
       data: encodeFunctionData({ // [!code hl]
         abi: Abis.tip20, // [!code hl]
@@ -726,12 +723,12 @@ Send multiple payments in a single transaction using batch transactions:
       }), // [!code hl]
     })) // [!code hl]
 
-    const receipt = await client.sendTransactionSync({ calls }) // [!code hl]
-    console.log(receipt.transactionHash)
+    const hash = await client.sendTransaction({ calls }) // [!code hl]
+    console.log(hash)
     ```
 
     ```ts twoslash [viem.config.ts]
-    // [!include ~/snippets/viem.config.ts:moderato]
+    // [!include ~/snippets/viem.config.ts:setup]
     ```
 
     :::
@@ -1005,7 +1002,7 @@ Send multiple payments in a single transaction using batch transactions:
   </Tab>
 </Tabs>
 
-`sendTransactionSync` puts every call in one all-or-nothing Tempo transaction and returns its receipt. `sendCalls` is for wallet requests; a loop or `Promise.all` sends separate transactions.
+Passing `calls` creates one all-or-nothing Tempo transaction. `sendTransaction` returns its hash immediately; use `sendTransactionSync` when you need the receipt. Use `sendCalls` or `sendCallsSync` for connected-wallet batch requests.
 
 ### Index payment events
 

--- a/src/pages/docs/guide/payments/send-a-payment.mdx
+++ b/src/pages/docs/guide/payments/send-a-payment.mdx
@@ -1001,7 +1001,7 @@ Send multiple payments in a single transaction using batch transactions:
   </Tab>
 </Tabs>
 
-Pass every encoded call together so Tempo executes all transfers in one all-or-nothing transaction. A loop or `Promise.all` sends separate transactions.
+Pass every encoded call together so Tempo executes all transfers in one all-or-nothing transaction.
 
 ### Index payment events
 

--- a/src/pages/docs/guide/payments/send-a-payment.mdx
+++ b/src/pages/docs/guide/payments/send-a-payment.mdx
@@ -723,8 +723,7 @@ Send multiple payments in a single transaction using batch transactions:
       }), // [!code hl]
     })) // [!code hl]
 
-    const hash = await client.sendTransaction({ calls }) // [!code hl]
-    console.log(hash)
+    await client.sendTransaction({ calls }) // [!code hl]
     ```
 
     ```ts twoslash [viem.config.ts]
@@ -1002,7 +1001,7 @@ Send multiple payments in a single transaction using batch transactions:
   </Tab>
 </Tabs>
 
-Passing `calls` creates one all-or-nothing Tempo transaction. `sendTransaction` returns its hash immediately; use `sendTransactionSync` when you need the receipt. Use `sendCalls` or `sendCallsSync` for connected-wallet batch requests.
+Pass every encoded call together so Tempo executes all transfers in one all-or-nothing transaction. A loop or `Promise.all` sends separate transactions.
 
 ### Index payment events
 

--- a/src/pages/docs/guide/payments/send-a-payment.mdx
+++ b/src/pages/docs/guide/payments/send-a-payment.mdx
@@ -708,34 +708,30 @@ Send multiple payments in a single transaction using batch transactions:
     import { Abis } from 'viem/tempo'
     import { client } from './viem.config'
 
-    const tokenABI = Abis.tip20
-    const recipient1 = '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb'
-    const recipient2 = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+    const token = '0x20c0000000000000000000000000000000000001'
+    const recipients = [
+      '0x742d35cc6634c0532925a3b844bc9e7595f0bebb',
+      '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+    ] as const
+    const amount = parseUnits('100', 6)
 
-    const calls = [ // [!code hl]
-      { // [!code hl]
-        to: '0x20c0000000000000000000000000000000000001', // [!code hl]
-        data: encodeFunctionData({ // [!code hl]
-          abi: tokenABI, // [!code hl]
-          functionName: 'transfer', // [!code hl]
-          args: [recipient1, parseUnits('100', 6)], // [!code hl]
-        }), // [!code hl]
-      }, // [!code hl]
-      { // [!code hl]
-        to: '0x20c0000000000000000000000000000000000001', // [!code hl]
-        data: encodeFunctionData({ // [!code hl]
-          abi: tokenABI, // [!code hl]
-          functionName: 'transfer', // [!code hl]
-          args: [recipient2, parseUnits('50', 6)], // [!code hl]
-        }), // [!code hl]
-      }, // [!code hl]
-    ] // [!code hl]
+    await client.faucet.fundSync({ account: client.account })
 
-    const hash = await client.sendTransaction({ calls })
+    const calls = recipients.map((to) => ({ // [!code hl]
+      to: token, // [!code hl]
+      data: encodeFunctionData({ // [!code hl]
+        abi: Abis.tip20, // [!code hl]
+        functionName: 'transfer', // [!code hl]
+        args: [to, amount], // [!code hl]
+      }), // [!code hl]
+    })) // [!code hl]
+
+    const receipt = await client.sendTransactionSync({ calls }) // [!code hl]
+    console.log(receipt.transactionHash)
     ```
 
     ```ts twoslash [viem.config.ts]
-    // [!include ~/snippets/viem.config.ts:setup]
+    // [!include ~/snippets/viem.config.ts:moderato]
     ```
 
     :::
@@ -1008,6 +1004,8 @@ Send multiple payments in a single transaction using batch transactions:
 
   </Tab>
 </Tabs>
+
+`sendTransactionSync` puts every call in one all-or-nothing Tempo transaction and returns its receipt. `sendCalls` is for wallet requests; a loop or `Promise.all` sends separate transactions.
 
 ### Index payment events
 

--- a/src/pages/docs/guide/payments/transfer-memos.mdx
+++ b/src/pages/docs/guide/payments/transfer-memos.mdx
@@ -135,22 +135,24 @@ await Actions.token.transferSync(walletClient, {
 
 ### Payroll batch payments
 
-Batch multiple payments in a single Tempo transaction with employee IDs in each memo for clear accounting records.
+Start with the [Viem batch payment setup](/docs/guide/payments/send-a-payment#batch-payment-transactions), then encode `transferWithMemo` for each employee ID.
 
 ```ts
 import { Abis } from 'viem/tempo'
 import { encodeFunctionData, parseUnits, stringToHex, pad } from 'viem'
+import { client } from './viem.config'
 
 const calls = employees.map(emp => ({
   to: tokenAddress,
   data: encodeFunctionData({
-    abi: Abis.TIP20,
+    abi: Abis.tip20,
     functionName: 'transferWithMemo',
     args: [emp.wallet, parseUnits(emp.salary, 6), pad(stringToHex(emp.id), { size: 32 })]
   })
 }))
 
-await walletClient.sendCalls({ calls })
+const receipt = await client.sendTransactionSync({ calls })
+console.log(receipt.transactionHash)
 ```
 
 ### Refund address in memo

--- a/src/pages/docs/guide/payments/transfer-memos.mdx
+++ b/src/pages/docs/guide/payments/transfer-memos.mdx
@@ -151,8 +151,7 @@ const calls = employees.map(emp => ({
   })
 }))
 
-const hash = await client.sendTransaction({ calls })
-console.log(hash)
+await client.sendTransaction({ calls })
 ```
 
 ### Refund address in memo

--- a/src/pages/docs/guide/payments/transfer-memos.mdx
+++ b/src/pages/docs/guide/payments/transfer-memos.mdx
@@ -151,8 +151,8 @@ const calls = employees.map(emp => ({
   })
 }))
 
-const receipt = await client.sendTransactionSync({ calls })
-console.log(receipt.transactionHash)
+const hash = await client.sendTransaction({ calls })
+console.log(hash)
 ```
 
 ### Refund address in memo

--- a/src/snippets/viem.config.ts
+++ b/src/snippets/viem.config.ts
@@ -1,7 +1,3 @@
-// @ts-nocheck
-// biome-ignore-all lint: snippet regions are included independently
-// biome-ignore-all format: snippet
-
 // [!region setup]
 import { privateKeyToAccount } from 'viem/accounts'
 import { createClient } from 'viem/tempo'
@@ -9,15 +5,4 @@ import { createClient } from 'viem/tempo'
 export const client = createClient({
   account: privateKeyToAccount('0x...'),
 })
-
 // [!endregion setup]
-
-// [!region moderato]
-import { privateKeyToAccount } from 'viem/accounts'
-import { createClient } from 'viem/tempo'
-
-export const client = createClient({
-  account: privateKeyToAccount('0x...'),
-  testnet: true,
-})
-// [!endregion moderato]

--- a/src/snippets/viem.config.ts
+++ b/src/snippets/viem.config.ts
@@ -1,3 +1,7 @@
+// @ts-nocheck
+// biome-ignore-all lint: snippet regions are included independently
+// biome-ignore-all format: snippet
+
 // [!region setup]
 import { privateKeyToAccount } from 'viem/accounts'
 import { createClient } from 'viem/tempo'
@@ -5,4 +9,15 @@ import { createClient } from 'viem/tempo'
 export const client = createClient({
   account: privateKeyToAccount('0x...'),
 })
+
 // [!endregion setup]
+
+// [!region moderato]
+import { privateKeyToAccount } from 'viem/accounts'
+import { createClient } from 'viem/tempo'
+
+export const client = createClient({
+  account: privateKeyToAccount('0x...'),
+  testnet: true,
+})
+// [!endregion moderato]


### PR DESCRIPTION
## What

- Build each TIP-20 transfer as a call to the token contract.
- Submit all calls together as one atomic Tempo transaction.
- Use the same direct-client pattern and correct ABI name in the payroll memo example.

## Why

Tempo batches multiple calls inside one transaction.

## Checks

- Production build
- Generated Markdown audit
- Markdown component check
- `git diff --check`
