### PR TITLE
fix(performance): use public nightly preset

### DIFF
--- a/src/marketing/app/_components/stats.ts
+++ b/src/marketing/app/_components/stats.ts
@@ -58,8 +58,7 @@ export function statValue(stat: Stat): string {
 }
 
 // Latest run from the current nightly benchmark preset.
-const PERF_API_URL =
-  'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=1&scenario_id=tip20-50k'
+const PERF_API_URL = 'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=1&scenario_id=public'
 
 type PerfRuns = {
   runs?: {

--- a/src/marketing/app/performance/_lib/runs.ts
+++ b/src/marketing/app/performance/_lib/runs.ts
@@ -4,8 +4,10 @@
 
 const PERF_API_URL = 'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=100'
 
-const DEFAULT_SCENARIO_FROM = '2026-07-13'
-const DEFAULT_SCENARIO_ID = 'tip20-50k'
+const PUBLIC_SCENARIO_FROM = '2026-07-22'
+const PUBLIC_SCENARIO_ID = 'public'
+const TIP20_50K_SCENARIO_FROM = '2026-07-13'
+const TIP20_50K_SCENARIO_ID = 'tip20-50k'
 const TIP20_SCENARIO_UNTIL = '2026-07-10'
 
 type ApiRun = {
@@ -64,8 +66,12 @@ function isNightlyScenario(run: ApiRun): boolean {
   const scenarioId = run.scenario?.id
   if (!startedAt || !scenarioId) return false
 
-  if (startedAt >= DEFAULT_SCENARIO_FROM) {
-    return scenarioId === DEFAULT_SCENARIO_ID
+  if (startedAt >= PUBLIC_SCENARIO_FROM) {
+    return scenarioId === PUBLIC_SCENARIO_ID
+  }
+
+  if (startedAt >= TIP20_50K_SCENARIO_FROM) {
+    return scenarioId === TIP20_50K_SCENARIO_ID
   }
 
   return startedAt < TIP20_SCENARIO_UNTIL && scenarioId.startsWith('tip20-')

--- a/src/marketing/app/performance/_lib/runs.ts
+++ b/src/marketing/app/performance/_lib/runs.ts
@@ -4,7 +4,7 @@
 
 const PERF_API_URL = 'https://perf.tempo.xyz/api/perf/runs?feed=nightly&limit=100'
 
-const PUBLIC_SCENARIO_FROM = '2026-07-22'
+const PUBLIC_SCENARIO_FROM = '2026-07-23'
 const PUBLIC_SCENARIO_ID = 'public'
 const TIP20_50K_SCENARIO_FROM = '2026-07-13'
 const TIP20_50K_SCENARIO_ID = 'tip20-50k'


### PR DESCRIPTION
## Summary

- Use the `public` scenario for nightly performance runs starting July 23.
- Preserve the existing `tip20-50k` and older TIP-20 history before the cutover.
- Query `public` for the homepage’s latest benchmark stats.

## Validation

- `pnpm check`
- `pnpm check:types`
- `pnpm test` / `pnpm build` are blocked because this sandbox cannot fetch the external OpenAPI spec during Vocs startup.

Prompted by: @shekhirin