### PR TITLE
Add T9 network upgrade docs page

### DIFF
--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| TBD | TBD | Testnet + Mainnet | Required for T9; adds the native ZoneFactory for protocol-managed zone creation and predictable ZonePortal accounts. Release details and activation timing are TBD. | <Badge variant="red">Required</Badge> |
+| TBD | TBD | Testnet + Mainnet | Required for T9; adds TIP-403 registry support for TIP-20 token policy bindings and targeted migration for existing tokens. Release details and activation timing are TBD. | <Badge variant="red">Required</Badge> |
 | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8; active on testnet and scheduled for mainnet activation on July 30. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
@@ -41,8 +41,8 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | | |
 |---|---|
-| **Scope** | Native ZoneFactory for protocol-managed zone creation and predictable ZonePortal accounts |
-| **TIPs** | [Enshrined ZoneFactory](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1091.md) |
+| **Scope** | TIP-20 policy IDs in TIP-403 and targeted migration for existing tokens that need a registry-backed policy binding |
+| **TIPs** | [TIP-20 Policy IDs in TIP-403](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md) |
 | **Details** | [T9 network upgrade](/docs/protocol/upgrades/t9) |
 | **Release** | TBD |
 | **Testnet** | TBD |

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.12.0 | Target: Aug 3, 2026 | Testnet + Mainnet | Required for T9; adds TIP-403 registry support for TIP-20 token policy bindings and targeted migration for existing tokens. Testnet activation is scheduled for Aug 5, 2026; mainnet activation is scheduled for Aug 10, 2026. | <Badge variant="red">Required</Badge> |
+| v1.12.0 | Target: Aug 3, 2026 | Testnet + Mainnet | Required for T9. Adds TIP-403 storage for TIP-20 token policy bindings and a migration path for existing tokens that need one. Testnet activation is scheduled for Aug 5, 2026; mainnet activation is scheduled for Aug 10, 2026. | <Badge variant="red">Required</Badge> |
 | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8; active on testnet and scheduled for mainnet activation on July 30. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
@@ -41,7 +41,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | | |
 |---|---|
-| **Scope** | TIP-20 policy IDs in TIP-403 and targeted migration for existing tokens that need a registry-backed policy binding |
+| **Scope** | TIP-20 policy IDs in TIP-403, plus migration for existing TIP-20 tokens that need a TIP-403 binding |
 | **TIPs** | [TIP-20 Policy IDs in TIP-403](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md) |
 | **Details** | [T9 network upgrade](/docs/protocol/upgrades/t9) |
 | **Release** | v1.12.0 (target: August 3, 2026) |
@@ -49,7 +49,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | **Mainnet** | Scheduled: August 10, 2026 |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
-T9 is scheduled for testnet on August 5, 2026 and mainnet on August 10, 2026. The T9-compatible release, v1.12.0, is targeted for August 3, 2026. Node operators should run the T9-compatible release before activation once it is published.
+T9 is scheduled for testnet on August 5, 2026 and mainnet on August 10, 2026. v1.12.0 is targeted for August 3, 2026. Node operators should plan to upgrade before activation once the release is available.
 
 ---
 

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| TBD | TBD | Testnet + Mainnet | Required for T9; adds TIP-403 registry support for TIP-20 token policy bindings and targeted migration for existing tokens. Release details and activation timing are TBD. | <Badge variant="red">Required</Badge> |
+| v1.12.0 | Target: Aug 3, 2026 | Testnet + Mainnet | Required for T9; adds TIP-403 registry support for TIP-20 token policy bindings and targeted migration for existing tokens. Testnet activation is scheduled for Aug 5, 2026; mainnet activation is scheduled for Aug 10, 2026. | <Badge variant="red">Required</Badge> |
 | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8; active on testnet and scheduled for mainnet activation on July 30. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
@@ -44,12 +44,12 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | **Scope** | TIP-20 policy IDs in TIP-403 and targeted migration for existing tokens that need a registry-backed policy binding |
 | **TIPs** | [TIP-20 Policy IDs in TIP-403](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md) |
 | **Details** | [T9 network upgrade](/docs/protocol/upgrades/t9) |
-| **Release** | TBD |
-| **Testnet** | TBD |
-| **Mainnet** | TBD |
+| **Release** | v1.12.0 (target: August 3, 2026) |
+| **Testnet** | Scheduled: August 5, 2026 |
+| **Mainnet** | Scheduled: August 10, 2026 |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
-T9 is not scheduled yet. The T9-compatible release, testnet activation time, and mainnet activation time are TBD. Node operators should run the T9-compatible release before activation once it is published.
+T9 is scheduled for testnet on August 5, 2026 and mainnet on August 10, 2026. The T9-compatible release, v1.12.0, is targeted for August 3, 2026. Node operators should run the T9-compatible release before activation once it is published.
 
 ---
 

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.12.0 | Target: Aug 3, 2026 | Testnet + Mainnet | Required for T9. Adds TIP-403 storage for TIP-20 token policy bindings and a migration path for existing tokens that need one. Testnet activation is scheduled for Aug 5, 2026; mainnet activation is scheduled for Aug 10, 2026. | <Badge variant="red">Required</Badge> |
+| v1.12.0 | Target: Aug 3, 2026 | Testnet + Mainnet | Required for T9. Adds TIP-403 storage for TIP-20 token policy bindings used by zones/provable contract flows, plus a targeted migration path for existing tokens that need one. Testnet activation is scheduled for Aug 5, 2026; mainnet activation is scheduled for Aug 10, 2026. | <Badge variant="red">Required</Badge> |
 | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8; active on testnet and scheduled for mainnet activation on July 30. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
@@ -41,7 +41,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | | |
 |---|---|
-| **Scope** | TIP-20 policy IDs in TIP-403, plus migration for existing TIP-20 tokens that need a TIP-403 binding |
+| **Scope** | TIP-20 policy IDs in TIP-403 for zones/provable contract flows, plus targeted migration for existing TIP-20 tokens that need a TIP-403 binding |
 | **TIPs** | [TIP-20 Policy IDs in TIP-403](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md) |
 | **Details** | [T9 network upgrade](/docs/protocol/upgrades/t9) |
 | **Release** | v1.12.0 (target: August 3, 2026) |

--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,6 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
+| TBD | TBD | Testnet + Mainnet | Required for T9; adds the native ZoneFactory for protocol-managed zone creation and predictable ZonePortal accounts. Release details and activation timing are TBD. | <Badge variant="red">Required</Badge> |
 | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8; active on testnet and scheduled for mainnet activation on July 30. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
@@ -35,6 +36,22 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | [v1.4.0](https://github.com/tempoxyz/tempo/releases/tag/v1.4.0) | Mar 5, 2026 | Moderato + Mainnet | Required for T1C; introduces keychain signature migration so only V2 signatures and hashes are accepted after activation | <Badge variant="red">Required</Badge> |
 | [v1.3.1](https://github.com/tempoxyz/tempo/releases/tag/v1.3.1) | Feb 22, 2026 | Testnet + Mainnet | Fixes high-load issues and finalizes T1A/T1B hardening for expiring nonce replay protection and keychain precompile gas handling | <Badge variant="red">Required</Badge> |
 | [v1.2.0](https://github.com/tempoxyz/tempo/releases/tag/v1.2.0) | Feb 13, 2026 | Mainnet only | Fixes validation bug rejecting transactions with gas limits above ~16.7M, blocking large contract deployments | <Badge variant="red">Required</Badge> |
+
+## T9
+
+| | |
+|---|---|
+| **Scope** | Native ZoneFactory for protocol-managed zone creation and predictable ZonePortal accounts |
+| **TIPs** | [Enshrined ZoneFactory](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1091.md) |
+| **Details** | [T9 network upgrade](/docs/protocol/upgrades/t9) |
+| **Release** | TBD |
+| **Testnet** | TBD |
+| **Mainnet** | TBD |
+| **Priority** | <Badge variant="red">Required</Badge> |
+
+T9 is not scheduled yet. The T9-compatible release, testnet activation time, and mainnet activation time are TBD. Node operators should run the T9-compatible release before activation once it is published.
+
+---
 
 ## T8
 

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -69,12 +69,6 @@ Release notes and binaries will be linked here when the T9-compatible release is
 
 ## Integration impact
 
-### For node operators
-
-- Upgrade to the T9-compatible node release before activation.
-- T9 adds TIP-403 registry support for TIP-20 token policy bindings.
-- Nodes that do not include T9 support will fall out of sync after activation.
-
 ### For TIP-20 issuers and token admins
 
 - New TIP-20 tokens write their TIP-403 policy binding during creation.

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -31,16 +31,6 @@ T9 focuses on two changes that are needed for the first zone rollout:
 
 The practical effect is that zones become easier to reason about. A zone is created through one protocol entry point, gets a predictable portal account, and can check token transfer rules from one registry.
 
-## Who T9 affects
-
-| Partner type | What changes |
-|--------------|--------------|
-| Zone builders and operators | Create zones through the native ZoneFactory. Each zone gets a predictable portal account for Tempo-side zone activity. |
-| Token issuers and token admins | Tokens used by zones need an explicit TIP-403 policy binding. Tokens that are not used by zones keep working without immediate migration. |
-| Wallets, explorers, and indexers | Existing TIP-20 policy reads continue to work, but zone-aware tooling should recognize ZonePortal accounts and TIP-403 token-policy bindings. |
-| Apps not using zones | No immediate integration change unless the app's tokens, users, or workflows are enabled on a zone. |
-| Node operators | Upgrade before activation so nodes stay in sync. |
-
 ## Features
 
 ### ZoneFactory for zone creation

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -33,6 +33,10 @@ T9 has one protocol change:
 
 That registry binding is required for zone token enablement and useful for tooling that needs the TIP-403 view. For zones, a ZonePortal can check the TIP-403 binding before enabling a token instead of relying on token-local state.
 
+### Why this matters for zones
+
+Tempo Zones keep balances, transfers, and account relationships private. At the same time, tokens in a zone still need to follow the issuer's transfer policy. T9 gives zones a registry-backed way to prove which policy applies to each token before that token is enabled in the zone.
+
 ## What changes
 
 ### Token policy lookup in TIP-403
@@ -41,7 +45,7 @@ TIP-403 already stores transfer policy data. With T9, it can also record which t
 
 New TIP-20 tokens write this binding when they are created. Policy changes after T9 keep the binding up to date. Existing tokens only need targeted migration when they need to be enabled in a zone, used by a provable contract flow, or read by tooling that needs their policy ID to be available from TIP-403.
 
-Read the [TIP-1092 specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md).
+Read the [specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md).
 
 ### Targeted migration
 

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -1,13 +1,13 @@
 ---
 title: T9 Network Upgrade
-description: T9 prepares Tempo for protocol-managed Zones with native zone creation and TIP-403 token policy bindings.
+description: T9 prepares Tempo for protocol-managed Zones with native ZoneFactory creation and predictable zone portals.
 ---
 
 # T9 Network Upgrade
 
-T9 prepares Tempo for protocol-managed Zones. It adds the native ZoneFactory used to create zones, and gives zones a registry-backed way to check which transfer policy applies to a TIP-20 token.
+T9 prepares Tempo for protocol-managed Zones. It adds the native ZoneFactory used to create zones and gives every zone a predictable Tempo-side portal account.
 
-For ecosystem partners, T9 matters most if you plan to operate a zone, support zone deposits or withdrawals, issue tokens that may be enabled on a zone, or index zone activity.
+For ecosystem partners, T9 matters most if you plan to operate a zone, support zone deposits or withdrawals, or index zone activity.
 
 :::info[T9 status]
 T9 is not scheduled yet. The T9-compatible release, testnet activation time, and mainnet activation time are TBD.
@@ -24,12 +24,11 @@ Node operators should run the T9-compatible release before the activation timest
 
 ## Overview
 
-T9 focuses on two changes that are needed for the first zone rollout:
+T9 focuses on one protocol change needed for the first zone rollout:
 
 - **Protocol-managed zone creation.** Tempo gets one native ZoneFactory for creating zones and recording their portal accounts.
-- **Token policies that zones can rely on.** TIP-403 stores the active transfer policy for tokens that are used by zones and other provable flows.
 
-A zone is created through one protocol entry point, gets a predictable portal account, and can check token transfer rules from one registry.
+A zone is created through one protocol entry point, gets a predictable portal account, and appears in one canonical registry.
 
 ## Features
 
@@ -70,31 +69,9 @@ Each zone starts with a small set of configuration choices:
 
 The sequencer set can contain up to 8 addresses. The threshold says how many sequencers must sign a settlement for it to be accepted. For example, a threshold of 3 with 5 sequencers means any 3 of those 5 sequencers can approve the settlement.
 
-The initial token must already have a TIP-403 transfer-policy binding. This gives the zone a clear registry-backed answer for which transfer policy applies to that token.
+The initial token has to satisfy the policy requirements enforced by the factory. This keeps zone creation from succeeding with a token the zone cannot safely use.
 
 Zone admins also choose whether account access and callback gateways start open or restricted. If a restricted setting starts with an empty role list, that access is denied until the admin adds roles or changes the setting.
-
-### TIP-20 policy IDs in TIP-403
-
-TIP-403 already stores the contents of transfer policies. T9 also lets TIP-403 store which transfer policy a TIP-20 token is currently using.
-
-This matters for zones because zones need a policy answer that can be checked from TIP-403 state. Without this, a zone would need to inspect each token contract to know which transfer policy applies.
-
-New TIP-20 tokens write their TIP-403 policy binding during token creation.
-
-Existing TIP-20 tokens do not all need to migrate at T9 activation. Unmigrated tokens keep working by falling back to their old token-local policy ID. Zone and provable-contract flows must require an explicit TIP-403 binding and cannot rely on that fallback.
-
-Read the specification [here](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md).
-
-### Targeted token-policy migration
-
-T9 adds a targeted migration path for existing TIP-20 tokens that need a TIP-403 policy binding.
-
-The migration copies the token's current local policy ID into TIP-403. It is permissionless because it cannot choose a new policy; it can only register the policy the token is already using.
-
-Full automatic migration is not required. As of July 10, 2026, scans found 4,355 TIP-20 tokens on Presto mainnet and 15,291,992 TIP-20 tokens on Moderato testnet. Migrating every historical token during the network upgrade would create unnecessary registry state, especially on testnet.
-
-Operators and zone tooling should migrate only the tokens that are enabled on, or about to be enabled on, a zone. Token issuers do not need to migrate every historical token unless those tokens are part of a zone or another provable flow.
 
 ## Compatible releases
 
@@ -120,20 +97,12 @@ Release notes and binaries will be linked here when the T9-compatible release is
 - Create zones through the native ZoneFactory.
 - Use `isZonePortal(address)` when checking whether an address is a valid zone portal.
 - Keep sequencer sets to at most 8 addresses.
-- Make sure every token enabled on a zone has an explicit TIP-403 policy binding.
+- Confirm the initial token meets the factory's policy requirements before creating the zone.
 - Choose account-access and callback-gateway settings carefully at zone creation, because empty restricted role lists deny access.
-
-### For TIP-20 issuers and token admins
-
-- New TIP-20 tokens get a TIP-403 policy binding during creation.
-- Existing tokens keep working if they are not migrated.
-- Tokens used by zones or provable-contract flows need a TIP-403 binding.
-- `transferPolicyId()` continues to return the effective policy ID.
-- After activation, `changeTransferPolicyId(uint64 newPolicyId)` writes the new active policy to TIP-403.
 
 ### For SDKs, indexers, and low-level tooling
 
-- SDKs and indexers that read `transferPolicyId()` from TIP-20 can keep using that API for the effective policy ID.
-- Tools that need a provable token-to-policy binding should read TIP-403 and require the binding to be set.
-- Migration tooling should batch token migrations and verify that every zone-enabled token has a TIP-403 binding.
-- Event consumers can keep using the existing TIP-20 `TransferPolicyUpdate` event for active policy changes.
+- Track zones through the native ZoneFactory registry and `ZoneCreated` events.
+- Use `isZonePortal(address)` instead of reproducing the portal address check.
+- Treat ZonePortal addresses as stable. Future portal logic changes must go through a network upgrade without changing portal addresses.
+- Apps that do not create zones or interact with zone portals do not need an immediate integration change for T9.

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -1,0 +1,137 @@
+---
+title: T9 Network Upgrade
+description: T9 prepares Tempo for protocol-managed Zones with native zone creation and TIP-403 token policy bindings.
+---
+
+# T9 Network Upgrade
+
+T9 prepares Tempo for protocol-managed Zones. It adds the native ZoneFactory used to create zones, and gives zones a registry-backed way to check which transfer policy applies to a TIP-20 token.
+
+:::info[T9 status]
+T9 is not scheduled yet. The T9-compatible release, testnet activation time, and mainnet activation time are TBD.
+:::
+
+## Timeline
+
+| Milestone | Date | Timestamp |
+|-----------|------|-----------|
+| Testnet activation | TBD | TBD |
+| Mainnet activation | TBD | TBD |
+
+Node operators should run the T9-compatible release before the activation timestamp on each network. Nodes that are not updated before activation will fall out of sync.
+
+## Overview
+
+T9 focuses on two changes that are needed for the first zone rollout:
+
+- **Protocol-managed zone creation.** Tempo gets one native ZoneFactory for creating zones and recording their portal accounts.
+- **Token policies that zones can rely on.** TIP-403 stores the active transfer policy for tokens that are used by zones and other provable flows.
+
+For most developers, the practical effect is that zones become easier to reason about. A zone is created through one protocol entry point, gets a predictable portal account, and can check token transfer rules from one registry.
+
+## Features
+
+### ZoneFactory for zone creation
+
+T9 adds the native ZoneFactory. This is the protocol entry point for creating a zone.
+
+When a zone is created, the factory assigns a zone ID, creates the zone's portal account, records the zone metadata, and emits the creation event. This gives Tempo one canonical zone registry instead of relying on a separately deployed factory contract.
+
+For the first T9 launch, zone creation is permissioned. Only the configured factory owner can create zones. This keeps the initial rollout controlled while the Zones stack is being introduced. A future network upgrade can make zone creation open.
+
+Read the specification [here](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1091.md).
+
+### Predictable portal accounts
+
+Every zone gets a predictable ZonePortal account. The portal is the zone's Tempo-side entry point for deposits, withdrawals, settlements, and other zone operations.
+
+The address is derived from the zone ID, so developers and tools do not need to track an ordinary deployment address. Zone ID `1` maps to:
+
+```text
+0x5AD0000000000000000000000000000000000001
+```
+
+Contracts and offchain tools should use `isZonePortal(address)` when they need to check whether an address is a valid zone portal.
+
+Portal accounts keep stable addresses and independent state. The shared portal logic is installed by the network upgrade, and future logic changes must also go through a network upgrade.
+
+### Zone setup inputs
+
+Each zone starts with a small set of configuration choices:
+
+- the initial token
+- the zone admin
+- the sequencer set and settlement threshold
+- account-access settings
+- callback-gateway settings
+- an RPC URL
+
+The sequencer set can contain up to 8 addresses. The threshold says how many sequencers must sign a settlement for it to be accepted. For example, a threshold of 3 with 5 sequencers means any 3 of those 5 sequencers can approve the settlement.
+
+The initial token must already have a TIP-403 transfer-policy binding. This gives the zone a clear registry-backed answer for which transfer policy applies to that token.
+
+Zone admins also choose whether account access and callback gateways start open or restricted. If a restricted setting starts with an empty role list, that access is denied until the admin adds roles or changes the setting.
+
+### TIP-20 policy IDs in TIP-403
+
+TIP-403 already stores the contents of transfer policies. T9 also lets TIP-403 store which transfer policy a TIP-20 token is currently using.
+
+This matters for zones because zones need a policy answer that can be checked from TIP-403 state. Without this, a zone would need to inspect each token contract to know which transfer policy applies.
+
+New TIP-20 tokens write their TIP-403 policy binding during token creation.
+
+Existing TIP-20 tokens do not all need to migrate at T9 activation. Unmigrated tokens keep working by falling back to their old token-local policy ID. Zone and provable-contract flows must require an explicit TIP-403 binding and cannot rely on that fallback.
+
+Read the specification [here](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md).
+
+### Targeted token-policy migration
+
+T9 adds a targeted migration path for existing TIP-20 tokens that need a TIP-403 policy binding.
+
+The migration copies the token's current local policy ID into TIP-403. It is permissionless because it cannot choose a new policy; it can only register the policy the token is already using.
+
+Full automatic migration is not required. As of July 10, 2026, scans found 4,355 TIP-20 tokens on Presto mainnet and 15,291,992 TIP-20 tokens on Moderato testnet. Migrating every historical token during the network upgrade would create unnecessary registry state, especially on testnet.
+
+Operators and zone tooling should migrate only the tokens that are enabled on, or about to be enabled on, a zone.
+
+## Compatible releases
+
+The T9-compatible release is not published yet.
+
+| Ecosystem | T9-compatible releases |
+|-----------|------------------------|
+| Node operators | TBD |
+| Rust SDK crates | TBD |
+
+Release notes and binaries will be linked here when the T9-compatible release is published.
+
+## Integration impact
+
+### For node operators
+
+- Upgrade to the T9-compatible node release before activation.
+- T9 installs the native ZoneFactory and shared zone runtimes at activation.
+- Nodes that do not include T9 support will fall out of sync after activation.
+
+### For zone operators and zone tooling
+
+- Create zones through the native ZoneFactory.
+- Use `isZonePortal(address)` when checking whether an address is a valid zone portal.
+- Keep sequencer sets to at most 8 addresses.
+- Make sure every token enabled on a zone has an explicit TIP-403 policy binding.
+- Choose account-access and callback-gateway settings carefully at zone creation, because empty restricted role lists deny access.
+
+### For TIP-20 issuers and token admins
+
+- New TIP-20 tokens get a TIP-403 policy binding during creation.
+- Existing tokens keep working if they are not migrated.
+- Tokens used by zones or provable-contract flows need a TIP-403 binding.
+- `transferPolicyId()` continues to return the effective policy ID.
+- After activation, `changeTransferPolicyId(uint64 newPolicyId)` writes the new active policy to TIP-403.
+
+### For SDKs, indexers, and low-level tooling
+
+- SDKs and indexers that read `transferPolicyId()` from TIP-20 can keep using that API for the effective policy ID.
+- Tools that need a provable token-to-policy binding should read TIP-403 and require the binding to be set.
+- Migration tooling should batch token migrations and verify that every zone-enabled token has a TIP-403 binding.
+- Event consumers can keep using the existing TIP-20 `TransferPolicyUpdate` event for active policy changes.

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -5,9 +5,9 @@ description: T9 records TIP-20 token policy bindings in TIP-403 and adds a migra
 
 # T9 Network Upgrade
 
-T9 records each TIP-20 token's active transfer policy in TIP-403. This gives zones, provable contract flows, apps, indexers, and other tooling a single place to check which policy a token is using.
+T9 records each TIP-20 token's active transfer policy in TIP-403. This is necessary for [Tempo Zones](/docs/protocol/zones#tempo-zones-are-private): zones keep balances, transfers, and account relationships private, but they still need a provable way to know which issuer policy applies to a token. The same registry binding also gives provable contract flows, apps, indexers, and other tooling a single place to check which policy a token is using.
 
-In simpler terms, T9 makes the answer to "which transfer rules apply to this token?" available from TIP-403 when that answer needs to be proved or checked from registry state.
+In simpler terms, T9 moves the answer to "which transfer rules apply to this token?" into TIP-403, where it can be checked from registry state.
 
 For most partners, T9 is only relevant if you issue TIP-20 tokens, run tooling that reads token policy state, or build zone/provable contract flows that depend on TIP-403 policy checks.
 
@@ -31,7 +31,7 @@ T9 has one protocol change:
 
 - **TIP-20 policy IDs in TIP-403.** TIP-403 can record which transfer policy a TIP-20 token is currently using.
 
-That gives zones and tooling a standard place to read token policy state when they need the TIP-403 view. For zones, this means a ZonePortal can check the TIP-403 binding before enabling a token instead of relying on token-local state.
+That registry binding is required for zone token enablement and useful for tooling that needs the TIP-403 view. For zones, a ZonePortal can check the TIP-403 binding before enabling a token instead of relying on token-local state.
 
 ## What changes
 
@@ -39,7 +39,7 @@ That gives zones and tooling a standard place to read token policy state when th
 
 TIP-403 already stores transfer policy data. With T9, it can also record which transfer policy a TIP-20 token is using.
 
-New TIP-20 tokens write this binding when they are created. Policy changes after T9 keep the binding up to date. Existing tokens only need targeted migration when a zone, provable contract flow, or tooling path needs their policy ID to be available from TIP-403.
+New TIP-20 tokens write this binding when they are created. Policy changes after T9 keep the binding up to date. Existing tokens only need targeted migration when they need to be enabled in a zone, used by a provable contract flow, or read by tooling that needs their policy ID to be available from TIP-403.
 
 Read the [TIP-1092 specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md).
 
@@ -57,13 +57,13 @@ v1.12.0 is targeted for August 3, 2026. Release notes and binaries will be linke
 
 ### For TIP-20 issuers and token admins
 
-- Migrate an existing token when a zone, provable contract flow, or tooling path needs to read its policy ID from TIP-403.
+- Migrate an existing token when it needs to be enabled in a zone, used by a provable contract flow, or read by tooling that needs its policy ID from TIP-403.
 - After activation, policy updates write the TIP-403 binding for the updated token.
 
 ### For zones, provable contract flows, and tooling
 
+- Treat the TIP-403 binding as required before enabling a token in a zone or using it in a provable contract flow.
 - Use TIP-403 when your flow needs the registry view of token policy state.
-- Require the TIP-403 binding before enabling or using a token in a zone or provable contract flow.
 - If the binding is missing, migrate the specific token and verify that TIP-403 has the binding before continuing.
 
 ### For migration tooling

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -1,13 +1,13 @@
 ---
 title: T9 Network Upgrade
-description: T9 prepares Tempo for protocol-managed Zones with native ZoneFactory creation and predictable zone portals.
+description: T9 adds TIP-403 registry support for TIP-20 token policy bindings and targeted migration for existing tokens.
 ---
 
 # T9 Network Upgrade
 
-T9 prepares Tempo for protocol-managed Zones. It adds the native ZoneFactory used to create zones and gives every zone a predictable Tempo-side portal account.
+T9 updates how Tempo records the transfer policy used by TIP-20 tokens. It lets TIP-403 store the active policy for a token, so policy-aware tooling can read that answer from the registry when it needs to.
 
-For ecosystem partners, T9 matters most if you plan to operate a zone, support zone deposits or withdrawals, or index zone activity.
+For ecosystem partners, T9 matters most if you issue TIP-20 tokens, maintain wallets or indexers that read token policy state, or build flows that need a registry-backed answer for token policy checks.
 
 :::info[T9 status]
 T9 is not scheduled yet. The T9-compatible release, testnet activation time, and mainnet activation time are TBD.
@@ -24,54 +24,37 @@ Node operators should run the T9-compatible release before the activation timest
 
 ## Overview
 
-T9 focuses on one protocol change needed for the first zone rollout:
+T9 focuses on one protocol change:
 
-- **Protocol-managed zone creation.** Tempo gets one native ZoneFactory for creating zones and recording their portal accounts.
+- **TIP-20 policy IDs in TIP-403.** TIP-403 can store which transfer policy a TIP-20 token is currently using.
 
-A zone is created through one protocol entry point, gets a predictable portal account, and appears in one canonical registry.
+This keeps token policy information in one registry when a flow needs that stronger guarantee. Existing tokens keep working even if they have not been migrated yet.
 
 ## Features
 
-### ZoneFactory for zone creation
+### Token policy lookup in TIP-403
 
-T9 adds the native ZoneFactory. This is the protocol entry point for creating a zone.
+TIP-403 already stores transfer policy data. T9 also lets TIP-403 store the active transfer policy ID for a TIP-20 token.
 
-When a zone is created, the factory assigns a zone ID, creates the zone's portal account, records the zone metadata, and emits the creation event. This gives Tempo one canonical zone registry instead of relying on a separately deployed factory contract.
+In plain terms, this gives contracts and offchain tools a registry-backed way to ask: "Which transfer policy is this token using?"
 
-For the first T9 launch, zone creation is permissioned. Only the configured factory owner can create zones. This keeps the initial rollout controlled while the Zones stack is being introduced. A future network upgrade can make zone creation open.
+New TIP-20 tokens write this TIP-403 binding when they are created. After T9, token policy changes also update the TIP-403 binding.
 
-Read the specification [here](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1091.md).
+Read the specification [here](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md).
 
-### Predictable portal accounts
+### Existing tokens keep working
 
-Every zone gets a predictable ZonePortal account. The portal is the zone's Tempo-side entry point for deposits, withdrawals, settlements, and other zone operations.
+Existing TIP-20 tokens do not all need to move at activation. If a token has not been migrated, normal token behavior can still use the token's existing local policy ID.
 
-The address is derived from the zone ID, so developers and partner tools do not need to track an ordinary deployment address. Zone ID `1` maps to:
+The difference is for flows that specifically need the policy answer to come from TIP-403. Those flows should require the TIP-403 binding to exist before using that token.
 
-```text
-0x5AD0000000000000000000000000000000000001
-```
+### Targeted migration
 
-Contracts and offchain tools should use `isZonePortal(address)` when they need to check whether an address is a valid zone portal.
+T9 adds a targeted migration path for existing TIP-20 tokens that need a TIP-403 binding.
 
-Portal accounts keep stable addresses and independent state. The shared portal logic is installed by the network upgrade, and future logic changes must also go through a network upgrade.
+The migration copies the token's current local policy ID into TIP-403. It does not choose a new policy or change the token's rules; it only registers the policy the token is already using.
 
-### Zone setup inputs
-
-Each zone starts with a small set of configuration choices:
-
-- the initial token
-- the zone admin
-- the sequencer set and settlement threshold
-- account-access settings
-- callback-gateway settings
-- an RPC URL
-
-The sequencer set can contain up to 8 addresses. The threshold says how many sequencers must sign a settlement for it to be accepted. For example, a threshold of 3 with 5 sequencers means any 3 of those 5 sequencers can approve the settlement.
-
-The initial token has to satisfy the policy requirements enforced by the factory. This keeps zone creation from succeeding with a token the zone cannot safely use.
-
-Zone admins also choose whether account access and callback gateways start open or restricted. If a restricted setting starts with an empty role list, that access is denied until the admin adds roles or changes the setting.
+This means teams can migrate the tokens they need instead of forcing every historical token into the registry at once.
 
 ## Compatible releases
 
@@ -89,20 +72,19 @@ Release notes and binaries will be linked here when the T9-compatible release is
 ### For node operators
 
 - Upgrade to the T9-compatible node release before activation.
-- T9 installs the native ZoneFactory and shared zone runtimes at activation.
+- T9 adds TIP-403 registry support for TIP-20 token policy bindings.
 - Nodes that do not include T9 support will fall out of sync after activation.
 
-### For zone operators and zone tooling
+### For TIP-20 issuers and token admins
 
-- Create zones through the native ZoneFactory.
-- Use `isZonePortal(address)` when checking whether an address is a valid zone portal.
-- Keep sequencer sets to at most 8 addresses.
-- Confirm the initial token meets the factory's policy requirements before creating the zone.
-- Choose account-access and callback-gateway settings carefully at zone creation, because empty restricted role lists deny access.
+- New TIP-20 tokens write their TIP-403 policy binding during creation.
+- Existing tokens keep working if they are not migrated.
+- Existing tokens should be migrated when a flow needs their policy ID to be available from TIP-403.
+- After activation, policy changes update the active policy in TIP-403.
 
 ### For SDKs, indexers, and low-level tooling
 
-- Track zones through the native ZoneFactory registry and `ZoneCreated` events.
-- Use `isZonePortal(address)` instead of reproducing the portal address check.
-- Treat ZonePortal addresses as stable. Future portal logic changes must go through a network upgrade without changing portal addresses.
-- Apps that do not create zones or interact with zone portals do not need an immediate integration change for T9.
+- Existing token policy reads can keep using the current TIP-20 API when they only need the effective policy ID.
+- Tooling that needs a registry-backed token-to-policy answer should read TIP-403.
+- Migration tooling should migrate only the tokens that need a TIP-403 binding.
+- Apps that do not read or enforce TIP-20 policy state do not need an immediate integration change for T9.

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -7,6 +7,8 @@ description: T9 prepares Tempo for protocol-managed Zones with native zone creat
 
 T9 prepares Tempo for protocol-managed Zones. It adds the native ZoneFactory used to create zones, and gives zones a registry-backed way to check which transfer policy applies to a TIP-20 token.
 
+For ecosystem partners, T9 matters most if you plan to operate a zone, support zone deposits or withdrawals, issue tokens that may be enabled on a zone, or index zone activity.
+
 :::info[T9 status]
 T9 is not scheduled yet. The T9-compatible release, testnet activation time, and mainnet activation time are TBD.
 :::
@@ -27,7 +29,17 @@ T9 focuses on two changes that are needed for the first zone rollout:
 - **Protocol-managed zone creation.** Tempo gets one native ZoneFactory for creating zones and recording their portal accounts.
 - **Token policies that zones can rely on.** TIP-403 stores the active transfer policy for tokens that are used by zones and other provable flows.
 
-For most developers, the practical effect is that zones become easier to reason about. A zone is created through one protocol entry point, gets a predictable portal account, and can check token transfer rules from one registry.
+The practical effect is that zones become easier to reason about. A zone is created through one protocol entry point, gets a predictable portal account, and can check token transfer rules from one registry.
+
+## Who T9 affects
+
+| Partner type | What changes |
+|--------------|--------------|
+| Zone builders and operators | Create zones through the native ZoneFactory. Each zone gets a predictable portal account for Tempo-side zone activity. |
+| Token issuers and token admins | Tokens used by zones need an explicit TIP-403 policy binding. Tokens that are not used by zones keep working without immediate migration. |
+| Wallets, explorers, and indexers | Existing TIP-20 policy reads continue to work, but zone-aware tooling should recognize ZonePortal accounts and TIP-403 token-policy bindings. |
+| Apps not using zones | No immediate integration change unless the app's tokens, users, or workflows are enabled on a zone. |
+| Node operators | Upgrade before activation so nodes stay in sync. |
 
 ## Features
 
@@ -45,7 +57,7 @@ Read the specification [here](https://github.com/tempoxyz/tempo/blob/main/tips/t
 
 Every zone gets a predictable ZonePortal account. The portal is the zone's Tempo-side entry point for deposits, withdrawals, settlements, and other zone operations.
 
-The address is derived from the zone ID, so developers and tools do not need to track an ordinary deployment address. Zone ID `1` maps to:
+The address is derived from the zone ID, so developers and partner tools do not need to track an ordinary deployment address. Zone ID `1` maps to:
 
 ```text
 0x5AD0000000000000000000000000000000000001
@@ -92,7 +104,7 @@ The migration copies the token's current local policy ID into TIP-403. It is per
 
 Full automatic migration is not required. As of July 10, 2026, scans found 4,355 TIP-20 tokens on Presto mainnet and 15,291,992 TIP-20 tokens on Moderato testnet. Migrating every historical token during the network upgrade would create unnecessary registry state, especially on testnet.
 
-Operators and zone tooling should migrate only the tokens that are enabled on, or about to be enabled on, a zone.
+Operators and zone tooling should migrate only the tokens that are enabled on, or about to be enabled on, a zone. Token issuers do not need to migrate every historical token unless those tokens are part of a zone or another provable flow.
 
 ## Compatible releases
 

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -10,15 +10,16 @@ T9 updates how Tempo records the transfer policy used by TIP-20 tokens. It lets 
 For ecosystem partners, T9 matters most if you issue TIP-20 tokens, maintain wallets or indexers that read token policy state, or build flows that need a registry-backed answer for token policy checks.
 
 :::info[T9 status]
-T9 is not scheduled yet. The T9-compatible release, testnet activation time, and mainnet activation time are TBD.
+The T9-compatible release, v1.12.0, is targeted for August 3, 2026. Testnet activation is scheduled for August 5, 2026, and mainnet activation is scheduled for August 10, 2026.
 :::
 
 ## Timeline
 
 | Milestone | Date | Timestamp |
 |-----------|------|-----------|
-| Testnet activation | TBD | TBD |
-| Mainnet activation | TBD | TBD |
+| Target release | August 3, 2026 | TBD |
+| Testnet activation | August 5, 2026 | TBD |
+| Mainnet activation | August 10, 2026 | TBD |
 
 Node operators should run the T9-compatible release before the activation timestamp on each network. Nodes that are not updated before activation will fall out of sync.
 
@@ -58,11 +59,11 @@ This means teams can migrate the tokens they need instead of forcing every histo
 
 ## Compatible releases
 
-The T9-compatible release is not published yet.
+The T9-compatible node release, v1.12.0, is targeted for August 3, 2026. Release details are not published yet.
 
 | Ecosystem | T9-compatible releases |
 |-----------|------------------------|
-| Node operators | TBD |
+| Node operators | v1.12.0 (targeted for August 3, 2026) |
 | Rust SDK crates | TBD |
 
 Release notes and binaries will be linked here when the T9-compatible release is published.

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -29,7 +29,7 @@ T9 focuses on two changes that are needed for the first zone rollout:
 - **Protocol-managed zone creation.** Tempo gets one native ZoneFactory for creating zones and recording their portal accounts.
 - **Token policies that zones can rely on.** TIP-403 stores the active transfer policy for tokens that are used by zones and other provable flows.
 
-The practical effect is that zones become easier to reason about. A zone is created through one protocol entry point, gets a predictable portal account, and can check token transfer rules from one registry.
+A zone is created through one protocol entry point, gets a predictable portal account, and can check token transfer rules from one registry.
 
 ## Features
 

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -5,9 +5,11 @@ description: T9 records TIP-20 token policy bindings in TIP-403 and adds a migra
 
 # T9 Network Upgrade
 
-T9 records each TIP-20 token's active transfer policy in TIP-403. This gives apps, indexers, and other tooling a single place to check which policy a token is using.
+T9 records each TIP-20 token's active transfer policy in TIP-403. This gives zones, provable contract flows, apps, indexers, and other tooling a single place to check which policy a token is using.
 
-For most partners, T9 is only relevant if you issue TIP-20 tokens, run tooling that reads token policy state, or build flows that depend on TIP-403 policy checks.
+In simpler terms, T9 makes the answer to "which transfer rules apply to this token?" available from TIP-403 when that answer needs to be proved or checked from registry state.
+
+For most partners, T9 is only relevant if you issue TIP-20 tokens, run tooling that reads token policy state, or build zone/provable contract flows that depend on TIP-403 policy checks.
 
 :::info[T9 status]
 v1.12.0 is targeted for August 3, 2026. Testnet activation is scheduled for August 5, 2026, and mainnet activation is scheduled for August 10, 2026.
@@ -29,7 +31,7 @@ T9 has one protocol change:
 
 - **TIP-20 policy IDs in TIP-403.** TIP-403 can record which transfer policy a TIP-20 token is currently using.
 
-That gives apps and tooling a standard place to read token policy state when they need the TIP-403 view.
+That gives zones and tooling a standard place to read token policy state when they need the TIP-403 view.
 
 ## What changes
 
@@ -37,41 +39,32 @@ That gives apps and tooling a standard place to read token policy state when the
 
 TIP-403 already stores transfer policy data. With T9, it can also record which transfer policy a TIP-20 token is using.
 
-New TIP-20 tokens write this binding when they are created. Policy changes after T9 keep the binding up to date.
+New TIP-20 tokens write this binding when they are created. Policy changes after T9 keep the binding up to date. Existing tokens only need targeted migration when a zone, provable contract flow, or tooling path needs their policy ID to be available from TIP-403.
 
 Read the [TIP-1092 specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md).
-
-### Existing tokens keep working
-
-Existing TIP-20 tokens do not need to be migrated at activation. They keep using their local policy ID unless a team chooses to register that token in TIP-403.
-
-Teams should migrate a token when their app or tooling needs the policy ID to be available from TIP-403.
 
 ### Targeted migration
 
 T9 adds a migration path for individual existing TIP-20 tokens. The migration copies the token's current local policy ID into TIP-403. It does not change the token's policy or rules, and it can be run only for the tokens that need the TIP-403 binding.
 
-## Compatible releases
+## Compatible release
 
 v1.12.0 is targeted for August 3, 2026. Release notes and binaries will be linked here when they are available.
-
-| Ecosystem | T9-compatible releases |
-|-----------|------------------------|
-| Node operators | v1.12.0 (targeted for August 3, 2026) |
-| Rust SDK crates | TBD |
 
 ## Integration impact
 
 ### For TIP-20 issuers and token admins
 
-- New TIP-20 tokens write their TIP-403 policy binding when they are created.
-- Existing tokens keep working if they are not migrated.
-- Migrate an existing token when a flow needs to read its policy ID from TIP-403.
-- After activation, policy updates keep the TIP-403 binding up to date.
+- Migrate an existing token when a zone, provable contract flow, or tooling path needs to read its policy ID from TIP-403.
+- After activation, policy updates write the TIP-403 binding for the updated token.
 
-### For SDKs, indexers, and tooling
+### For zones, provable contract flows, and tooling
 
-- Existing token policy reads can keep using the current TIP-20 API when they only need the token's effective policy ID.
-- Use TIP-403 when your tooling needs the registry view of token policy state.
-- Migration tooling should operate on the specific tokens that need a TIP-403 binding.
-- Apps that do not read or enforce TIP-20 policy state do not need an immediate change for T9.
+- Use TIP-403 when your flow needs the registry view of token policy state.
+- Require the TIP-403 binding before enabling or using a token in a zone or provable contract flow.
+- If the binding is missing, migrate the specific token and verify that TIP-403 has the binding before continuing.
+
+### For migration tooling
+
+- Migrate only the specific tokens that need a TIP-403 binding.
+- Batch token lists and verify each binding after migration.

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -1,16 +1,16 @@
 ---
 title: T9 Network Upgrade
-description: T9 adds TIP-403 registry support for TIP-20 token policy bindings and targeted migration for existing tokens.
+description: T9 records TIP-20 token policy bindings in TIP-403 and adds a migration path for existing tokens.
 ---
 
 # T9 Network Upgrade
 
-T9 updates how Tempo records the transfer policy used by TIP-20 tokens. It lets TIP-403 store the active policy for a token, so policy-aware tooling can read that answer from the registry when it needs to.
+T9 records each TIP-20 token's active transfer policy in TIP-403. This gives apps, indexers, and other tooling a single place to check which policy a token is using.
 
-For ecosystem partners, T9 matters most if you issue TIP-20 tokens, maintain wallets or indexers that read token policy state, or build flows that need a registry-backed answer for token policy checks.
+For most partners, T9 is only relevant if you issue TIP-20 tokens, run tooling that reads token policy state, or build flows that depend on TIP-403 policy checks.
 
 :::info[T9 status]
-The T9-compatible release, v1.12.0, is targeted for August 3, 2026. Testnet activation is scheduled for August 5, 2026, and mainnet activation is scheduled for August 10, 2026.
+v1.12.0 is targeted for August 3, 2026. Testnet activation is scheduled for August 5, 2026, and mainnet activation is scheduled for August 10, 2026.
 :::
 
 ## Timeline
@@ -21,65 +21,57 @@ The T9-compatible release, v1.12.0, is targeted for August 3, 2026. Testnet acti
 | Testnet activation | August 5, 2026 | TBD |
 | Mainnet activation | August 10, 2026 | TBD |
 
-Node operators should run the T9-compatible release before the activation timestamp on each network. Nodes that are not updated before activation will fall out of sync.
+Node operators should plan to upgrade to v1.12.0 before the activation time for each network.
 
 ## Overview
 
-T9 focuses on one protocol change:
+T9 has one protocol change:
 
-- **TIP-20 policy IDs in TIP-403.** TIP-403 can store which transfer policy a TIP-20 token is currently using.
+- **TIP-20 policy IDs in TIP-403.** TIP-403 can record which transfer policy a TIP-20 token is currently using.
 
-This keeps token policy information in one registry when a flow needs that stronger guarantee. Existing tokens keep working even if they have not been migrated yet.
+That gives apps and tooling a standard place to read token policy state when they need the TIP-403 view.
 
-## Features
+## What changes
 
 ### Token policy lookup in TIP-403
 
-TIP-403 already stores transfer policy data. T9 also lets TIP-403 store the active transfer policy ID for a TIP-20 token.
+TIP-403 already stores transfer policy data. With T9, it can also record which transfer policy a TIP-20 token is using.
 
-In plain terms, this gives contracts and offchain tools a registry-backed way to ask: "Which transfer policy is this token using?"
+New TIP-20 tokens write this binding when they are created. Policy changes after T9 keep the binding up to date.
 
-New TIP-20 tokens write this TIP-403 binding when they are created. After T9, token policy changes also update the TIP-403 binding.
-
-Read the specification [here](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md).
+Read the [TIP-1092 specification](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md).
 
 ### Existing tokens keep working
 
-Existing TIP-20 tokens do not all need to move at activation. If a token has not been migrated, normal token behavior can still use the token's existing local policy ID.
+Existing TIP-20 tokens do not need to be migrated at activation. They keep using their local policy ID unless a team chooses to register that token in TIP-403.
 
-The difference is for flows that specifically need the policy answer to come from TIP-403. Those flows should require the TIP-403 binding to exist before using that token.
+Teams should migrate a token when their app or tooling needs the policy ID to be available from TIP-403.
 
 ### Targeted migration
 
-T9 adds a targeted migration path for existing TIP-20 tokens that need a TIP-403 binding.
-
-The migration copies the token's current local policy ID into TIP-403. It does not choose a new policy or change the token's rules; it only registers the policy the token is already using.
-
-This means teams can migrate the tokens they need instead of forcing every historical token into the registry at once.
+T9 adds a migration path for individual existing TIP-20 tokens. The migration copies the token's current local policy ID into TIP-403. It does not change the token's policy or rules, and it can be run only for the tokens that need the TIP-403 binding.
 
 ## Compatible releases
 
-The T9-compatible node release, v1.12.0, is targeted for August 3, 2026. Release details are not published yet.
+v1.12.0 is targeted for August 3, 2026. Release notes and binaries will be linked here when they are available.
 
 | Ecosystem | T9-compatible releases |
 |-----------|------------------------|
 | Node operators | v1.12.0 (targeted for August 3, 2026) |
 | Rust SDK crates | TBD |
 
-Release notes and binaries will be linked here when the T9-compatible release is published.
-
 ## Integration impact
 
 ### For TIP-20 issuers and token admins
 
-- New TIP-20 tokens write their TIP-403 policy binding during creation.
+- New TIP-20 tokens write their TIP-403 policy binding when they are created.
 - Existing tokens keep working if they are not migrated.
-- Existing tokens should be migrated when a flow needs their policy ID to be available from TIP-403.
-- After activation, policy changes update the active policy in TIP-403.
+- Migrate an existing token when a flow needs to read its policy ID from TIP-403.
+- After activation, policy updates keep the TIP-403 binding up to date.
 
-### For SDKs, indexers, and low-level tooling
+### For SDKs, indexers, and tooling
 
-- Existing token policy reads can keep using the current TIP-20 API when they only need the effective policy ID.
-- Tooling that needs a registry-backed token-to-policy answer should read TIP-403.
-- Migration tooling should migrate only the tokens that need a TIP-403 binding.
-- Apps that do not read or enforce TIP-20 policy state do not need an immediate integration change for T9.
+- Existing token policy reads can keep using the current TIP-20 API when they only need the token's effective policy ID.
+- Use TIP-403 when your tooling needs the registry view of token policy state.
+- Migration tooling should operate on the specific tokens that need a TIP-403 binding.
+- Apps that do not read or enforce TIP-20 policy state do not need an immediate change for T9.

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -31,7 +31,7 @@ T9 has one protocol change:
 
 - **TIP-20 policy IDs in TIP-403.** TIP-403 can record which transfer policy a TIP-20 token is currently using.
 
-That gives zones and tooling a standard place to read token policy state when they need the TIP-403 view.
+That gives zones and tooling a standard place to read token policy state when they need the TIP-403 view. For zones, this means a ZonePortal can check the TIP-403 binding before enabling a token instead of relying on token-local state.
 
 ## What changes
 
@@ -46,6 +46,8 @@ Read the [TIP-1092 specification](https://github.com/tempoxyz/tempo/blob/main/ti
 ### Targeted migration
 
 T9 adds a migration path for individual existing TIP-20 tokens. The migration copies the token's current local policy ID into TIP-403. It does not change the token's policy or rules, and it can be run only for the tokens that need the TIP-403 binding.
+
+For zone enablement, ZonePortal checks whether the token already has a TIP-403 binding. If it is missing, ZonePortal migrates that token, checks again, and rejects the token if the binding is still missing.
 
 ## Compatible release
 

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -15,11 +15,11 @@ v1.12.0 is targeted for August 3, 2026. Testnet activation is scheduled for Augu
 
 ## Timeline
 
-| Milestone | Date | Timestamp |
-|-----------|------|-----------|
-| Target release | August 3, 2026 | TBD |
-| Testnet activation | August 5, 2026 | TBD |
-| Mainnet activation | August 10, 2026 | TBD |
+| Milestone | Date |
+|-----------|------|
+| Target release | August 3, 2026 |
+| Testnet activation | August 5, 2026 |
+| Mainnet activation | August 10, 2026 |
 
 Node operators should plan to upgrade to v1.12.0 before the activation time for each network.
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -883,6 +883,11 @@ export default defineConfig({
             collapsed: false,
             items: [
               {
+                text: 'T9',
+                badge: { text: 'Planned', variant: 'note' as const },
+                link: '/docs/protocol/upgrades/t9',
+              },
+              {
                 text: 'T8',
                 badge: { text: 'Planned', variant: 'note' as const },
                 link: '/docs/protocol/upgrades/t8',


### PR DESCRIPTION
## Summary

- Adds a T9 network upgrade page focused on TIP-20 policy IDs in TIP-403, including why the binding is necessary for Tempo Zones and useful for provable contract flows/tooling that need registry-backed policy state.
- Clarifies that existing TIP-20 tokens only need targeted migration when they need to be enabled in a zone, used by a provable contract flow, or read by tooling that needs the TIP-403 binding.
- Adds T9 to the Network Upgrades and Releases page with v1.12.0 targeted for August 3, 2026, testnet activation scheduled for August 5, 2026, and mainnet activation scheduled for August 10, 2026.
- Adds T9 to the protocol Network Upgrades sidebar.