### PR TITLE
Update T8 sidebar label

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -884,7 +884,7 @@ export default defineConfig({
             items: [
               {
                 text: 'T8',
-                badge: { text: 'Planned', variant: 'note' as const },
+                badge: { text: 'Testnet', variant: 'info' as const },
                 link: '/docs/protocol/upgrades/t8',
               },
               {


### PR DESCRIPTION
## What changed

- Change the T8 sidebar badge from `Planned` to `Testnet`.
- Keep T7 marked as `Latest` until T8 is live on mainnet.

## Why

T8 is active on testnet now, so `Planned` is stale, but `Latest` would be premature before mainnet activation.

## Validation

- Checked the diff is limited to the T8 badge in `vocs.config.ts`.
- Local preview was not run for this one-line navigation label update.