### PR TITLE
fix: improve api crawlability

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -58,11 +58,11 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
           VERCEL_ENV: production
 
-      - name: Audit generated Markdown
-        run: pnpm run check:markdown
-
       - name: Check generated public links
         run: node scripts/check-generated-public-links.mjs
+
+      - name: Audit generated Markdown
+        run: pnpm run check:markdown
 
   ci-gate:
     name: CI Gate

--- a/scripts/check-generated-public-links.mjs
+++ b/scripts/check-generated-public-links.mjs
@@ -23,19 +23,20 @@ const llmsFiles = ['llms.txt', 'llms-full.txt'].map((file) => path.join(publicDi
 
 const attributeLink = {
   label: 'HTML or JSX link attribute',
-  pattern: /\b(?:href|to)=(?:\\?["'])\/docs(?=\/|[#?]|\\?["'])/g,
+  pattern: /\b(?:href|to)=(?:\\?["'])(?:\/developers)?\/docs(?=\/|[#?]|\\?["'])/g,
 }
 const serializedHref = {
   label: 'serialized href',
-  pattern: /(?:\\?["'])href(?:\\?["'])\s*:\s*(?:\\?["'])\/docs(?=\/|[#?]|\\?["'])/g,
+  pattern:
+    /(?:\\?["'])href(?:\\?["'])\s*:\s*(?:\\?["'])(?:\/developers)?\/docs(?=\/|[#?]|\\?["'])/g,
 }
 const markdownLink = {
   label: 'Markdown link',
-  pattern: /\]\(\s*\/docs(?=\/|[#?]|\s|\))/g,
+  pattern: /\]\(\s*(?:\/developers)?\/docs(?=\/|[#?]|\s|\))/g,
 }
 const markdownReference = {
   label: 'Markdown reference link',
-  pattern: /^\s*\[[^\]]+\]:\s*<?\/docs(?=\/|[#?]|>?(?:\s|$))/gm,
+  pattern: /^\s*\[[^\]]+\]:\s*<?(?:\/developers)?\/docs(?=\/|[#?]|>?(?:\s|$))/gm,
 }
 
 const candidateGroups = [
@@ -61,7 +62,7 @@ for (const { files, patterns } of candidateGroups) {
 }
 
 if (failures.length > 0) {
-  console.error('Generated public artifacts contain uncanonicalized /docs link targets:')
+  console.error('Generated public artifacts contain root-relative docs link targets:')
   console.error(
     failures
       .slice(0, 50)

--- a/scripts/finalize-sitemap.ts
+++ b/scripts/finalize-sitemap.ts
@@ -4,6 +4,7 @@ import { finalizeSitemap } from '../src/lib/sitemap.ts'
 import { getBlogPostSlugs } from '../src/marketing/blogPlugin.ts'
 
 const sitemapPath = path.resolve('dist/public/sitemap.xml')
+const openApiMarkdownPath = path.resolve('dist/public/assets/md/docs/api')
 let sitemap: string
 
 try {
@@ -19,7 +20,19 @@ try {
   throw error
 }
 
-const finalized = finalizeSitemap(sitemap, getBlogPostSlugs())
+const openApiRouteSlugs = await fs
+  .readdir(openApiMarkdownPath, { withFileTypes: true })
+  .then((entries) =>
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+      .map((entry) => entry.name.slice(0, -'.md'.length)),
+  )
+  .catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return []
+    throw error
+  })
+
+const finalized = finalizeSitemap(sitemap, getBlogPostSlugs(), openApiRouteSlugs)
 
 if (finalized !== sitemap) {
   await fs.writeFile(sitemapPath, finalized, 'utf-8')

--- a/src/lib/base-url.ts
+++ b/src/lib/base-url.ts
@@ -1,0 +1,10 @@
+export function resolveBaseUrl(): string {
+  if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') return ''
+  if (URL.canParse(process.env.VITE_BASE_URL ?? '')) {
+    return (process.env.VITE_BASE_URL as string).replace(/\/$/, '')
+  }
+  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz/developers'
+  const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
+  if (productionUrl) return `https://${productionUrl}`
+  return ''
+}

--- a/src/lib/canonical-developer-links.test.ts
+++ b/src/lib/canonical-developer-links.test.ts
@@ -2,27 +2,27 @@ import { describe, expect, test } from 'vitest'
 import { canonicalizeGeneratedDeveloperLinks } from './canonical-developer-links'
 
 describe('canonicalizeGeneratedDeveloperLinks', () => {
-  test('prefixes generated HTML hrefs with the public developers mount', () => {
+  test('uses canonical public URLs for generated HTML hrefs', () => {
     expect(
       canonicalizeGeneratedDeveloperLinks(
         '<a href="/docs">Docs</a><a href="/docs/api#authentication">API</a>',
       ),
     ).toBe(
-      '<a href="/developers/docs">Docs</a><a href="/developers/docs/api#authentication">API</a>',
+      '<a href="https://tempo.xyz/developers/docs">Docs</a><a href="https://tempo.xyz/developers/docs/api#authentication">API</a>',
     )
   })
 
-  test('prefixes href fields in raw and HTML-escaped RSC payloads', () => {
+  test('uses canonical public URLs in raw and HTML-escaped RSC href fields', () => {
     expect(
       canonicalizeGeneratedDeveloperLinks(
         '{"href":"/docs/api","to":"/docs/api"} {\\"href\\":\\"/docs/api\\",\\"to\\":\\"/docs/api\\"}',
       ),
     ).toBe(
-      '{"href":"/developers/docs/api","to":"/docs/api"} {\\"href\\":\\"/developers/docs/api\\",\\"to\\":\\"/docs/api\\"}',
+      '{"href":"https://tempo.xyz/developers/docs/api","to":"/docs/api"} {\\"href\\":\\"https://tempo.xyz/developers/docs/api\\",\\"to\\":\\"/docs/api\\"}',
     )
   })
 
-  test('prefixes generated Markdown links', () => {
+  test('uses canonical public URLs for generated Markdown links', () => {
     expect(
       canonicalizeGeneratedDeveloperLinks(
         [
@@ -34,11 +34,21 @@ describe('canonicalizeGeneratedDeveloperLinks', () => {
       ),
     ).toBe(
       [
-        '- [Docs](/developers/docs)',
-        '- [API](/developers/docs/api)',
-        '- [Authentication](/developers/docs/api#authentication)',
-        '<Card title="API" to="/developers/docs/api" />',
+        '- [Docs](https://tempo.xyz/developers/docs)',
+        '- [API](https://tempo.xyz/developers/docs/api)',
+        '- [Authentication](https://tempo.xyz/developers/docs/api#authentication)',
+        '<Card title="API" to="https://tempo.xyz/developers/docs/api" />',
       ].join('\n'),
+    )
+  })
+
+  test('normalizes already-prefixed generated links', () => {
+    expect(
+      canonicalizeGeneratedDeveloperLinks(
+        '<a href="/developers/docs/api">API</a> [API](/developers/docs/api)',
+      ),
+    ).toBe(
+      '<a href="https://tempo.xyz/developers/docs/api">API</a> [API](https://tempo.xyz/developers/docs/api)',
     )
   })
 
@@ -47,7 +57,6 @@ describe('canonicalizeGeneratedDeveloperLinks', () => {
       '{"to":"/docs/api","path":"/docs/api"}',
       '<a href="/docsify">Docsify</a>',
       '[External](https://example.com/docs)',
-      '<a href="/developers/docs/api">API</a>',
     ].join('\n')
 
     expect(canonicalizeGeneratedDeveloperLinks(content)).toBe(content)

--- a/src/lib/canonical-developer-links.test.ts
+++ b/src/lib/canonical-developer-links.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from 'vitest'
 import { canonicalizeGeneratedDeveloperLinks } from './canonical-developer-links'
 
+const publicDevelopersUrl = 'https://tempo.xyz/developers/docs'
+
 describe('canonicalizeGeneratedDeveloperLinks', () => {
   test('uses canonical public URLs for generated HTML hrefs', () => {
     expect(
       canonicalizeGeneratedDeveloperLinks(
         '<a href="/docs">Docs</a><a href="/docs/api#authentication">API</a>',
+        publicDevelopersUrl,
       ),
     ).toBe(
       '<a href="https://tempo.xyz/developers/docs">Docs</a><a href="https://tempo.xyz/developers/docs/api#authentication">API</a>',
@@ -16,6 +19,7 @@ describe('canonicalizeGeneratedDeveloperLinks', () => {
     expect(
       canonicalizeGeneratedDeveloperLinks(
         '{"href":"/docs/api","to":"/docs/api"} {\\"href\\":\\"/docs/api\\",\\"to\\":\\"/docs/api\\"}',
+        publicDevelopersUrl,
       ),
     ).toBe(
       '{"href":"https://tempo.xyz/developers/docs/api","to":"/docs/api"} {\\"href\\":\\"https://tempo.xyz/developers/docs/api\\",\\"to\\":\\"/docs/api\\"}',
@@ -31,6 +35,7 @@ describe('canonicalizeGeneratedDeveloperLinks', () => {
           '- [Authentication](/docs/api#authentication)',
           '<Card title="API" to="/docs/api" />',
         ].join('\n'),
+        publicDevelopersUrl,
       ),
     ).toBe(
       [
@@ -46,10 +51,20 @@ describe('canonicalizeGeneratedDeveloperLinks', () => {
     expect(
       canonicalizeGeneratedDeveloperLinks(
         '<a href="/developers/docs/api">API</a> [API](/developers/docs/api)',
+        publicDevelopersUrl,
       ),
     ).toBe(
       '<a href="https://tempo.xyz/developers/docs/api">API</a> [API](https://tempo.xyz/developers/docs/api)',
     )
+  })
+
+  test('uses the configured public URL', () => {
+    expect(
+      canonicalizeGeneratedDeveloperLinks(
+        '<a href="/docs/api">API</a>',
+        'https://docs.example.com/reference/docs',
+      ),
+    ).toBe('<a href="https://docs.example.com/reference/docs/api">API</a>')
   })
 
   test('leaves internal route values and unrelated URLs unchanged', () => {
@@ -59,6 +74,6 @@ describe('canonicalizeGeneratedDeveloperLinks', () => {
       '[External](https://example.com/docs)',
     ].join('\n')
 
-    expect(canonicalizeGeneratedDeveloperLinks(content)).toBe(content)
+    expect(canonicalizeGeneratedDeveloperLinks(content, publicDevelopersUrl)).toBe(content)
   })
 })

--- a/src/lib/canonical-developer-links.ts
+++ b/src/lib/canonical-developer-links.ts
@@ -1,15 +1,18 @@
-const publicDevelopersPath = '/developers/docs'
+const publicDevelopersUrl = 'https://tempo.xyz/developers/docs'
 
 /**
  * Rewrites generated public link targets without changing Vocs' internal route
  * values. The docs app routes at `/docs` internally, but production is mounted
- * at `/developers`, so a bare href otherwise takes an unnecessary 308 hop.
+ * on a different origin path, so a root-relative href otherwise takes a 308 hop.
  */
 export function canonicalizeGeneratedDeveloperLinks(content: string) {
   return content
-    .replace(/href=(["'])\/docs(?=\/|[#?]|\1)/g, `href=$1${publicDevelopersPath}`)
-    .replace(/to=(["'])\/docs(?=\/|[#?]|\1)/g, `to=$1${publicDevelopersPath}`)
-    .replace(/"href":"\/docs(?=\/|[#?]|")/g, `"href":"${publicDevelopersPath}`)
-    .replace(/\\"href\\":\\"\/docs(?=\/|[#?]|\\")/g, `\\"href\\":\\"${publicDevelopersPath}`)
-    .replace(/\]\(\/docs(?=\/|[#?]|\))/g, `](${publicDevelopersPath}`)
+    .replace(/href=(["'])(?:\/developers)?\/docs(?=\/|[#?]|\1)/g, `href=$1${publicDevelopersUrl}`)
+    .replace(/to=(["'])(?:\/developers)?\/docs(?=\/|[#?]|\1)/g, `to=$1${publicDevelopersUrl}`)
+    .replace(/"href":"(?:\/developers)?\/docs(?=\/|[#?]|")/g, `"href":"${publicDevelopersUrl}`)
+    .replace(
+      /\\"href\\":\\"(?:\/developers)?\/docs(?=\/|[#?]|\\")/g,
+      `\\"href\\":\\"${publicDevelopersUrl}`,
+    )
+    .replace(/\]\((?:\/developers)?\/docs(?=\/|[#?]|\))/g, `](${publicDevelopersUrl}`)
 }

--- a/src/lib/canonical-developer-links.ts
+++ b/src/lib/canonical-developer-links.ts
@@ -1,11 +1,9 @@
-const publicDevelopersUrl = 'https://tempo.xyz/developers/docs'
-
 /**
  * Rewrites generated public link targets without changing Vocs' internal route
  * values. The docs app routes at `/docs` internally, but production is mounted
  * on a different origin path, so a root-relative href otherwise takes a 308 hop.
  */
-export function canonicalizeGeneratedDeveloperLinks(content: string) {
+export function canonicalizeGeneratedDeveloperLinks(content: string, publicDevelopersUrl: string) {
   return content
     .replace(/href=(["'])(?:\/developers)?\/docs(?=\/|[#?]|\1)/g, `href=$1${publicDevelopersUrl}`)
     .replace(/to=(["'])(?:\/developers)?\/docs(?=\/|[#?]|\1)/g, `to=$1${publicDevelopersUrl}`)

--- a/src/lib/sitemap.test.ts
+++ b/src/lib/sitemap.test.ts
@@ -11,6 +11,12 @@ const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
     <lastmod>2026-07-18</lastmod>
   </url>
   <url>
+    <loc>https://tempo.xyz/developers/docs/api</loc>
+  </url>
+  <url>
+    <loc>https://tempo.xyz/developers/docs/api/authentication</loc>
+  </url>
+  <url>
     <loc>https://tempo.xyz/developers/example/[id]</loc>
   </url>
 </urlset>`
@@ -22,6 +28,7 @@ describe('finalizeSitemap', () => {
     expect(result).toContain('<loc>https://tempo.xyz/developers/blog/t6</loc>')
     expect(result).toContain('<loc>https://tempo.xyz/developers/blog/t7-network-upgrade</loc>')
     expect(result.indexOf('/blog/t6')).toBeLessThan(result.indexOf('/blog/t7-network-upgrade'))
+    expect(result).not.toMatch(/<loc>https:\/\/tempo\.xyz\/developers\/blog\/t6<\/loc>\s*<lastmod>/)
     expect(result).not.toContain('[slug]')
     expect(result).not.toContain('[id]')
   })
@@ -44,5 +51,24 @@ describe('finalizeSitemap', () => {
     const result = finalizeSitemap(withoutBlogTemplate, ['t6'])
 
     expect(result).toContain('<loc>https://tempo.xyz/developers/blog/t6</loc>')
+  })
+
+  it('adds generated OpenAPI routes without lastmod in stable order', () => {
+    const result = finalizeSitemap(sitemap, [], ['billing', 'activities', 'billing'])
+
+    expect(result).toContain('<loc>https://tempo.xyz/developers/docs/api/activities</loc>')
+    expect(result).toContain('<loc>https://tempo.xyz/developers/docs/api/billing</loc>')
+    expect(result.indexOf('/api/activities')).toBeLessThan(result.indexOf('/api/billing'))
+    expect(result).not.toMatch(
+      /<loc>https:\/\/tempo\.xyz\/developers\/docs\/api\/(?:activities|billing)<\/loc>\s*<lastmod>/,
+    )
+  })
+
+  it('does not duplicate an authored OpenAPI route', () => {
+    const result = finalizeSitemap(sitemap, [], ['authentication'])
+
+    expect(
+      result.match(/<loc>https:\/\/tempo\.xyz\/developers\/docs\/api\/authentication<\/loc>/g),
+    ).toHaveLength(1)
   })
 })

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,7 +1,11 @@
 const TEMPLATE_URL_PATTERN = /<url>\s*<loc>([^<]*\/\[[^\]]+\][^<]*)<\/loc>[\s\S]*?<\/url>\s*/g
 const LOCATION_PATTERN = /<loc>([^<]+)<\/loc>/g
 
-export function finalizeSitemap(sitemap: string, blogPostSlugs: readonly string[]): string {
+export function finalizeSitemap(
+  sitemap: string,
+  blogPostSlugs: readonly string[],
+  openApiRouteSlugs: readonly string[] = [],
+): string {
   let blogBaseUrl: string | undefined
 
   const withoutTemplates = sitemap.replace(TEMPLATE_URL_PATTERN, (_entry, location: string) => {
@@ -21,15 +25,34 @@ export function finalizeSitemap(sitemap: string, blogPostSlugs: readonly string[
     if (blogIndexUrl) blogBaseUrl = `${blogIndexUrl.replace(/\/$/, '')}/`
   }
 
-  const uniqueSlugs = [...new Set(blogPostSlugs)].sort((a, b) => a.localeCompare(b))
-  if (uniqueSlugs.length === 0) return withoutTemplates
-  if (!blogBaseUrl) throw new Error('Could not resolve the blog base URL from the sitemap')
+  const uniqueBlogSlugs = [...new Set(blogPostSlugs)].sort((a, b) => a.localeCompare(b))
+  const uniqueOpenApiSlugs = [...new Set(openApiRouteSlugs)].sort((a, b) => a.localeCompare(b))
+  if (uniqueBlogSlugs.length === 0 && uniqueOpenApiSlugs.length === 0) return withoutTemplates
   if (!withoutTemplates.includes('</urlset>')) {
     throw new Error('Could not find the sitemap urlset closing tag')
   }
 
-  const entries = uniqueSlugs
-    .map((slug) => `${blogBaseUrl}${encodeURIComponent(slug)}`)
+  const locations: string[] = []
+
+  if (uniqueOpenApiSlugs.length > 0) {
+    const openApiIndexUrl = Array.from(existingLocations).find((location) =>
+      /\/docs\/api\/?$/.test(location),
+    )
+    if (!openApiIndexUrl) {
+      throw new Error('Could not resolve the OpenAPI base URL from the sitemap')
+    }
+    const openApiBaseUrl = `${openApiIndexUrl.replace(/\/$/, '')}/`
+    locations.push(
+      ...uniqueOpenApiSlugs.map((slug) => `${openApiBaseUrl}${encodeURIComponent(slug)}`),
+    )
+  }
+
+  if (uniqueBlogSlugs.length > 0) {
+    if (!blogBaseUrl) throw new Error('Could not resolve the blog base URL from the sitemap')
+    locations.push(...uniqueBlogSlugs.map((slug) => `${blogBaseUrl}${encodeURIComponent(slug)}`))
+  }
+
+  const entries = locations
     .filter((location) => !existingLocations.has(location))
     .map((location) => `  <url>\n    <loc>${location}</loc>\n  </url>`)
 

--- a/src/marketing/seo.ts
+++ b/src/marketing/seo.ts
@@ -5,6 +5,8 @@
 import { OG_IMAGE_VERSION } from '../lib/og-sections'
 import { type CategorySlug, categoryBySlug } from './app/blog/_lib/categories'
 
+export { resolveBaseUrl } from '../lib/base-url'
+
 export type PostSeo = {
   slug: string
   title: string // raw post title (no " — Tempo Developers" suffix)
@@ -12,20 +14,6 @@ export type PostSeo = {
   date: string // YYYY-MM-DD
   category: CategorySlug
   authors: string
-}
-
-// Mirrors the baseUrl resolution in vocs.config.ts so canonical and OG URLs are
-// absolute in production and gracefully relative on preview/local builds
-// (returning '' there, just like the docs site, to avoid leaking preview URLs).
-export function resolveBaseUrl(): string {
-  if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') return ''
-  if (URL.canParse(process.env.VITE_BASE_URL ?? '')) {
-    return (process.env.VITE_BASE_URL as string).replace(/\/$/, '')
-  }
-  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz/developers'
-  const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
-  if (productionUrl) return `https://${productionUrl}`
-  return ''
 }
 
 export function absoluteUrl(base: string, pathname: string): string {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import Icons from 'unplugin-icons/vite'
 import { defineConfig, loadEnv, type Plugin, type ResolvedConfig } from 'vite'
 import mkcert from 'vite-plugin-mkcert'
 import { vocs } from 'vocs/vite'
+import { resolveBaseUrl } from './src/lib/base-url'
 import { canonicalizeGeneratedDeveloperLinks } from './src/lib/canonical-developer-links'
 import { blogPostsPlugin } from './src/marketing/blogPlugin'
 
@@ -216,12 +217,15 @@ function llmsAgentPreamble(): Plugin {
 
         await Promise.all(candidates.map(prependAgentNotice))
         if (process.env.VERCEL_ENV === 'production') {
+          const publicDevelopersUrl = `${resolveBaseUrl()}/docs`
           const generatedPages = [
             ...(await filesWithExtension(publicDir, '.html')),
             ...(await filesWithExtension(path.join(publicDir, 'RSC'), '.txt')),
           ]
           await Promise.all(
-            [...new Set([...candidates, ...generatedPages])].map(canonicalizeGeneratedLinksInFile),
+            [...new Set([...candidates, ...generatedPages])].map((filePath) =>
+              canonicalizeGeneratedLinksInFile(filePath, publicDevelopersUrl),
+            ),
           )
         }
       },
@@ -276,10 +280,10 @@ async function prependAgentNotice(filePath: string) {
   }
 }
 
-async function canonicalizeGeneratedLinksInFile(filePath: string) {
+async function canonicalizeGeneratedLinksInFile(filePath: string, publicDevelopersUrl: string) {
   try {
     const content = await fs.readFile(filePath, 'utf-8')
-    const canonical = canonicalizeGeneratedDeveloperLinks(content)
+    const canonical = canonicalizeGeneratedDeveloperLinks(content, publicDevelopersUrl)
     if (canonical !== content) await fs.writeFile(filePath, canonical, 'utf-8')
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,19 +1,12 @@
 import { Changelog, defineConfig, Embedding, Reranker, Retriever } from 'vocs/config'
+import { resolveBaseUrl } from './src/lib/base-url'
 import { docsRouteDestination, proxiedLegacyDocsRoutes } from './src/lib/docs-routing'
 import { createFeedbackAdapter } from './src/lib/feedback-adapter'
 import { plainMarkdownComponents } from './src/lib/markdown-output'
 
 // Only set baseUrl in production — Vocs injects a <base> tag from this value,
 // which causes all links to resolve to the absolute URL on preview deployments.
-const baseUrl = (() => {
-  if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production') return ''
-  const viteBaseUrl = process.env.VITE_BASE_URL
-  if (viteBaseUrl && URL.canParse(viteBaseUrl)) return viteBaseUrl.replace(/\/$/, '')
-  if (process.env.VERCEL_ENV === 'production') return 'https://tempo.xyz/developers'
-  const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
-  if (productionUrl) return `https://${productionUrl}`
-  return ''
-})()
+const baseUrl = resolveBaseUrl()
 
 const searchIndexFields = ['title', 'titles', 'subtitle', 'path', 'excerpt']
 const searchBoost = { title: 5, subtitle: 3, titles: 2, path: 3, excerpt: 3 }


### PR DESCRIPTION
Include every generated OpenAPI group page in the production sitemap and emit direct canonical developer links, avoiding missing API crawl targets and redirects through the legacy `/docs` mount.