### PR TITLE
docs: improve tempo api page seo

### DIFF
--- a/src/lib/vocs-config-seo.test.ts
+++ b/src/lib/vocs-config-seo.test.ts
@@ -23,6 +23,18 @@ describe('vocs.config docs SEO controls', () => {
       'Send a Payment ⋅ Tempo Docs',
     )
     expect(titleFor('/docs/api', 'Tempo API')).toBe('Tempo API ⋅ Tempo Docs')
+    expect(titleFor('/docs/api/authentication', 'Authentication')).toBe(
+      'Authentication ⋅ Tempo Docs',
+    )
+    expect(titleFor('/docs/api/json-rpc', 'Tempo JSON-RPC API: Endpoints & Methods')).toBe(
+      'Tempo JSON-RPC API: Endpoints & Methods ⋅ Tempo Docs',
+    )
+    expect(
+      titleFor('/docs/api/indexer-api', 'Tempo Indexer API: Query Blockchain Data with SQL'),
+    ).toBe('Tempo Indexer API: Query Blockchain Data with SQL ⋅ Tempo Docs')
+    expect(titleFor('/docs/api/fee-payer', 'Tempo Fee Payer API: Sponsor Transaction Fees')).toBe(
+      'Tempo Fee Payer API: Sponsor Transaction Fees ⋅ Tempo Docs',
+    )
     expect(titleFor('/docs/protocol/transactions', 'Tempo Transactions')).toBe(
       'Tempo Transactions ⋅ Tempo Docs',
     )

--- a/src/lib/vocs-config-seo.test.ts
+++ b/src/lib/vocs-config-seo.test.ts
@@ -23,6 +23,15 @@ describe('vocs.config docs SEO controls', () => {
       'Send a Payment ⋅ Tempo Docs',
     )
     expect(titleFor('/docs/api', 'Tempo API')).toBe('Tempo API ⋅ Tempo Docs')
+    expect(titleFor('/docs/protocol/transactions', 'Tempo Transactions')).toBe(
+      'Tempo Transactions ⋅ Tempo Docs',
+    )
+    expect(titleFor('/', 'Tempo')).toBe('Tempo')
+    expect(titleFor('/build/tempo-transactions', 'Tempo Transactions')).toBe('Tempo Transactions')
+    expect(titleFor('/blog', 'Blog')).toBe('Blog ⋅ Tempo')
+  })
+
+  test('formats authored API titles when Vocs supplies routed metadata', () => {
     expect(titleFor('/docs/api/authentication', 'Authentication')).toBe(
       'Authentication ⋅ Tempo Docs',
     )
@@ -35,12 +44,6 @@ describe('vocs.config docs SEO controls', () => {
     expect(titleFor('/docs/api/fee-payer', 'Tempo Fee Payer API: Sponsor Transaction Fees')).toBe(
       'Tempo Fee Payer API: Sponsor Transaction Fees ⋅ Tempo Docs',
     )
-    expect(titleFor('/docs/protocol/transactions', 'Tempo Transactions')).toBe(
-      'Tempo Transactions ⋅ Tempo Docs',
-    )
-    expect(titleFor('/', 'Tempo')).toBe('Tempo')
-    expect(titleFor('/build/tempo-transactions', 'Tempo Transactions')).toBe('Tempo Transactions')
-    expect(titleFor('/blog', 'Blog')).toBe('Blog ⋅ Tempo')
   })
 
   test('omits article modified metadata for docs pages only', () => {

--- a/src/pages/docs/_layout.tsx
+++ b/src/pages/docs/_layout.tsx
@@ -43,6 +43,7 @@ if (typeof window !== 'undefined') {
 export default function DocsLayout(
   props: PropsWithChildren<{
     path?: string
+    // This downstream consumer takes effect when the separately tracked Vocs OpenAPI frontmatter update is adopted.
     frontmatter?: {
       description?: string
       interactive?: boolean

--- a/src/pages/docs/_layout.tsx
+++ b/src/pages/docs/_layout.tsx
@@ -43,7 +43,12 @@ if (typeof window !== 'undefined') {
 export default function DocsLayout(
   props: PropsWithChildren<{
     path?: string
-    frontmatter?: { interactive?: boolean; mipd?: boolean }
+    frontmatter?: {
+      description?: string
+      interactive?: boolean
+      mipd?: boolean
+      title?: string
+    }
   }>,
 ) {
   const pageSettled = usePageSettled()
@@ -51,7 +56,11 @@ export default function DocsLayout(
 
   return (
     <>
-      <DocsJsonLd path={props.path} />
+      <DocsJsonLd
+        description={props.frontmatter?.description}
+        path={props.path}
+        title={props.frontmatter?.title}
+      />
       <DocsHeader />
       <DocsSectionNav />
       <DocsSidebarDrawer />

--- a/src/pages/docs/api.mdx
+++ b/src/pages/docs/api.mdx
@@ -1,13 +1,13 @@
 ---
 title: Tempo API
-description: Explore Tempo API endpoints and RPC methods for account activity, balances, blocks, tokens, transfers, and chain data.
+description: Build stablecoin payment apps with the official Tempo blockchain API for account activity, webhooks, funding, exchange quotes, fee sponsorship, and indexed SQL.
 ---
 
 import { Cards, Card, OpenApi } from 'vocs'
 
 # Tempo API
 
-Use the Tempo API for indexed chain data, readable account activity, token metadata, balances, transfers, transaction receipts, RPC methods, and fee sponsorship.
+The Tempo API is the official Tempo blockchain API for stablecoin payment applications. Use it to read account and transaction activity, manage webhooks and integrations, quote funding and exchanges, sponsor fees, run indexed SQL, and call Tempo over JSON-RPC.
 
 :::warning
 The Tempo API is under active development. Endpoints are not yet stable and may change without notice.
@@ -20,6 +20,8 @@ Every endpoint is served over HTTPS from `https://api.tempo.xyz` under the `/v1`
 ```bash
 curl 'https://api.tempo.xyz/v1/blocks'
 ```
+
+## Choose a Tempo API surface
 
 The same base URL and credentials give you access to four surfaces:
 

--- a/src/pages/docs/api/authentication.mdx
+++ b/src/pages/docs/api/authentication.mdx
@@ -1,9 +1,9 @@
 ---
 title: Authentication
-description: Authenticate Tempo API requests with production or sandbox API keys, or pay per request with MPP.
+description: Authenticate requests to the Tempo blockchain API with public access, production or sandbox API keys, or MPP pay-per-request credentials.
 ---
 
-# API Authentication
+# Authentication
 
 The Tempo API supports three ways to authenticate a request, so you can start without credentials and add authentication as your needs grow:
 

--- a/src/pages/docs/api/authentication.mdx
+++ b/src/pages/docs/api/authentication.mdx
@@ -3,6 +3,8 @@ title: Authentication
 description: Authenticate requests to the Tempo blockchain API with public access, production or sandbox API keys, or MPP pay-per-request credentials.
 ---
 
+<span id="api-authentication" />
+
 # Authentication
 
 The Tempo API supports three ways to authenticate a request, so you can start without credentials and add authentication as your needs grow:

--- a/src/pages/docs/api/fee-payer.mdx
+++ b/src/pages/docs/api/fee-payer.mdx
@@ -5,6 +5,8 @@ description: Sponsor and broadcast Tempo transactions through the hosted Fee Pay
 
 import { Cards, Card } from 'vocs'
 
+<span id="fee-payer-api" />
+
 # Tempo Fee Payer API
 
 Use the Fee Payer API to cover transaction fees for your users.

--- a/src/pages/docs/api/fee-payer.mdx
+++ b/src/pages/docs/api/fee-payer.mdx
@@ -1,11 +1,11 @@
 ---
-title: Fee Payer API
-description: Cover Tempo transaction fees for your users with fee sponsorship.
+title: "Tempo Fee Payer API: Sponsor Transaction Fees"
+description: Sponsor and broadcast Tempo transactions through the hosted Fee Payer API with authenticated production and sandbox endpoints or a public testnet service.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Fee Payer API
+# Tempo Fee Payer API
 
 Use the Fee Payer API to cover transaction fees for your users.
 

--- a/src/pages/docs/api/indexer-api.mdx
+++ b/src/pages/docs/api/indexer-api.mdx
@@ -1,13 +1,13 @@
 ---
-title: Indexer API
-description: The Tempo API exposes an Indexer entrypoint for read-only SQL over chain data, indexed by tidx into PostgreSQL and ClickHouse.
+title: "Tempo Indexer API: Query Blockchain Data with SQL"
+description: Query indexed Tempo blockchain data with read-only SQL over HTTP, including blocks, transactions, logs, receipts, balances, and DEX analytics.
 interactive: true
 ---
 
 import { Card, Cards } from 'vocs'
 import { TidxQuery } from '../../../components/TidxQuery'
 
-# Indexer API
+# Tempo Indexer API
 
 <span id="indexer-tidx" />
 

--- a/src/pages/docs/api/indexer-api.mdx
+++ b/src/pages/docs/api/indexer-api.mdx
@@ -7,6 +7,8 @@ interactive: true
 import { Card, Cards } from 'vocs'
 import { TidxQuery } from '../../../components/TidxQuery'
 
+<span id="indexer-api" />
+
 # Tempo Indexer API
 
 <span id="indexer-tidx" />

--- a/src/pages/docs/api/json-rpc.mdx
+++ b/src/pages/docs/api/json-rpc.mdx
@@ -5,6 +5,8 @@ description: Connect to Tempo JSON-RPC from Viem, Wagmi, Foundry, or Rust for st
 
 import { OpenApi, Tabs, Tab } from 'vocs'
 
+<span id="json-rpc-api" />
+
 # Tempo JSON-RPC API
 
 The Tempo API exposes a **JSON-RPC entrypoint** for raw, node-level chain access alongside its REST and Indexer surfaces. Through it, Tempo nodes serve all standard [Ethereum JSON-RPC methods](https://ethereum.org/developers/docs/apis/json-rpc/) (`eth_`, `net_`, `web3_`, `txpool_`, `trace_`, `debug_`) plus Tempo-specific namespaces for fork scheduling, consensus data, and node administration.

--- a/src/pages/docs/api/json-rpc.mdx
+++ b/src/pages/docs/api/json-rpc.mdx
@@ -1,11 +1,11 @@
 ---
-title: JSON-RPC API
-description: The Tempo API exposes a JSON-RPC entrypoint for raw chain access from Viem, Wagmi, and Rust.
+title: "Tempo JSON-RPC API: Endpoints & Methods"
+description: Connect to Tempo JSON-RPC from Viem, Wagmi, Foundry, or Rust for standard Ethereum methods and Tempo-specific blockchain access.
 ---
 
 import { OpenApi, Tabs, Tab } from 'vocs'
 
-# JSON-RPC API
+# Tempo JSON-RPC API
 
 The Tempo API exposes a **JSON-RPC entrypoint** for raw, node-level chain access alongside its REST and Indexer surfaces. Through it, Tempo nodes serve all standard [Ethereum JSON-RPC methods](https://ethereum.org/developers/docs/apis/json-rpc/) (`eth_`, `net_`, `web3_`, `txpool_`, `trace_`, `debug_`) plus Tempo-specific namespaces for fork scheduling, consensus data, and node administration.
 

--- a/src/pages/docs/build.mdx
+++ b/src/pages/docs/build.mdx
@@ -11,6 +11,8 @@ Use this section when you are designing payment experiences or payment infrastru
 
 Start with **Make Payments** if you are not sure where to begin. It covers the core transfer flow and introduces the payment primitives used throughout the rest of the docs.
 
+Use the [Tempo API](/docs/api) when your application backend needs indexed payment activity, webhooks, funding or exchange quotes, fee sponsorship, or integration management.
+
 Use [Agentic Payments](/docs/guide/machine-payments) when agents, APIs, or services need to pay per request. Use [Private Zones](/docs/guide/private-zones) when your product needs isolated execution, private transfers, or zone bridging flows.
 
 ## Core Build Paths

--- a/src/pages/docs/guide/payments/index.mdx
+++ b/src/pages/docs/guide/payments/index.mdx
@@ -9,6 +9,8 @@ import { Cards, Card } from 'vocs'
 
 Send and receive payments using stablecoins on Tempo. Start with core payment flows, then add reconciliation, receive controls, fee preferences, sponsorship, and higher-throughput transaction patterns.
 
+Use the [Tempo API](/docs/api) in your application backend to monitor account and transaction activity, deliver webhook updates, and sponsor transaction fees.
+
 Use [receive policies](/docs/guide/payments/configure-receive-policies) when an account needs to filter inbound TIP-20 transfers or mints by token and sender.
 
 ## Core Payment Flows

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -82,6 +82,12 @@ If you are new to Tempo, start with **Connect to Tempo**, then use **Stablecoin 
     icon="lucide:terminal-square"
   />
   <Card
+    title="Tempo API"
+    description="Read payment activity, use webhooks, quote funding and exchanges, sponsor fees, and query indexed data."
+    to="/docs/api"
+    icon="lucide:cloud"
+  />
+  <Card
     title="Tempo Protocol"
     description="Technical references for tokens, policies, fees, transactions, blockspace, exchange, zones, and TIPs."
     to="/docs/protocol"


### PR DESCRIPTION
Improves Tempo API page intent, contextual internal links, authored metadata, and JSON-LD frontmatter propagation for payment developers. Integrates with the upstream Vocs metadata fix: https://github.com/wevm/vocs/pull/600