### PR TITLE
docs: add a Node.js Viem quickstart

### DIFF
--- a/src/pages/docs/sdk/typescript/index.mdx
+++ b/src/pages/docs/sdk/typescript/index.mdx
@@ -39,6 +39,28 @@ The Tempo extensions cover common chain operations such as querying state, sendi
 
 ## Viem SDK for Tempo
 
+Use Viem for Node.js scripts, servers, and other headless applications.
+
+### Create a testnet client
+
+Install Viem:
+
+```bash
+npm install viem
+```
+
+Set `TEMPO_TEST_PRIVATE_KEY` to a dedicated test account key. This script connects to Tempo Testnet and uses the [faucet](/docs/quickstart/faucet) to fund the account with test tokens.
+
+```ts twoslash [testnet.ts] filename="testnet.ts"
+// [!include ~/snippets/node-viem-quickstart.ts:testnet]
+```
+
+:::warning
+This example is testnet-only. For mainnet, use a separately funded mainnet account, omit `testnet: true`, and remove the faucet call.
+:::
+
+Tempo actions are grouped by feature under namespaces such as `client.token`, `client.policy`, `client.fee`, `client.dex`, `client.accessKey`, and `client.receivePolicy`. See the [Viem Actions reference](https://viem.sh/tempo/actions) for the full list.
+
 The T3-compatible `viem` release includes the updated access-key ABI, including periodic limits and call scoping. See the [T3 network upgrade](/docs/protocol/upgrades/t3) for migration details.
 
 <Cards>

--- a/src/pages/docs/sdk/typescript/index.mdx
+++ b/src/pages/docs/sdk/typescript/index.mdx
@@ -49,7 +49,7 @@ Install Viem:
 npm install viem
 ```
 
-Set `TEMPO_TEST_PRIVATE_KEY` to a dedicated test account key. This script connects to Tempo Testnet and uses the [faucet](/docs/quickstart/faucet) to fund the account with test tokens.
+Connect to Tempo Testnet and use the [faucet](/docs/quickstart/faucet) to fund the account with test tokens.
 
 ```ts twoslash [testnet.ts] filename="testnet.ts"
 // [!include ~/snippets/node-viem-quickstart.ts:testnet]

--- a/src/snippets/node-viem-quickstart.ts
+++ b/src/snippets/node-viem-quickstart.ts
@@ -1,11 +1,8 @@
 // [!region testnet]
-import { env } from 'node:process'
 import { Account, createClient } from 'viem/tempo'
 
-const privateKey = env.TEMPO_TEST_PRIVATE_KEY
-if (!privateKey) throw new Error('Set TEMPO_TEST_PRIVATE_KEY')
-
-const account = Account.fromSecp256k1(privateKey as `0x${string}`)
+const privateKey = '0x...'
+const account = Account.fromSecp256k1(privateKey)
 const client = createClient({ account, testnet: true })
 
 await client.faucet.fundSync({ account })

--- a/src/snippets/node-viem-quickstart.ts
+++ b/src/snippets/node-viem-quickstart.ts
@@ -1,0 +1,12 @@
+// [!region testnet]
+import { env } from 'node:process'
+import { Account, createClient } from 'viem/tempo'
+
+const privateKey = env.TEMPO_TEST_PRIVATE_KEY
+if (!privateKey) throw new Error('Set TEMPO_TEST_PRIVATE_KEY')
+
+const account = Account.fromSecp256k1(privateKey as `0x${string}`)
+const client = createClient({ account, testnet: true })
+
+await client.faucet.fundSync({ account })
+// [!endregion testnet]


### PR DESCRIPTION
## Summary

- Add a minimal Node.js testnet client example to the TypeScript SDK page.
- Use a placeholder test account key, Viem's built-in Tempo testnet selection, and the testnet faucet action.
- Point scripts and servers to the typed Tempo action namespaces.
- Keep the runnable example in a shared TypeScript snippet that is checked by the docs type check.

## Why

The TypeScript SDK page explains when to use Viem, while feature guides assume that a client is already configured. This adds one canonical starting point for scripts and servers without repeating setup across individual feature guides.

The example is explicitly testnet-only. The mainnet note requires a separately funded account and removes both `testnet: true` and the faucet call.

## Validation

- TypeScript check
- Markdown output audit
- Production Vite build
- Generated HTML and Markdown inspection