### PR TITLE
docs: clarify Tempo fee setup choices

### DIFF
--- a/src/pages/docs/protocol/fees/index.mdx
+++ b/src/pages/docs/protocol/fees/index.mdx
@@ -9,6 +9,15 @@ import { Cards, Card } from 'vocs'
 
 Tempo has no native token. Instead, transaction fees—including both gas fees and priority fees—can be paid directly in stablecoins. When you send a transaction, you can choose which supported stablecoin to use for fees.
 
+## Choose a fee setup
+
+| Goal | Use |
+| --- | --- |
+| Choose the fee token for one transaction | Pass [`feeToken`](/docs/guide/payments/pay-fees-in-any-stablecoin#quick-fee-token-snippet). |
+| Set an account's persistent default fee token | Call [`client.fee.setUserToken`](/docs/guide/payments/pay-fees-in-any-stablecoin#set-a-default-user-fee-token). |
+| Have another local account pay | Pass the account as [`feePayer`](/docs/guide/tempo-transaction#fee-sponsorship). |
+| Request sponsorship from a relay or API | Configure a relay and pass [`feePayer: true`](/docs/api/fee-payer#sponsor-transaction-fees). |
+
 For a stablecoin to be accepted, it must be USD-denominated, issued as a native TIP-20 contract, and have sufficient liquidity on the native Fee AMM.
 
 Tempo uses a bounded dynamic base fee. It can fall when block gas usage is below target and rise back toward the cap when the network is busy. For a 50,000 gas transfer, the base-fee cap is about $0.0006, with a quiet-period floor around $0.00003. All fees accrue to the validator who proposes the block.

--- a/src/snippets/tempo-tx-properties.mdx
+++ b/src/snippets/tempo-tx-properties.mdx
@@ -256,6 +256,7 @@ over the transaction with a special "fee payer envelope" to commit to paying fee
     ```tsx twoslash [example.ts]
     // @noErrors
     import { client } from './viem.config'
+    import { privateKeyToAccount } from 'viem/accounts'
 
     const feePayer = privateKeyToAccount('0x...')
 
@@ -281,6 +282,7 @@ over the transaction with a special "fee payer envelope" to commit to paying fee
     ```tsx twoslash [example.ts]
     // @noErrors
     import { useSendTransactionSync } from 'wagmi'
+    import { privateKeyToAccount } from 'viem/accounts'
 
     export const feePayer = privateKeyToAccount('0x...')
 


### PR DESCRIPTION
## Summary

- Add a four-row decision table for Tempo fee configuration.
- Link per-transaction fee-token selection, the account's persistent default, a local fee-payer account, and relay/API sponsorship to their existing guides.
- Add the missing `privateKeyToAccount` imports to the existing local fee-payer examples.

## Why

Tempo exposes separate controls for choosing a fee token and choosing who pays the fee. Each path is documented, but there is no single choice point that distinguishes their behavior. The table directs readers to the existing canonical implementation for each case without duplicating those flows.

## Validation

- TypeScript check
- Production Vite build
- Generated Markdown audit
- Rendered HTML and Markdown inspection
- All linked section anchors verified