### PR TITLE
docs: improve authentication page title

### DIFF
--- a/src/lib/vocs-config-seo.test.ts
+++ b/src/lib/vocs-config-seo.test.ts
@@ -32,8 +32,8 @@ describe('vocs.config docs SEO controls', () => {
   })
 
   test('formats authored API titles when Vocs supplies routed metadata', () => {
-    expect(titleFor('/docs/api/authentication', 'Authentication')).toBe(
-      'Authentication ⋅ Tempo Docs',
+    expect(titleFor('/docs/api/authentication', 'Tempo API Authentication: API Keys & MPP')).toBe(
+      'Tempo API Authentication: API Keys & MPP ⋅ Tempo Docs',
     )
     expect(titleFor('/docs/api/json-rpc', 'Tempo JSON-RPC API: Endpoints & Methods')).toBe(
       'Tempo JSON-RPC API: Endpoints & Methods ⋅ Tempo Docs',

--- a/src/pages/docs/api/authentication.mdx
+++ b/src/pages/docs/api/authentication.mdx
@@ -1,11 +1,11 @@
 ---
-title: Authentication
+title: "Tempo API Authentication: API Keys & MPP"
 description: Authenticate requests to the Tempo blockchain API with public access, production or sandbox API keys, or MPP pay-per-request credentials.
 ---
 
 <span id="api-authentication" />
 
-# Authentication
+# Tempo API Authentication
 
 The Tempo API supports three ways to authenticate a request, so you can start without credentials and add authentication as your needs grow:
 


### PR DESCRIPTION
Adds a search-specific title and heading to Tempo API Authentication, aligning the page with neighboring API specialist pages while preserving its existing route and navigation label.