### PR TITLE
docs: strengthen tempo api internal links

### DIFF
--- a/src/pages/docs/guide/payments/accept-a-payment.mdx
+++ b/src/pages/docs/guide/payments/accept-a-payment.mdx
@@ -14,6 +14,8 @@ import { Tabs, Tab } from 'vocs'
 
 Accept stablecoin payments in your application. Learn how to receive payments, verify transactions, and reconcile payments using memos.
 
+For a hosted backend path, use the [Tempo API for indexed payment activity and webhooks](/docs/api) instead of polling chain state directly.
+
 ## Receive stablecoin payments
 
 Payments are automatically credited to the recipient's address when a transfer is executed. You don't need to do anything special to "accept" a payment, it happens automatically onchain.

--- a/src/pages/docs/quickstart/connection-details.mdx
+++ b/src/pages/docs/quickstart/connection-details.mdx
@@ -12,6 +12,8 @@ import { ConnectWallet } from '../../../components/ConnectWallet.tsx'
 
 You can connect with Tempo like you would with any other EVM chain.
 
+Use the public RPC endpoints below for direct node access. If your backend also needs indexed chain data, webhooks, funding or exchange quotes, or fee sponsorship, see the [official Tempo API overview](/docs/api).
+
 ## Connect using a Browser Wallet
 
 Click on your browser wallet below to automatically connect it to the Tempo network.

--- a/src/pages/docs/quickstart/integrate-tempo.mdx
+++ b/src/pages/docs/quickstart/integrate-tempo.mdx
@@ -12,6 +12,8 @@ Use this section when you are connecting an existing app, wallet, contract, brid
 
 Tempo is EVM-compatible and targets the **Osaka** EVM hard fork. Most Ethereum tooling works as expected, with Tempo-specific differences documented where they matter.
 
+For application backends that need indexed chain activity, webhooks, funding or exchange quotes, fee sponsorship, or managed JSON-RPC access, start with the [Tempo API overview](/docs/api).
+
 ## Connect and Fund
 
 <Cards>


### PR DESCRIPTION
Add contextual links to the Tempo API hub from integration, network connection, and payment acceptance guides, improving discovery for developers who need hosted backend services.