### PR TITLE
fix: restore client-side docs navigation

### DIFF
--- a/e2e/structured-data.test.ts
+++ b/e2e/structured-data.test.ts
@@ -67,7 +67,7 @@ test('renders generated OpenAPI page semantics into JSON-LD', async ({ request }
   expect(articles[0]).toMatchObject({
     name: 'Activities · Tempo API',
     headline: 'Activities · Tempo API',
+    description: 'A readable feed of what an account did onchain.',
   })
-  expect(articles[0]).not.toHaveProperty('description')
   expect(nodesByType(nodes, 'BreadcrumbList')).toHaveLength(1)
 })

--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -2,7 +2,7 @@
 
 import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useConfig } from 'vocs'
-import { useRouter } from 'waku'
+import { useRouter, Link as WakuLink } from 'waku'
 import { DOCS_SEARCH_PARAM } from '../lib/docs-search'
 import { AmpLogo, ClaudeLogo, CodexLogo } from './AgentLogos'
 
@@ -27,10 +27,10 @@ const TEMPO_SDK_DOCS_URL = `${DOCS_BASE_PATH}/sdk`
 
 function featurePath(slug: string) {
   const featurePaths: Record<string, string> = {
-    transactions: `${DEVELOPERS_BASE_PATH}/build/tempo-transactions`,
-    tokens: `${DEVELOPERS_BASE_PATH}/build/tip20-tokens`,
+    transactions: '/build/tempo-transactions',
+    tokens: '/build/tip20-tokens',
   }
-  return featurePaths[slug] ?? DEVELOPERS_BASE_PATH
+  return featurePaths[slug] ?? '/'
 }
 
 function isExternal(href: string) {
@@ -80,13 +80,7 @@ function isActiveMenuItem(pathname: string, item: MenuItem) {
   return !isExternal(item.href) && pathMatches(pathname, item.href)
 }
 
-function Anchor({
-  href,
-  children,
-  onFocus,
-  onPointerEnter,
-  ...props
-}: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+function Anchor({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   if (!href) return <a {...props}>{children}</a>
   if (isExternal(href)) {
     return (
@@ -96,20 +90,9 @@ function Anchor({
     )
   }
   return (
-    <a
-      {...props}
-      href={href}
-      onFocus={(event) => {
-        prefetchPath(href)
-        onFocus?.(event)
-      }}
-      onPointerEnter={(event) => {
-        prefetchPath(href)
-        onPointerEnter?.(event)
-      }}
-    >
+    <WakuLink {...props} to={href} unstable_prefetchOnEnter unstable_prefetchOnView>
       {children}
-    </a>
+    </WakuLink>
   )
 }
 
@@ -370,10 +353,10 @@ const developersMenu: MegaMenuData = {
 }
 
 const menu: MenuItem[] = [
-  { label: 'Build', href: `${DEVELOPERS_BASE_PATH}#protocol`, mega: protocolMenu },
+  { label: 'Build', href: '/#protocol', mega: protocolMenu },
   { label: 'Resources', href: `${DOCS_BASE_PATH}/guide`, mega: developersMenu },
-  { label: 'Performance', href: `${DEVELOPERS_BASE_PATH}/performance` },
-  { label: 'Blog', href: `${DEVELOPERS_BASE_PATH}/blog` },
+  { label: 'Performance', href: '/performance' },
+  { label: 'Blog', href: '/blog' },
   { label: 'Docs', href: DOCS_BASE_PATH },
 ]
 
@@ -746,10 +729,8 @@ function AgentCommandSection(props: {
         <span className="grid size-[34px] shrink-0 place-items-center bg-surface-input text-foreground">
           {icon}
         </span>
-        <a
+        <Anchor
           href={href}
-          target={external ? '_blank' : undefined}
-          rel={external ? 'noopener noreferrer' : undefined}
           onClick={onClick}
           className="relative flex min-w-0 flex-col gap-0.5 pr-5"
         >
@@ -760,7 +741,7 @@ function AgentCommandSection(props: {
           <span className="font-sans text-[13px] text-foreground/45 leading-[1.4] tracking-[0]">
             {desc}
           </span>
-        </a>
+        </Anchor>
       </div>
       {children ? <div className="mt-3 ml-[52px] space-y-3">{children}</div> : null}
     </div>

--- a/src/components/DocsSectionNav.tsx
+++ b/src/components/DocsSectionNav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import { useRouter } from 'waku'
+import { Link, useRouter } from 'waku'
 
 type SectionNavItem = {
   id: 'overview' | 'build' | 'integrate' | 'protocol' | 'tools' | 'api' | 'node'
@@ -156,11 +156,13 @@ export default function DocsSectionNav() {
               const active = isActive(pathname, item)
               return (
                 <li key={item.id}>
-                  <a
+                  <Link
                     ref={(element) => {
                       if (active) activeLinkRef.current = element
                     }}
-                    href={item.href}
+                    to={item.href}
+                    unstable_prefetchOnEnter
+                    unstable_prefetchOnView
                     aria-current={active ? 'page' : undefined}
                     className={`flex h-full items-center border-b-2 pt-0.5 font-normal font-sans text-[14px] tracking-[0] transition-colors ${
                       active
@@ -169,7 +171,7 @@ export default function DocsSectionNav() {
                     }`}
                   >
                     {item.label}
-                  </a>
+                  </Link>
                 </li>
               )
             })}

--- a/src/lib/rsc-route-normalization.test.ts
+++ b/src/lib/rsc-route-normalization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { normalizeProxiedRscFetch } from '../pages/_layout'
 import { normalizeRscFetchUrl } from './rsc-route-normalization'
 
@@ -39,6 +39,33 @@ describe('normalizeRscFetchUrl', () => {
 })
 
 describe('normalizeProxiedRscFetch', () => {
+  it('normalizes the exact developers mount before Waku initializes', () => {
+    const replaceState = vi.fn()
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        __tempoNormalizeProxiedRscFetch: false,
+        fetch: vi.fn(),
+        history: { replaceState, state: { key: 'value' } },
+        location: {
+          hash: '#start',
+          hostname: 'tempo.xyz',
+          href: 'https://tempo.xyz/developers?tab=docs#start',
+          origin: 'https://tempo.xyz',
+          pathname: '/developers',
+          search: '?tab=docs',
+        },
+      },
+    })
+
+    try {
+      Function(normalizeProxiedRscFetch)()
+      expect(replaceState).toHaveBeenCalledWith({ key: 'value' }, '', '/developers/?tab=docs#start')
+    } finally {
+      Reflect.deleteProperty(globalThis, 'window')
+    }
+  })
+
   it.each([
     [
       'rewrites cross-origin RSC requests to the current origin',

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -2,6 +2,17 @@ import type { PropsWithChildren } from 'react'
 
 export const normalizeProxiedRscFetch = `
 (() => {
+  if (
+    window.location.hostname === 'tempo.xyz' &&
+    window.location.pathname === '/developers'
+  ) {
+    window.history.replaceState(
+      window.history.state,
+      '',
+      window.location.pathname + '/' + window.location.search + window.location.hash,
+    );
+  }
+
   if (window.__tempoNormalizeProxiedRscFetch) return;
   window.__tempoNormalizeProxiedRscFetch = true;
   const originalFetch = window.fetch.bind(window);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       blogPostsPlugin(),
       marketingPages(),
-      developersProxyRouteNormalization(),
+      developersProxyClientBasePath(),
       vocs(),
       Icons({ compiler: 'jsx', jsx: 'react' }),
       react(),
@@ -56,98 +56,20 @@ export default defineConfig(({ mode }) => {
 
 const marketingRoutes = ['/', '/build', '/blog', '/performance']
 
-function developersProxyRouteNormalization(): Plugin {
+function developersProxyClientBasePath(): Plugin {
   return {
-    name: 'tempo-developers-proxy-route-normalization',
+    name: 'tempo-developers-proxy-client-base-path',
     enforce: 'post',
-    transform(code, id) {
-      if (id !== '\0virtual:vite-rsc-waku/client-entry') return
-
-      return code
-        .replace(
-          "import { Router } from 'waku/router/client';",
-          "import { Router, unstable_parseRoute } from 'waku/router/client';",
-        )
-        .replace(
-          'const rootElement = createElement(StrictMode, null, createElement(Router));',
-          `const developersPrefix = '/developers';
-const shouldUseDevelopersPrefix = () => window.location.pathname === developersPrefix || window.location.pathname.startsWith(developersPrefix + '/');
-const publicDevelopersPath = (path) => {
-  if (path === '/') return developersPrefix;
-  if (path.startsWith(developersPrefix + '/')) return path;
-  return developersPrefix + path;
-};
-const normalizeDevelopersRoute = (route) => {
-  const routePath = typeof route.path === 'string' ? route.path : '/';
-  if (routePath === '/developers') return { ...route, path: '/' };
-  if (routePath.startsWith('/developers/')) {
-    return { ...route, path: routePath.slice('/developers'.length) || '/' };
-  }
-  return route;
-};
-const getUnprefixedInternalLink = (event) => {
-  if (!shouldUseDevelopersPrefix()) return;
-  const link = event.target instanceof Element ? event.target.closest('a[href^="/"]') : null;
-  if (!(link instanceof HTMLAnchorElement)) return;
-  const href = link.getAttribute('href');
-  if (!href || href.startsWith('//') || href.startsWith(developersPrefix + '/')) return;
-  if (href.startsWith('/assets/') || href.startsWith('/fonts/') || href.startsWith('/RSC/')) return;
-  return { link, href };
-};
-const originalFetch = window.fetch.bind(window);
-window.fetch = async (input, init) => {
-  const response = await originalFetch(input, init);
-  if (!shouldUseDevelopersPrefix()) return response;
-  const requestUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-  if (!requestUrl.includes('/RSC/')) return response;
-  const clone = response.clone();
-  const contentType = clone.headers.get('content-type') || '';
-  if (!contentType.includes('text/plain')) return response;
-  const text = await clone.text();
-  const normalized = text
-    .replaceAll('route:/developers/', 'route:/')
-    .replaceAll('route:/developers"', 'route:/"')
-    .replaceAll('route:/developers,', 'route:/,')
-    .replaceAll('route:/developers\\n', 'route:/\\n');
-  if (normalized === text) return response;
-  return new Response(normalized, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  });
-};
-document.addEventListener(
-  'click',
-  (event) => {
-    const target = getUnprefixedInternalLink(event);
-    if (!target) return;
-    event.preventDefault();
-    event.stopImmediatePropagation();
-    window.location.assign(publicDevelopersPath(target.href));
-  },
-  true,
-);
-for (const eventName of ['pointerover', 'mouseover']) {
-  document.addEventListener(
-    eventName,
-    (event) => {
-      if (!getUnprefixedInternalLink(event)) return;
-      event.stopImmediatePropagation();
-    },
-    true,
-  );
-}
-
-const initialRoute = normalizeDevelopersRoute(unstable_parseRoute(new URL(window.location.href)));
-const rootElement = createElement(
-  StrictMode,
-  null,
-  createElement(Router, {
-    initialRoute,
-    unstable_routeInterceptor: normalizeDevelopersRoute,
-  }),
-);`,
-        )
+    configEnvironment(name) {
+      if (name !== 'client' || process.env.VERCEL_ENV !== 'production') return
+      // tempo.xyz strips /developers before requests reach Waku.
+      // Other production hosts serve the same unprefixed routes directly.
+      return {
+        define: {
+          'import.meta.env.WAKU_CONFIG_BASE_PATH':
+            "(window.location.hostname === 'tempo.xyz' ? '/developers/' : '/')",
+        },
+      }
     },
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       blogPostsPlugin(),
       marketingPages(),
-      developersProxyClientBasePath(),
+      developersProxyBasePath(),
       vocs(),
       Icons({ compiler: 'jsx', jsx: 'react' }),
       react(),
@@ -56,18 +56,20 @@ export default defineConfig(({ mode }) => {
 
 const marketingRoutes = ['/', '/build', '/blog', '/performance']
 
-function developersProxyClientBasePath(): Plugin {
+function developersProxyBasePath(): Plugin {
   return {
-    name: 'tempo-developers-proxy-client-base-path',
+    name: 'tempo-developers-proxy-base-path',
     enforce: 'post',
     configEnvironment(name) {
-      if (name !== 'client' || process.env.VERCEL_ENV !== 'production') return
+      if (process.env.VERCEL_ENV !== 'production') return
       // tempo.xyz strips /developers before requests reach Waku.
-      // Other production hosts serve the same unprefixed routes directly.
+      // Production SSR targets that canonical mount; clients on other hosts stay unprefixed.
       return {
         define: {
           'import.meta.env.WAKU_CONFIG_BASE_PATH':
-            "(window.location.hostname === 'tempo.xyz' ? '/developers/' : '/')",
+            name === 'client'
+              ? "(window.location.hostname === 'tempo.xyz' ? '/developers/' : '/')"
+              : JSON.stringify('/developers/'),
         },
       }
     },


### PR DESCRIPTION
Use Waku’s hostname-aware client base path instead of intercepting internal links. This preserves client navigation at `tempo.xyz/developers` while keeping direct and preview hosts unprefixed.