### PR TITLE
Improve docs search titles and headings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Before finishing docs-only changes, run at least `pnpm check:types` when practic
    ```yaml
    ---
    title: Page Title
+   seoTitle: Search-specific title | Tempo Docs
    description: Concise active-voice description for search and social previews.
    ---
    ```
@@ -168,6 +169,7 @@ Each step should be actionable and concrete. Keep long conceptual background out
 ## SEO and Social Text
 
 - Every page needs `title` and `description` frontmatter.
+- Use optional `seoTitle` frontmatter when the exact browser title should differ from the visible H1. The Vocs title template emits it verbatim, while social metadata, structured data, search, and generated AI files continue to use `title`.
 - Keep `title` concise and specific.
 - Keep `description` active, concrete, and useful for search/social previews.
 - Do not start descriptions with "This page".

--- a/e2e/seo-head.test.ts
+++ b/e2e/seo-head.test.ts
@@ -68,17 +68,31 @@ const cases: {
   },
   {
     path: '/docs',
-    title: 'Tempo Documentation ⋅ Tempo Docs',
-    ogTitle: 'Tempo Documentation',
+    title: 'Tempo Developer Docs: APIs, SDKs &amp; Guides',
+    ogTitle: 'Tempo developer documentation',
     descriptionIncludes: 'Tempo docs for integration paths',
     ogImageIncludes: '/og-docs.png',
   },
   {
     path: '/docs/guide/payments/send-a-payment',
-    title: 'Send a Payment ⋅ Tempo Docs',
-    ogTitle: 'Send a Payment',
+    title: 'Send a Stablecoin Payment on Tempo | Docs',
+    ogTitle: 'How to send a stablecoin payment on Tempo',
     descriptionIncludes: 'stablecoin payments between accounts',
     ogImageIncludes: 'subsection=PAYMENTS',
+  },
+  {
+    path: '/docs/api',
+    title: 'Start with the Tempo API | Tempo Docs',
+    ogTitle: 'Tempo API',
+    descriptionIncludes: 'official Tempo blockchain API',
+    ogImageIncludes: 'section=API',
+  },
+  {
+    path: '/docs/api/console',
+    title: 'How to Use the Tempo API Console | Docs',
+    ogTitle: 'Using the Tempo API Console',
+    descriptionIncludes: 'create projects and API keys',
+    ogImageIncludes: 'section=API',
   },
 ]
 

--- a/e2e/structured-data.test.ts
+++ b/e2e/structured-data.test.ts
@@ -32,8 +32,8 @@ test('renders authored docs metadata and breadcrumbs into JSON-LD', async ({ req
 
   expect(articles).toHaveLength(1)
   expect(articles[0]).toMatchObject({
-    name: 'Send a Payment',
-    headline: 'Send a Payment',
+    name: 'How to send a stablecoin payment on Tempo',
+    headline: 'How to send a stablecoin payment on Tempo',
     description:
       'Send stablecoin payments between accounts on Tempo. Include optional memos for reconciliation and tracking with TypeScript, Rust, or Solidity.',
   })
@@ -41,9 +41,22 @@ test('renders authored docs metadata and breadcrumbs into JSON-LD', async ({ req
   expect(breadcrumbs[0]?.itemListElement).toEqual(
     expect.arrayContaining([
       expect.objectContaining({ name: 'Tempo Docs' }),
-      expect.objectContaining({ name: 'Send a Payment' }),
+      expect.objectContaining({ name: 'How to send a stablecoin payment on Tempo' }),
     ]),
   )
+})
+
+test('keeps audited OpenAPI browser and structured-data titles separate', async ({ request }) => {
+  const nodes = await structuredData(request, '/docs/api/console')
+  const articles = nodesByType(nodes, 'TechArticle')
+
+  expect(articles).toHaveLength(1)
+  expect(articles[0]).toMatchObject({
+    name: 'Using the Tempo API Console',
+    headline: 'Using the Tempo API Console',
+    description:
+      'Use Tempo API Console to create projects and API keys, switch environments, monitor usage, configure billing, and manage organization access in one place.',
+  })
 })
 
 test('renders authored OpenAPI guide metadata into JSON-LD', async ({ request }) => {

--- a/src/lib/docs-seo-metadata.test.ts
+++ b/src/lib/docs-seo-metadata.test.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+const docsRoot = path.resolve('src/pages/docs')
+
+const openApiTitleFiles = [
+  'api.mdx',
+  'api/console.mdx',
+  'api/console/api-keys.mdx',
+  'api/console/projects-and-environments.mdx',
+  'api/console/team.mdx',
+  'api/console/usage-and-billing.mdx',
+  'api/conventions.mdx',
+  'api/errors.mdx',
+  'api/pagination.mdx',
+  'api/rate-limits.mdx',
+  'api/transactions-and-transfers.mdx',
+  'api/transactions.mdx',
+  'api/transfers.mdx',
+  'api/typed-client.mdx',
+  'api/versioning-policy.mdx',
+]
+
+const preservedJxomFiles = [
+  'api/authentication.mdx',
+  'api/fee-payer.mdx',
+  'api/indexer-api.mdx',
+  'api/json-rpc.mdx',
+]
+
+function mdxFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const filepath = path.join(directory, entry.name)
+    if (entry.isDirectory()) return mdxFiles(filepath)
+    return entry.isFile() && filepath.endsWith('.mdx') ? [filepath] : []
+  })
+}
+
+function frontmatterString(source: string, key: string): string | undefined {
+  const frontmatter = source.match(/^---\n([\s\S]*?)\n---/)?.[1]
+  const serialized = frontmatter?.match(new RegExp(`^${key}: (.+)$`, 'm'))?.[1]
+  if (!serialized) return undefined
+  return JSON.parse(serialized)
+}
+
+function authoredH1(source: string): string | undefined {
+  return source.match(/^# (.+?)(?:\s+\{#[^}]+\})?$/m)?.[1].replaceAll('`', '')
+}
+
+describe('docs SEO metadata', () => {
+  test('keeps audited page titles, H1s, and SEO titles aligned', () => {
+    const auditedPages = mdxFiles(docsRoot)
+      .map((file) => ({ file, source: fs.readFileSync(file, 'utf8') }))
+      .filter(({ source }) => /^seoTitle:/m.test(source))
+
+    expect(auditedPages).toHaveLength(106)
+
+    for (const { file, source } of auditedPages) {
+      const title = frontmatterString(source, 'title')
+      const seoTitle = frontmatterString(source, 'seoTitle')
+
+      expect(title, file).toBeTruthy()
+      expect(authoredH1(source), file).toBe(title)
+      expect(seoTitle, file).toBeTruthy()
+      expect(seoTitle, file).not.toContain('—')
+      expect(authoredH1(source), file).not.toContain('—')
+    }
+  })
+
+  test('keeps jxom-authored API metadata outside the audit rewrite', () => {
+    for (const file of preservedJxomFiles) {
+      const source = fs.readFileSync(path.join(docsRoot, file), 'utf8')
+      expect(frontmatterString(source, 'seoTitle'), file).toBeUndefined()
+    }
+  })
+
+  test('works around OpenAPI title overrides without leaking tags into source titles', () => {
+    for (const file of openApiTitleFiles) {
+      const source = fs.readFileSync(path.join(docsRoot, file), 'utf8')
+      const seoTitle = frontmatterString(source, 'seoTitle')
+      const literalTitle = `<title>${seoTitle}</title>`
+
+      expect(seoTitle, file).toBeTruthy()
+      expect(source.lastIndexOf(literalTitle), file).toBeGreaterThan(source.lastIndexOf('<OpenApi'))
+    }
+  })
+})

--- a/src/lib/vocs-config-seo.test.ts
+++ b/src/lib/vocs-config-seo.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'vitest'
 import vocsConfig from '../../vocs.config'
 
-function titleFor(path: string, title: string) {
+function titleFor(path: string, title: string, seoTitle?: string) {
   expect(typeof vocsConfig.titleTemplate).toBe('function')
   const template =
     typeof vocsConfig.titleTemplate === 'function'
       ? vocsConfig.titleTemplate(path, {
-          frontmatter: { title },
+          frontmatter: { seoTitle, title },
           siteTitle: vocsConfig.title,
           title,
         })
@@ -17,6 +17,23 @@ function titleFor(path: string, title: string) {
 }
 
 describe('vocs.config docs SEO controls', () => {
+  test('uses exact authored SEO titles without changing page titles', () => {
+    expect(
+      titleFor(
+        '/docs/guide/payments/send-a-payment',
+        'How to send a stablecoin payment on Tempo',
+        'Send a Stablecoin Payment on Tempo | Docs',
+      ),
+    ).toBe('Send a Stablecoin Payment on Tempo | Docs')
+    expect(
+      titleFor(
+        '/docs',
+        'Tempo developer documentation',
+        'Tempo Developer Docs: APIs, SDKs & Guides',
+      ),
+    ).toBe('Tempo Developer Docs: APIs, SDKs & Guides')
+  })
+
   test('uses Tempo Docs title suffix for docs pages', () => {
     expect(titleFor('/docs', 'Documentation')).toBe('Tempo Documentation ⋅ Tempo Docs')
     expect(titleFor('/docs/guide/payments/send-a-payment', 'Send a Payment')).toBe(

--- a/src/pages/docs/api.mdx
+++ b/src/pages/docs/api.mdx
@@ -1,5 +1,6 @@
 ---
-title: Tempo API
+title: "Tempo API"
+seoTitle: "Start with the Tempo API | Tempo Docs"
 description: Build stablecoin payment apps with the official Tempo blockchain API for account activity, webhooks, funding, exchange quotes, fee sponsorship, and indexed SQL.
 ---
 
@@ -89,7 +90,7 @@ Check out an endpoint below and click "Try" to run it directly against the API. 
 
 Browse the [complete Tempo API reference](/docs/api/reference) to find every API group and endpoint.
 
-<title>Tempo API ⋅ Tempo Docs</title>
+<title>Start with the Tempo API | Tempo Docs</title>
 
 ## Next API integration steps
 

--- a/src/pages/docs/api/console.mdx
+++ b/src/pages/docs/api/console.mdx
@@ -1,11 +1,12 @@
 ---
-title: Using Tempo API Console
+title: "Using the Tempo API Console"
+seoTitle: "How to Use the Tempo API Console | Docs"
 description: Use Tempo API Console to create projects and API keys, switch environments, monitor usage, configure billing, and manage organization access in one place.
 ---
 
 import { Card, Cards } from 'vocs'
 
-# Using Tempo API Console
+# Using the Tempo API Console
 
 [Tempo API Console](https://console.tempo.xyz) is the control UI for your Tempo API account. Use it to organize integrations, issue credentials, monitor API usage and sponsored transactions, configure billing, and manage access to your organization.
 
@@ -101,3 +102,5 @@ Select [**Usage**](https://console.tempo.xyz/?to=/:org/usage%3Fenv%3Dsandbox) an
     icon="lucide:users"
   />
 </Cards>
+
+<title>How to Use the Tempo API Console | Docs</title>

--- a/src/pages/docs/api/console/api-keys.mdx
+++ b/src/pages/docs/api/console/api-keys.mdx
@@ -1,9 +1,10 @@
 ---
-title: Manage API Keys
+title: "How to create and manage API keys"
+seoTitle: "Create & Manage API Keys | Tempo Docs"
 description: Create project-scoped Tempo API keys, select permissions, store tokens securely, authenticate requests, and safely rotate or revoke credentials when needed.
 ---
 
-# Manage API Keys
+# How to create and manage API keys
 
 API keys authenticate an integration and attribute its usage to a project. Every key is fixed to the production or sandbox environment in which it was created.
 
@@ -93,3 +94,5 @@ Return to [**API Keys**](https://console.tempo.xyz/?to=/:org/api-keys), open the
 | The plaintext token was lost | Create a replacement key. Existing tokens cannot be revealed again. |
 
 For complete credential and chain-selection behavior, see [API authentication](/docs/api/authentication).
+
+<title>Create & Manage API Keys | Tempo Docs</title>

--- a/src/pages/docs/api/console/projects-and-environments.mdx
+++ b/src/pages/docs/api/console/projects-and-environments.mdx
@@ -1,9 +1,10 @@
 ---
-title: Projects and Environments
+title: "Managing projects and environments in the API Console"
+seoTitle: "Tempo API Projects & Environments | Docs"
 description: Organize Tempo API integrations into projects and keep production credentials, usage, billing, and sponsored transactions separate from sandbox activity.
 ---
 
-# Projects and Environments
+# Managing projects and environments in the API Console
 
 Projects identify the apps and integrations using your Tempo API organization. Environments separate production activity from sandbox testing without requiring a second organization.
 
@@ -66,3 +67,5 @@ API Keys and Usage are organization-wide by default. Use their project filter to
 - **Billing** remains organization-wide and environment-specific.
 
 Unknown or removed project filters fall back to the organization-wide view.
+
+<title>Tempo API Projects & Environments | Docs</title>

--- a/src/pages/docs/api/console/team.mdx
+++ b/src/pages/docs/api/console/team.mdx
@@ -1,9 +1,10 @@
 ---
-title: Teams and Access
+title: "Managing teams and access in the API Console"
+seoTitle: "Teams & Access in the API Console | Docs"
 description: Invite people to a Tempo API organization, assign owner, admin, or member roles, review pending invitations, and safely remove organization access when needed.
 ---
 
-# Teams and Access
+# Managing teams and access in the API Console
 
 The Team page controls who can access an organization in Tempo API Console. Membership applies across the organization's projects and both environments.
 
@@ -56,3 +57,5 @@ Role changes take effect for organization access after the update succeeds. They
 - **Leave an organization:** open your own actions menu and select **Leave organization**. The last owner cannot leave until another owner exists.
 
 Removing a member does not automatically revoke project API keys. Review [**API Keys**](https://console.tempo.xyz/?to=/:org/api-keys) separately when offboarding someone who managed integration credentials.
+
+<title>Teams & Access in the API Console | Docs</title>

--- a/src/pages/docs/api/console/usage-and-billing.mdx
+++ b/src/pages/docs/api/console/usage-and-billing.mdx
@@ -1,9 +1,10 @@
 ---
-title: Usage and Billing
+title: "Monitoring your API usage and billing"
+seoTitle: "Monitor API Usage & Billing | Tempo Docs"
 description: Monitor Tempo API requests and sponsored transactions, add payment methods, and configure organization spend limits and per-transaction sponsorship caps.
 ---
 
-# Usage and Billing
+# Monitoring your API usage and billing
 
 Tempo API Console reports API activity and manages billing for fee sponsorship. Usage and billing are organization-wide, with separate state for production and sandbox.
 
@@ -72,3 +73,5 @@ Production fee sponsorship requires an active billing source. A spend or sponsor
 5. Review the Billing page and adjust spend or sponsorship limits if needed.
 
 See [API rate limits](/docs/api/rate-limits) for request quotas and response headers. For sponsored transaction integration, follow the [fee sponsorship guide](https://viem.sh/tempo/guides/sponsor-fees#sponsor-via-a-relay).
+
+<title>Monitor API Usage & Billing | Tempo Docs</title>

--- a/src/pages/docs/api/conventions.mdx
+++ b/src/pages/docs/api/conventions.mdx
@@ -1,9 +1,10 @@
 ---
-title: Conventions
+title: "Tempo API conventions and base URL"
+seoTitle: "API Conventions & Base URL | Tempo Docs"
 description: Formatting standards and shared patterns used across the Tempo API — base URL, chains, identifiers, amounts, timestamps, request IDs, errors, and rate limits.
 ---
 
-# API Conventions
+# Tempo API conventions and base URL
 
 The Tempo API follows consistent formatting rules for identifiers, amounts, timestamps, and shared query parameters. This page is a quick reference for the patterns you'll encounter on every endpoint.
 
@@ -99,3 +100,5 @@ Errors use a single, consistent envelope with a conventional HTTP status code an
 ## API rate-limit conventions
 
 Every response carries standard `RateLimit-*` headers, and requests that exceed quota receive `429 Too Many Requests` with a `Retry-After` header. See [Rate Limits](/docs/api/rate-limits) for the full model and best practices.
+
+<title>API Conventions & Base URL | Tempo Docs</title>

--- a/src/pages/docs/api/errors.mdx
+++ b/src/pages/docs/api/errors.mdx
@@ -1,9 +1,10 @@
 ---
-title: Errors
+title: "Tempo API errors and response format"
+seoTitle: "API Errors & Response Format | Docs"
 description: How the Tempo API signals errors, including HTTP status codes, the error envelope, and the full catalog of machine-readable error codes.
 ---
 
-# API Errors
+# Tempo API errors and response format
 
 The Tempo API uses conventional HTTP status codes to indicate the result of a request:
 
@@ -124,3 +125,5 @@ Something went wrong on Tempo's side. These are transient. Retry with [exponenti
 :::warning
 For non-idempotent requests (such as `POST`), a `5xx` response does not guarantee the operation failed; it may have succeeded on the backend. Treat the outcome as **unknown** and reconcile state before blindly retrying. Read requests (`GET`) are always safe to retry.
 :::
+
+<title>API Errors & Response Format | Docs</title>

--- a/src/pages/docs/api/pagination.mdx
+++ b/src/pages/docs/api/pagination.mdx
@@ -1,9 +1,10 @@
 ---
-title: Pagination
+title: "Tempo API pagination: two modes explained"
+seoTitle: "API Pagination Modes | Tempo Docs"
 description: Page through Tempo API list endpoints with cursors, page numbers, and optional total counts.
 ---
 
-# API Pagination
+# Tempo API pagination: two modes explained
 
 Tempo list endpoints share one pagination contract. Use **cursor** pagination for stable traversal and deep reads. Use **page** pagination only when an endpoint supports it and you need a shallow, page-numbered UI.
 
@@ -152,3 +153,5 @@ The count is computed by a capped subquery up to `10,000` matched rows:
 - Pass cursors back verbatim, and URL-encode them when placing them in a query string.
 - Stop only when `nextCursor` is `null`.
 - Use page pagination only for shallow UI navigation where duplicate or skipped rows on a live feed are acceptable.
+
+<title>API Pagination Modes | Tempo Docs</title>

--- a/src/pages/docs/api/rate-limits.mdx
+++ b/src/pages/docs/api/rate-limits.mdx
@@ -1,9 +1,10 @@
 ---
-title: Rate Limits
+title: "Tempo API rate limits and quota structure"
+seoTitle: "API Rate Limits & Quota Structure | Docs"
 description: How the Tempo API rate limits requests, the headers it returns, and best practices for staying within quota.
 ---
 
-# API Rate Limits
+# Tempo API rate limits and quota structure
 
 The Tempo API enforces rate limits to ensure fair usage and system stability. Limits are counted in **fixed one-minute windows**, and every response reports your current quota in `RateLimit-*` headers.
 
@@ -98,3 +99,5 @@ async function withRetry<T>(fn: () => Promise<Response>): Promise<Response> {
 ### Authenticate for higher API quotas
 
 Anonymous traffic is held to the lower IP-based limit. Send an [API key](/docs/api/authentication) to get a per-key, per-scope quota, and request a higher limit if your workload needs it.
+
+<title>API Rate Limits & Quota Structure | Docs</title>

--- a/src/pages/docs/api/transactions-and-transfers.mdx
+++ b/src/pages/docs/api/transactions-and-transfers.mdx
@@ -1,9 +1,10 @@
 ---
-title: Transactions & Transfers
+title: "The data model for transactions and transfers"
+seoTitle: "Transactions & Transfers Data Model | Docs"
 description: Understand the Tempo API model for transactions and transfers.
 ---
 
-# Transactions & Transfers
+# The data model for transactions and transfers
 
 Transactions and transfers are the two most common resources in the Tempo API, and they are easy to confuse. They describe different things: a **transaction** is what a user submits to the chain, while a **transfer** is a token movement that results from executing one.
 
@@ -38,3 +39,5 @@ A transaction that calls a contract might emit several transfers (for example, a
 | **Endpoint** | [`/v1/transactions`](/docs/api/transactions) | [`/v1/transfers`](/docs/api/transfers) |
 | **Use it for** | Inspecting submitted transactions, fees, and status | Tracking who received which tokens, and reconciling balances |
 | **Key link** | Its hash appears on every transfer it produced | `transactionHash` points back to its transaction |
+
+<title>Transactions & Transfers Data Model | Docs</title>

--- a/src/pages/docs/api/transactions.mdx
+++ b/src/pages/docs/api/transactions.mdx
@@ -1,12 +1,15 @@
 ---
-title: Transactions
+title: "Working with transactions via the Tempo API"
+seoTitle: "Tempo Transactions API Reference | Docs"
 description: List and inspect transactions submitted to Tempo.
 ---
 
-# Transactions
+# Working with transactions via the Tempo API
 
 A transaction is what a user submits to Tempo: a signed envelope that moves value or calls a contract. One transaction can produce zero, one, or many token [transfers](/docs/api/transfers). Query [`/v1/transfers`](/docs/api/transfers) to list the token movements it caused.
 
 :::info
 See [Transactions & Transfers](/docs/api/transactions-and-transfers) for how a transaction relates to the transfers it produces.
 :::
+
+<title>Tempo Transactions API Reference | Docs</title>

--- a/src/pages/docs/api/transfers.mdx
+++ b/src/pages/docs/api/transfers.mdx
@@ -1,12 +1,15 @@
 ---
-title: Transfers
+title: "Transferring stablecoins with the Tempo API"
+seoTitle: "Stablecoin Transfers API | Tempo Docs"
 description: List token transfer events across Tempo — the token movements produced by executing transactions.
 ---
 
-# Transfers
+# Transferring stablecoins with the Tempo API
 
 A transfer is an effect of executing a [transaction](/docs/api/transactions): a TIP-20 token moved from one account to another, optionally with a payment memo. Multiple transfers can come from one transaction, and some transactions produce none; each transfer links back to its transaction via `transactionHash`.
 
 :::info
 See [Transactions & Transfers](/docs/api/transactions-and-transfers) for how a transfer relates to the transaction that produced it.
 :::
+
+<title>Stablecoin Transfers API | Tempo Docs</title>

--- a/src/pages/docs/api/typed-client.mdx
+++ b/src/pages/docs/api/typed-client.mdx
@@ -1,9 +1,10 @@
 ---
-title: Tempo API Typed Client
+title: "Tempo API typed client for TypeScript"
+seoTitle: "TypeScript Typed Client | Tempo Docs"
 description: Use the Tempo API Typed Client to call REST and JSON-RPC endpoints with autocomplete, API key headers, status narrowing, and error handling in TypeScript.
 ---
 
-# Tempo API Typed Client
+# Tempo API typed client for TypeScript
 
 Use the Tempo API Typed Client for endpoint autocomplete and full end-to-end type-safety across API parameters, response bodies, statuses, and errors.
 
@@ -170,3 +171,4 @@ if (response.status === 200) {
 }
 ```
 
+<title>TypeScript Typed Client | Tempo Docs</title>

--- a/src/pages/docs/api/versioning-policy.mdx
+++ b/src/pages/docs/api/versioning-policy.mdx
@@ -1,9 +1,10 @@
 ---
-title: Versioning Policy
+title: "Tempo API versioning policy"
+seoTitle: "Tempo API Versioning Policy | Docs"
 description: Learn how Tempo API versions, breaking changes, deprecations, and sunset notices work.
 ---
 
-# Versioning Policy
+# Tempo API versioning policy
 
 The Tempo API evolves without breaking existing integrations whenever practical. This page explains how the API is versioned, what we consider a breaking change, and how changes are communicated.
 
@@ -61,3 +62,5 @@ Link: <https://tempo.xyz/developers/docs/api/versioning-policy>; rel="deprecatio
 
 - All breaking changes and meaningful additions are recorded in the changelog with affected endpoints, migration notes, and any sunset date.
 - Deprecated operations and fields are flagged in this OpenAPI document.
+
+<title>Tempo API Versioning Policy | Docs</title>

--- a/src/pages/docs/build.mdx
+++ b/src/pages/docs/build.mdx
@@ -1,5 +1,6 @@
 ---
-title: Build on Tempo
+title: "Build on Tempo"
+seoTitle: "Build on Tempo: Choose Your Path | Docs"
 description: Choose Tempo build guides for stablecoin payments, issuance, exchange, private zones, agentic payments, fee sponsorship, and production workflows for launch.
 ---
 

--- a/src/pages/docs/cli/download.mdx
+++ b/src/pages/docs/cli/download.mdx
@@ -1,9 +1,10 @@
 ---
-title: tempo download
+title: "tempo download: CLI command reference"
+seoTitle: "tempo download: CLI Reference | Docs"
 description: Download chain snapshots for faster initial sync of a Tempo node.
 ---
 
-# `tempo download`
+# `tempo download`: CLI command reference
 
 Download chain snapshots for faster initial sync. Fetches MDBX state and static files, and generates a `reth.toml` prune config for the target data directory.
 

--- a/src/pages/docs/cli/index.mdx
+++ b/src/pages/docs/cli/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Tempo CLI
+title: "Tempo CLI: installation and usage"
+seoTitle: "Install & Use the Tempo CLI | Docs"
 description: Use the Tempo CLI for Tempo Wallet CLI, paid HTTP requests with MPP, and Tempo node operations from your terminal.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Tempo CLI
+# Tempo CLI: installation and usage
 
 The `tempo` binary covers three core workflows:
 

--- a/src/pages/docs/cli/node.mdx
+++ b/src/pages/docs/cli/node.mdx
@@ -1,11 +1,12 @@
 ---
-title: tempo node
+title: "tempo node: CLI command reference"
+seoTitle: "tempo node: CLI Reference | Tempo Docs"
 description: Command reference for running a Tempo node.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# `tempo node`
+# `tempo node`: CLI command reference
 
 Run a Tempo node. For faster initial sync, first download a snapshot with [`tempo download`](/docs/cli/download). For operational setup guides — system requirements, systemd configs, monitoring, validator onboarding — see [Run a Tempo Node](/docs/guide/node).
 

--- a/src/pages/docs/cli/request.mdx
+++ b/src/pages/docs/cli/request.mdx
@@ -1,11 +1,12 @@
 ---
-title: tempo request
+title: "tempo request: CLI command reference"
+seoTitle: "tempo request: CLI Reference | Docs"
 description: Make curl-compatible HTTP requests that automatically negotiate Machine Payments Protocol payments.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# `tempo request`
+# `tempo request`: CLI command reference
 
 A curl-compatible HTTP client that handles [Machine Payments Protocol](https://mpp.dev/overview) negotiation transparently. When a server responds with [`402 Payment Required`](https://mpp.dev/protocol/http-402), `tempo request` reads the [challenge](https://mpp.dev/protocol/challenges), signs and submits the payment onchain, then retries with the [credential](https://mpp.dev/protocol/credentials) in one command.
 

--- a/src/pages/docs/cli/wallet.mdx
+++ b/src/pages/docs/cli/wallet.mdx
@@ -1,11 +1,12 @@
 ---
-title: Tempo Wallet CLI
+title: "Tempo Wallet CLI: setting up and using it"
+seoTitle: "Tempo Wallet CLI: Setup & Use | Docs"
 description: Use Tempo Wallet CLI from the terminal for wallet auth, balances, access keys, MPP service discovery, paid requests, and agent workflows.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Tempo Wallet CLI
+# Tempo Wallet CLI: setting up and using it
 
 Tempo Wallet CLI is the command-line way to use [Tempo Wallet](https://wallet.tempo.xyz) from scripts, terminals, and AI agents. Use `tempo wallet` to authenticate, manage balances and access keys, discover [MPP](https://mpp.dev/overview) services, fund token or credit balances, and manage payment sessions. Use [`tempo request`](/docs/cli/request) when you want the CLI to make the paid HTTP call.
 

--- a/src/pages/docs/ecosystem/block-explorers.mdx
+++ b/src/pages/docs/ecosystem/block-explorers.mdx
@@ -1,9 +1,10 @@
 ---
-title: Block Explorers
+title: "Block explorers: using the Tempo Explorer"
+seoTitle: "Tempo Explorer: Browse Block Data | Docs"
 description: View transactions, blocks, accounts, and token activity on the Tempo network with block explorers.
 ---
 
-# Block Explorers
+# Block explorers: using the Tempo Explorer
 
 View transactions, blocks, accounts, and token activity on Tempo.
 

--- a/src/pages/docs/ecosystem/bridges.mdx
+++ b/src/pages/docs/ecosystem/bridges.mdx
@@ -1,9 +1,10 @@
 ---
-title: Bridges & Exchanges
+title: "Bridges & exchanges for stablecoin liquidity"
+seoTitle: "Stablecoin Bridges & Exchanges | Docs"
 description: Move assets to and from Tempo with cross-chain bridges and access deep DEX liquidity with exchange infrastructure.
 ---
 
-# Bridges & Exchanges
+# Bridges & exchanges for stablecoin liquidity
 
 Move assets to and from Tempo with cross-chain bridges and exchange infrastructure.
 

--- a/src/pages/docs/ecosystem/data-analytics.mdx
+++ b/src/pages/docs/ecosystem/data-analytics.mdx
@@ -1,9 +1,10 @@
 ---
-title: Data & Analytics
+title: "Data and analytics providers"
+seoTitle: "Data & Analytics for Tempo | Docs"
 description: Query blockchain data on Tempo with indexers, analytics platforms, oracles, and monitoring tools.
 ---
 
-# Data & Analytics
+# Data and analytics providers
 
 Query blockchain data with indexers, analytics platforms, and monitoring tools.
 

--- a/src/pages/docs/ecosystem/node-infrastructure.mdx
+++ b/src/pages/docs/ecosystem/node-infrastructure.mdx
@@ -1,9 +1,10 @@
 ---
-title: Node Infrastructure
+title: "Node infrastructure providers"
+seoTitle: "Node Infrastructure for Tempo | Docs"
 description: Connect to Tempo with reliable RPC endpoints and managed node services from infrastructure partners.
 ---
 
-# Node Infrastructure
+# Node infrastructure providers
 
 Connect to Tempo with reliable RPC endpoints and managed node services.
 

--- a/src/pages/docs/ecosystem/orchestration.mdx
+++ b/src/pages/docs/ecosystem/orchestration.mdx
@@ -1,9 +1,10 @@
 ---
-title: Issuance & Orchestration
+title: "Issuance & orchestration for stablecoins"
+seoTitle: "Stablecoin Issuance & Orchestration | Docs"
 description: Move money globally between local currencies and stablecoins. Issue, transfer, and manage stablecoins on Tempo.
 ---
 
-# Issuance & Orchestration
+# Issuance & orchestration for stablecoins
 
 Move money globally between local currencies and stablecoins. Issue, transfer, and manage stablecoins.
 

--- a/src/pages/docs/ecosystem/security-compliance.mdx
+++ b/src/pages/docs/ecosystem/security-compliance.mdx
@@ -1,9 +1,10 @@
 ---
-title: Security & Compliance
+title: "Security and compliance tools"
+seoTitle: "Security & Compliance Tools | Docs"
 description: Transaction scanning, threat detection, and compliance infrastructure for Tempo applications.
 ---
 
-# Security & Compliance
+# Security and compliance tools
 
 Transaction scanning, threat detection, and compliance infrastructure for Tempo applications.
 

--- a/src/pages/docs/ecosystem/wallets.mdx
+++ b/src/pages/docs/ecosystem/wallets.mdx
@@ -1,9 +1,10 @@
 ---
-title: Wallets
+title: "Wallets: embedded and external options"
+seoTitle: "Embedded & External Wallets | Tempo Docs"
 description: Integrate embedded, custodial, and institutional wallet infrastructure into your Tempo application.
 ---
 
-# Wallets
+# Wallets: embedded and external options
 
 Integrate user-friendly wallet experiences directly into your application.
 

--- a/src/pages/docs/guide/bridge-bungee.mdx
+++ b/src/pages/docs/guide/bridge-bungee.mdx
@@ -1,9 +1,10 @@
 ---
-title: Bridge via Bungee
+title: "Bridging stablecoins with Bungee"
+seoTitle: "Bridge Stablecoins via Bungee | Docs"
 description: Bridge tokens to and from Tempo using Bungee. Covers Bungee Link, deposit quotes, transaction execution, status tracking, and Tempo-specific caveats.
 ---
 
-# Bridge via Bungee
+# Bridging stablecoins with Bungee
 
 [Bungee](https://www.bungee.exchange/) is a cross-chain routing protocol built by the [SOCKET](https://docs.socket.tech/) team. For Tempo, the recommended integration path is Bungee Deposit: request a quote, execute the returned source-chain transaction, and track the request until Bungee delivers funds on the destination chain.
 

--- a/src/pages/docs/guide/bridge-layerzero.mdx
+++ b/src/pages/docs/guide/bridge-layerzero.mdx
@@ -1,9 +1,10 @@
 ---
-title: Bridge via LayerZero
+title: "Bridging stablecoins and USDT0 via LayerZero"
+seoTitle: "Bridge via LayerZero: USDT0 & More | Docs"
 description: Bridge tokens to and from Tempo using LayerZero. Covers Stargate pools and standard OFT adapters with cast commands and TypeScript examples.
 ---
 
-# Bridge via LayerZero
+# Bridging stablecoins and USDT0 via LayerZero
 
 [LayerZero](https://layerzero.network) is the omnichain messaging protocol that powers token bridging on Tempo. Tokens are bridged using the [OFT (Omnichain Fungible Token)](https://docs.layerzero.network/v2/developers/evm/oft/quickstart) standard - the source chain locks or burns tokens and the destination chain mints the bridged equivalent.
 

--- a/src/pages/docs/guide/bridge-relay.mdx
+++ b/src/pages/docs/guide/bridge-relay.mdx
@@ -1,9 +1,10 @@
 ---
-title: Bridge via Relay
+title: "Bridging stablecoins with Relay"
+seoTitle: "Bridge Stablecoins via Relay | Tempo Docs"
 description: Bridge tokens to and from Tempo using Relay. Includes supported token discovery, curl commands, TypeScript examples with viem, and status tracking.
 ---
 
-# Bridge via Relay
+# Bridging stablecoins with Relay
 
 [Relay](https://relay.link/) is a cross-chain payments network powered by a solver that fills bridge requests instantly. Users deposit on the source chain and receive funds on the destination chain within seconds - no lock-and-mint or messaging protocol required.
 

--- a/src/pages/docs/guide/getting-funds.mdx
+++ b/src/pages/docs/guide/getting-funds.mdx
@@ -1,5 +1,6 @@
 ---
-title: Getting Funds on Tempo
+title: "Getting funds on Tempo: wallet, faucet & bridge"
+seoTitle: "Get Funds on Tempo: 3 Ways to Start | Docs"
 description: Bridge assets to Tempo, add funds in Tempo Wallet, or use the faucet on testnet.
 interactive: true
 ---
@@ -8,7 +9,7 @@ import * as Demo from '../../../components/guides/Demo.tsx'
 import { DepositToTempoWallet } from '../../../components/guides/steps/wallet/DepositToTempoWallet.tsx'
 import { SignInWithTempo } from '../../../components/guides/steps/wallet/SignInWithTempo.tsx'
 
-# Getting Funds on Tempo
+# Getting funds on Tempo: wallet, faucet & bridge
 
 ## Tempo Wallet
 

--- a/src/pages/docs/guide/issuance/create-a-stablecoin.mdx
+++ b/src/pages/docs/guide/issuance/create-a-stablecoin.mdx
@@ -1,5 +1,6 @@
 ---
-title: Create a Stablecoin
+title: "How to create a TIP-20 stablecoin"
+seoTitle: "Create a TIP-20 Stablecoin | Tempo Docs"
 description: Create your own stablecoin on Tempo using TIP-20 tokens. Deploy tokens with built-in compliance features and role-based permissions.
 interactive: true
 ---
@@ -10,7 +11,7 @@ import { AddFunds } from '../../../../components/guides/steps/payments/AddFunds.
 import { Connect } from '../../../../components/guides/steps/auth/Connect.tsx'
 import { CreateToken } from '../../../../components/guides/steps/issuance/CreateToken.tsx'
 
-# Create a Stablecoin
+# How to create a TIP-20 stablecoin
 
 Create your own stablecoin on Tempo using [TIP-20 Tokens](/docs/protocol/tip20/overview).
 TIP-20 tokens are designed specifically for payments with built-in compliance features, role-based permissions,

--- a/src/pages/docs/guide/issuance/index.mdx
+++ b/src/pages/docs/guide/issuance/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Stablecoin Issuance
+title: "Stablecoin issuance using the TIP-20 standard"
+seoTitle: "Stablecoin Issuance with TIP-20 | Docs"
 description: Create and manage your own stablecoin on Tempo. Issue tokens, manage supply, and integrate with Tempo's payment infrastructure.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Stablecoin Issuance
+# Stablecoin issuance using the TIP-20 standard
 
 Create and manage your own stablecoin on Tempo. Launch the token first, then configure fees, roles, supply controls, and transfer policies.
 

--- a/src/pages/docs/guide/issuance/manage-stablecoin.mdx
+++ b/src/pages/docs/guide/issuance/manage-stablecoin.mdx
@@ -1,5 +1,6 @@
 ---
-title: Manage Your Stablecoin
+title: "Managing your TIP-20 stablecoin"
+seoTitle: "Manage Your TIP-20 Stablecoin | Docs"
 description: Configure stablecoin permissions, supply limits, and compliance policies. Grant roles, set transfer policies, and control pause/unpause functionality.
 interactive: true
 ---
@@ -18,7 +19,7 @@ import { RevokeTokenRoles } from '../../../../components/guides/steps/issuance/R
 import { SetSupplyCap } from '../../../../components/guides/steps/issuance/SetSupplyCap.tsx'
 import { Cards, Card } from 'vocs'
 
-# Manage Your Stablecoin
+# Managing your TIP-20 stablecoin
 
 Configure your stablecoin's permissions, supply limits, and compliance policies after deployment. This guide covers granting roles to manage token operations, setting supply caps, configuring transfer policies, and controlling token transfers through pause/unpause functionality.
 

--- a/src/pages/docs/guide/issuance/mint-stablecoins.mdx
+++ b/src/pages/docs/guide/issuance/mint-stablecoins.mdx
@@ -1,5 +1,6 @@
 ---
-title: Mint Stablecoins
+title: "How to mint TIP-20 stablecoins"
+seoTitle: "Mint TIP-20 Stablecoins | Tempo Docs"
 description: Mint new tokens to increase your stablecoin's total supply. Grant the issuer role and create tokens with optional memos for tracking.
 interactive: true
 ---
@@ -13,7 +14,7 @@ import { GrantTokenRoles } from '../../../../components/guides/steps/issuance/Gr
 import { MintToken } from '../../../../components/guides/steps/issuance/MintToken.tsx'
 import { Cards, Card } from 'vocs'
 
-# Mint Stablecoins
+# How to mint TIP-20 stablecoins
 
 Create new tokens by minting them to a specified address. Minting increases the total supply of your stablecoin.
 

--- a/src/pages/docs/guide/machine-payments/agent.mdx
+++ b/src/pages/docs/guide/machine-payments/agent.mdx
@@ -1,11 +1,12 @@
 ---
-title: Agent Quickstart
+title: "Agent quickstart: build an AI agent that pays for APIs"
+seoTitle: "Build an AI Agent That Pays for APIs | Docs"
 description: Use the tempo CLI to discover services, preview costs, and make paid requests from a terminal or AI agent — no SDK required.
 ---
 
 import { Card, Cards } from 'vocs'
 
-# Agent quickstart
+# Agent quickstart: build an AI agent that pays for APIs
 
 The `tempo` CLI handles `402 Payment Required` responses the same way the client SDK does — but from a terminal, script, or AI agent, with zero integration code.
 

--- a/src/pages/docs/guide/machine-payments/client.mdx
+++ b/src/pages/docs/guide/machine-payments/client.mdx
@@ -1,11 +1,12 @@
 ---
-title: Client Quickstart
+title: "Client quickstart: build an MPP client"
+seoTitle: "Build an MPP Client | Tempo Docs"
 description: Set up an MPP client on Tempo. Polyfill fetch to automatically pay for 402 responses with TIP-20 stablecoins.
 ---
 
 import { Card, Cards } from 'vocs'
 
-# Client quickstart
+# Client quickstart: build an MPP client
 
 Polyfill `fetch` to handle `402` responses. Your existing code works unchanged — payments happen in the background.
 

--- a/src/pages/docs/guide/machine-payments/index.mdx
+++ b/src/pages/docs/guide/machine-payments/index.mdx
@@ -1,5 +1,6 @@
 ---
-title: Agentic Payments
+title: "Make agentic payments with the Machine Payments Protocol"
+seoTitle: "Agentic Payments with MPP | Tempo Docs"
 description: Make agentic payments using the Machine Payments Protocol (MPP) on Tempo — charge for APIs, MCP tools, and digital content with TIP-20 stablecoins.
 ---
 
@@ -7,7 +8,7 @@ import { Card, Cards } from 'vocs'
 import { MermaidDiagram } from '../../../../components/MermaidDiagram'
 import { TerminalDemo } from '../../../../components/TerminalDemo'
 
-# Make Agentic Payments
+# Make agentic payments with the Machine Payments Protocol
 
 Make agentic payments using the [Machine Payments Protocol](https://mpp.dev) (MPP). MPP adds inline payments to any HTTP endpoint — agents, apps, or humans pay as part of their request, and the server verifies payment before returning the response.
 

--- a/src/pages/docs/guide/machine-payments/server.mdx
+++ b/src/pages/docs/guide/machine-payments/server.mdx
@@ -1,11 +1,12 @@
 ---
-title: Server Quickstart
+title: "Server quickstart: add MPP payments to your server"
+seoTitle: "Add MPP Payments to Your Server | Docs"
 description: Add payment gating to any HTTP endpoint on Tempo with mppx middleware for Next.js, Hono, Express, and the Fetch API.
 ---
 
 import { Card, Cards } from 'vocs'
 
-# Server quickstart
+# Server quickstart: add MPP payments to your server
 
 Plug MPP into any server framework to accept payments for protected resources. Use `mppx` middleware for your framework, or call `mppx/server` directly with the Fetch API.
 

--- a/src/pages/docs/guide/node/index.mdx
+++ b/src/pages/docs/guide/node/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Run a Tempo Node
+title: "Run a Tempo node: validator, RPC, and standby"
+seoTitle: "Run a Tempo Node: Validator, RPC & Standby | Docs"
 description: Run Tempo node infrastructure for RPC access, validator operations, system requirements, installation, monitoring, security, upgrades, and release operations.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Run a Tempo Node
+# Run a Tempo node: validator, RPC, and standby
 
 Run Tempo infrastructure when you need direct network access, dedicated RPC capacity, validator operations, or lower-level visibility into network behavior.
 

--- a/src/pages/docs/guide/node/installation.mdx
+++ b/src/pages/docs/guide/node/installation.mdx
@@ -1,9 +1,10 @@
 ---
-title: Install a Tempo Node
+title: "Install and configure a Tempo node"
+seoTitle: "Install & Configure a Tempo Node | Docs"
 description: Install Tempo node using pre-built binaries, build from source with Rust, or run with Docker. Get started in minutes with tempoup.
 ---
 
-# Install a Tempo Node
+# Install and configure a Tempo node
 
 We provide three different installation paths — installing a pre-built binary, building from source, or using our provided Docker image. For the full CLI command reference, see [`tempo node`](/docs/cli/node).
 

--- a/src/pages/docs/guide/node/security.mdx
+++ b/src/pages/docs/guide/node/security.mdx
@@ -1,9 +1,10 @@
 ---
-title: Node Security
+title: "Node security: best practices for operators"
+seoTitle: "Tempo Node Security | Tempo Docs"
 description: Security best practices for Tempo node operators, covering key management, network configuration, release verification, and data integrity.
 ---
 
-# Node Security
+# Node security: best practices for operators
 
 This page covers security best practices for Tempo node operators. Following these recommendations helps protect your validator from impersonation, unauthorized access, and operational mistakes.
 

--- a/src/pages/docs/guide/node/upgrade-cadence.mdx
+++ b/src/pages/docs/guide/node/upgrade-cadence.mdx
@@ -1,11 +1,12 @@
 ---
-title: Upgrade Cadence
+title: "Upgrade cadence and rollout timeline"
+seoTitle: "Upgrade Cadence & Rollout Timeline | Docs"
 description: How Tempo schedules and communicates network upgrades, including timelines, notification windows, and what to expect as a node operator.
 ---
 
 import { Badge } from '../../../../components/Badge'
 
-# Upgrade Cadence
+# Upgrade cadence and rollout timeline
 
 Tempo ships protocol upgrades on a **bi-weekly to monthly cadence**. Each upgrade bundles one or more protocol changes ([TIPs](https://tips.sh/)) into a named hardfork (T1, T2, T3, …).
 

--- a/src/pages/docs/guide/node/validator-failover.mdx
+++ b/src/pages/docs/guide/node/validator-failover.mdx
@@ -1,9 +1,10 @@
 ---
-title: Validator Failover
+title: "Validator failover: preparing a follower node"
+seoTitle: "Validator Failover with Follower Nodes | Docs"
 description: Promote a follower into a Tempo validator.
 ---
 
-# Validator failover
+# Validator failover: preparing a follower node
 
 This runbook covers a warm failover where a follower is promoted into a validator. A follower running in certified mode stores the same consensus finalization data used to bootstrap the validator.
 

--- a/src/pages/docs/guide/node/validator-setup.mdx
+++ b/src/pages/docs/guide/node/validator-setup.mdx
@@ -1,5 +1,6 @@
 ---
-title: Validator Onboarding
+title: "Validator onboarding"
+seoTitle: "Tempo Validator Onboarding | Docs"
 description: Generate signing keys and run your Tempo validator node for the first time.
 ---
 

--- a/src/pages/docs/guide/node/validator-troubleshooting.mdx
+++ b/src/pages/docs/guide/node/validator-troubleshooting.mdx
@@ -1,9 +1,10 @@
 ---
-title: Troubleshooting and FAQ
+title: "Tempo validator troubleshooting and FAQ"
+seoTitle: "Tempo Validator Troubleshooting & FAQ | Docs"
 description: Common issues and solutions for Tempo validator operators.
 ---
 
-# Troubleshooting and FAQ
+# Tempo validator troubleshooting and FAQ
 
 ## My node is not proposing blocks
 

--- a/src/pages/docs/guide/payments/accept-a-payment.mdx
+++ b/src/pages/docs/guide/payments/accept-a-payment.mdx
@@ -1,5 +1,6 @@
 ---
-title: Accept a Payment
+title: "How to receive stablecoin payments"
+seoTitle: "Receive Stablecoin Payments | Tempo Docs"
 description: Accept stablecoin payments in your application. Verify transactions, listen for transfer events, and reconcile payments using memos.
 interactive: true
 ---
@@ -10,7 +11,7 @@ import { Connect } from '../../../../components/guides/steps/auth/Connect.tsx'
 import * as Token from '../../../../components/guides/tokens'
 import { Tabs, Tab } from 'vocs'
 
-# Accept a Payment
+# How to receive stablecoin payments
 
 Accept stablecoin payments in your application. Learn how to receive payments, verify transactions, and reconcile payments using memos.
 

--- a/src/pages/docs/guide/payments/index.mdx
+++ b/src/pages/docs/guide/payments/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Stablecoin Payments
+title: "Stablecoin payments: integration guide"
+seoTitle: "Stablecoin Payments Integration | Docs"
 description: Send and receive stablecoin payments on Tempo. Integrate payments with flexible fee options, sponsorship capabilities, and parallel transactions.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Stablecoin Payments
+# Stablecoin payments: integration guide
 
 Send and receive payments using stablecoins on Tempo. Start with core payment flows, then add reconciliation, receive controls, fee preferences, sponsorship, and higher-throughput transaction patterns.
 

--- a/src/pages/docs/guide/payments/send-a-payment.mdx
+++ b/src/pages/docs/guide/payments/send-a-payment.mdx
@@ -1,5 +1,6 @@
 ---
-title: Send a Payment
+title: "How to send a stablecoin payment on Tempo"
+seoTitle: "Send a Stablecoin Payment on Tempo | Docs"
 description: Send stablecoin payments between accounts on Tempo. Include optional memos for reconciliation and tracking with TypeScript, Rust, or Solidity.
 interactive: true
 ---
@@ -11,7 +12,7 @@ import { SendPayment } from '../../../../components/guides/steps/payments/SendPa
 import { Cards, Card } from 'vocs'
 import { Tabs, Tab } from 'vocs'
 
-# Send a Payment
+# How to send a stablecoin payment on Tempo
 
 Send stablecoin payments between accounts on Tempo. Payments can include optional memos for reconciliation and tracking.
 

--- a/src/pages/docs/guide/payments/send-parallel-transactions.mdx
+++ b/src/pages/docs/guide/payments/send-parallel-transactions.mdx
@@ -1,5 +1,6 @@
 ---
-title: Send Parallel Transactions
+title: "Send parallel transactions using expiring nonces"
+seoTitle: "Parallel Transactions with Expiring Nonces | Docs"
 description: Submit multiple transactions concurrently using Tempo's expiring nonce system under-the-hood.
 interactive: true
 ---
@@ -11,7 +12,7 @@ import { SendParallelPayments } from '../../../../components/guides/steps/paymen
 import * as Token from '../../../../components/guides/tokens'
 import { Cards, Card } from 'vocs'
 
-# Send Parallel Transactions
+# Send parallel transactions using expiring nonces
 
 Tempo enables concurrent transaction execution through its [expiring nonce](/docs/guide/tempo-transaction#expiring-nonces) system. Unlike traditional sequential nonces that require transactions to be processed one at a time, expiring nonces allow multiple transactions to be submitted simultaneously without nonce conflicts. Each transaction uses an independent nonce that automatically expires after a set time window, enabling true parallel execution.
 

--- a/src/pages/docs/guide/payments/sponsor-user-fees.mdx
+++ b/src/pages/docs/guide/payments/sponsor-user-fees.mdx
@@ -1,5 +1,6 @@
 ---
-title: Sponsor User Fees
+title: "Sponsor user fees with feePayer"
+seoTitle: "Sponsor User Fees with feePayer | Docs"
 description: Enable gasless transactions by sponsoring fees for your users. Set up a fee payer service and improve UX by removing friction from payment flows.
 interactive: true
 ---
@@ -10,7 +11,7 @@ import { AddFunds } from '../../../../components/guides/steps/payments/AddFunds.
 import { Connect } from '../../../../components/guides/steps/auth/Connect.tsx'
 import { SendRelayerSponsoredPayment } from '../../../../components/guides/steps/payments/SponsorUserFees.tsx'
 
-# Sponsor User Fees
+# Sponsor user fees with `feePayer`
 
 Enable gasless transactions by sponsoring transaction fees for your users. Tempo's native fee sponsorship allows applications to pay fees on behalf of users, improving UX and removing friction from payment flows.
 

--- a/src/pages/docs/guide/private-zones/connect-to-a-zone.mdx
+++ b/src/pages/docs/guide/private-zones/connect-to-a-zone.mdx
@@ -1,9 +1,10 @@
 ---
-title: Connect to a Zone
+title: "Connect to a Tempo Zone on testnet"
+seoTitle: "Connect to a Tempo Zone on Testnet | Docs"
 description: Connect to Tempo Zones on testnet using Zone A and Zone B RPC URLs, chain IDs, and a minimal viem client setup for private flows.
 ---
 
-# Connect to a Zone
+# Connect to a Tempo Zone on testnet
 
 :::info
 Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/guide/private-zones/deposit-to-a-zone.mdx
+++ b/src/pages/docs/guide/private-zones/deposit-to-a-zone.mdx
@@ -1,5 +1,6 @@
 ---
-title: Deposit to a Zone
+title: "Deposit pathUSD to a Tempo Zone on testnet"
+seoTitle: "Deposit pathUSD to a Tempo Zone on Testnet | Docs"
 description: Deposit pathUSD from your public-chain balance into Zone A and confirm the resulting zone balance.
 interactive: true
 ---
@@ -10,7 +11,7 @@ import { DepositToZone } from '../../../../components/guides/zones/DepositToZone
 
 export const depositZoneBalances = [{ label: 'Zone A', token: Demo.pathUsd, zone: 6 }]
 
-# Deposit to a Zone
+# Deposit pathUSD to a Tempo Zone on testnet
 
 :::info
 Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/guide/private-zones/index.mdx
+++ b/src/pages/docs/guide/private-zones/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Connect to Tempo Zones
+title: "Connect to Tempo Zones on testnet"
+seoTitle: "Tempo Zones: Private Transactions on Testnet | Docs"
 description: Learn how Tempo Zones work alongside the public chain and follow guides for depositing, sending within a zone, routing pathUSD across zones, swapping into betaUSD, and withdrawing.
 ---
 
 import { Card, Cards } from 'vocs'
 
-# Connect to Tempo Zones
+# Connect to Tempo Zones on testnet
 
 :::info
 Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/guide/private-zones/withdraw-from-a-zone.mdx
+++ b/src/pages/docs/guide/private-zones/withdraw-from-a-zone.mdx
@@ -1,5 +1,6 @@
 ---
-title: Withdraw from a Zone
+title: "Withdraw pathUSD from a Tempo Zone on testnet"
+seoTitle: "Withdraw pathUSD from a Tempo Zone on Testnet | Docs"
 description: Withdraw pathUSD from Zone A back to your public-chain balance with a direct zone outbox withdrawal.
 interactive: true
 ---
@@ -10,7 +11,7 @@ import { WithdrawFromZone } from '../../../../components/guides/zones/WithdrawFr
 
 export const withdrawalZoneBalances = [{ label: 'Zone A', token: Demo.pathUsd, zone: 6 }]
 
-# Withdraw from a Zone
+# Withdraw pathUSD from a Tempo Zone on testnet
 
 :::info
 Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/guide/stablecoin-dex/executing-swaps.mdx
+++ b/src/pages/docs/guide/stablecoin-dex/executing-swaps.mdx
@@ -1,5 +1,6 @@
 ---
-title: Executing Swaps
+title: "Executing swaps on the Tempo Stablecoin DEX"
+seoTitle: "How to Execute Swaps on the DEX | Docs"
 description: Learn to execute instant stablecoin swaps on Tempo's DEX. Get price quotes, set slippage protection, and batch approvals with swaps.
 interactive: true
 ---
@@ -10,7 +11,7 @@ import { AddFunds } from '../../../../components/guides/steps/payments/AddFunds.
 import { Connect } from '../../../../components/guides/steps/auth/Connect.tsx'
 import { MakeSwaps } from '../../../../components/guides/steps/exchange/MakeSwaps.tsx'
 
-# Executing Swaps
+# Executing swaps on the Tempo Stablecoin DEX
 
 Execute swaps between stablecoins on the exchange. Swaps execute immediately against existing orders in the orderbook, providing instant liquidity for cross-stablecoin payments.
 

--- a/src/pages/docs/guide/stablecoin-dex/index.mdx
+++ b/src/pages/docs/guide/stablecoin-dex/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Exchange Stablecoins
+title: "Exchange stablecoins on the Tempo DEX"
+seoTitle: "How the Tempo Stablecoin DEX Works | Docs"
 description: Trade between stablecoins on Tempo's enshrined DEX. Execute swaps, provide liquidity, and query the onchain orderbook for optimal pricing.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Exchange Stablecoins
+# Exchange stablecoins on the Tempo DEX
 
 Trade between stablecoins on Tempo's enshrined decentralized exchange (DEX). Start with quote-token behavior, then execute swaps, provide liquidity, or manage the fee-liquidity path for a stablecoin.
 

--- a/src/pages/docs/guide/stablecoin-dex/providing-liquidity.mdx
+++ b/src/pages/docs/guide/stablecoin-dex/providing-liquidity.mdx
@@ -1,5 +1,6 @@
 ---
-title: Providing Liquidity
+title: "How to provide liquidity on the Tempo DEX"
+seoTitle: "Providing Liquidity on the Tempo DEX | Docs"
 description: Place limit and flip orders to provide liquidity on the Stablecoin DEX orderbook. Learn to manage orders and set prices using ticks.
 interactive: true
 ---
@@ -13,7 +14,7 @@ import { Connect } from '../../../../components/guides/steps/auth/Connect.tsx'
 import { PlaceOrder } from '../../../../components/guides/steps/exchange/PlaceOrder.tsx'
 import { QueryOrder } from '../../../../components/guides/steps/exchange/QueryOrder.tsx'
 
-# Providing Liquidity
+# How to provide liquidity on the Tempo DEX
 
 Add liquidity for a token pair by placing orders on the Stablecoin DEX. You can provide liquidity on the `buy` or `sell` side of the orderbook, with `limit` or `flip` orders. To learn more about order types see the [documentation on order types](/docs/protocol/exchange/providing-liquidity#order-types).
 

--- a/src/pages/docs/guide/tempo-transaction/index.mdx
+++ b/src/pages/docs/guide/tempo-transaction/index.mdx
@@ -1,12 +1,13 @@
 ---
-title: Use Tempo Transactions
+title: "Using Tempo Transactions: integration guides"
+seoTitle: "Tempo Transactions: Integration Guide | Docs"
 description: Learn how to use Tempo Transactions for configurable fee tokens, fee sponsorship, batch calls, access keys, and concurrent execution.
 ---
 
 import { Cards, Card } from 'vocs'
 import TempoTxProperties from '../../../../snippets/tempo-tx-properties.mdx'
 
-# Use Tempo Transactions
+# Using Tempo Transactions: integration guides
 
 Tempo Transactions are a new [EIP-2718](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2718.md) transaction type, exclusively available on Tempo.
 

--- a/src/pages/docs/guide/using-tempo-with-ai.mdx
+++ b/src/pages/docs/guide/using-tempo-with-ai.mdx
@@ -1,5 +1,6 @@
 ---
-title: Use Tempo with AI
+title: "Using Tempo with AI through the MCP server"
+seoTitle: "Use Tempo with AI via MCP Server | Docs"
 description: Connect AI coding agents to Tempo docs, MCP tools, Markdown pages, plugins, workflow skills, and feedback loops for accurate development.
 interactive: true
 ---
@@ -8,7 +9,7 @@ import { Tabs, Tab } from 'vocs'
 import { DocsLinkButton } from '../../../components/DocsLinkButton.tsx'
 import { TempoMcpExplorer } from '../../../components/TempoMcpExplorer.tsx'
 
-# Use Tempo with AI
+# Using Tempo with AI through the MCP server
 
 Tempo publishes documentation, Markdown pages, MCP tools, and agent plugins so AI coding agents can work with Tempo using current project context instead of guesses.
 

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -1,14 +1,12 @@
 ---
-title: Documentation
+title: "Tempo developer documentation"
+seoTitle: "Tempo Developer Docs: APIs, SDKs & Guides"
 description: Tempo docs for integration paths, payment guides, protocol references, SDKs, APIs, node operations, AI resources, and partners.
 ---
 
 import { Cards, Card } from 'vocs'
 
-<meta property="og:title" content="Tempo Documentation" />
-<meta name="twitter:title" content="Tempo Documentation" />
-
-# Get Started
+# Tempo developer documentation
 
 Connect to Tempo and learn how to build stablecoin payment products. Start with network setup, fund a wallet, send your first payment, then choose the product workflow, reference, or operational surface you need next.
 

--- a/src/pages/docs/protocol/blockspace/consensus.mdx
+++ b/src/pages/docs/protocol/blockspace/consensus.mdx
@@ -1,9 +1,10 @@
 ---
-title: Consensus and Finality
+title: "Consensus and finality using Simplex BFT"
+seoTitle: "Consensus & Finality: Simplex BFT | Docs"
 description: "Tempo uses Simplex BFT via Commonware for deterministic sub-second finality with Byzantine fault tolerance."
 ---
 
-# Consensus and Finality
+# Consensus and finality using Simplex BFT
 
 Tempo uses Simplex BFT consensus to provide deterministic, sub-second finality. This page describes the consensus mechanism, finality guarantees, and fault tolerance properties.
 

--- a/src/pages/docs/protocol/blockspace/overview.mdx
+++ b/src/pages/docs/protocol/blockspace/overview.mdx
@@ -1,9 +1,10 @@
 ---
-title: Blockspace Overview
+title: "Blockspace overview: understanding payment lanes"
+seoTitle: "Blockspace & Payment Lanes | Tempo Docs"
 description: Technical specification for Tempo block structure including header fields, payment lanes, and system transaction ordering.
 ---
 
-# Blockspace Overview
+# Blockspace overview: understanding payment lanes
 
 ## Abstract
 

--- a/src/pages/docs/protocol/exchange/exchange-balance.mdx
+++ b/src/pages/docs/protocol/exchange/exchange-balance.mdx
@@ -1,9 +1,10 @@
 ---
-title: DEX Balance
+title: "Understanding DEX balances on Tempo"
+seoTitle: "Understanding DEX Balances | Tempo Docs"
 description: Hold token balances directly on the Stablecoin DEX to save gas costs on trades, receive maker proceeds automatically, and trade more efficiently.
 ---
 
-# DEX Balance
+# Understanding DEX balances on Tempo
 
 The Stablecoin DEX allows you to hold token balances directly using the DEX contract. This eliminates the need for token transfers on every trade, significantly reducing gas costs for active traders and liquidity providers.
 

--- a/src/pages/docs/protocol/exchange/executing-swaps.mdx
+++ b/src/pages/docs/protocol/exchange/executing-swaps.mdx
@@ -1,9 +1,10 @@
 ---
-title: Executing Swaps
+title: "Executing swaps | Protocol reference"
+seoTitle: "Executing Swaps: Protocol Reference | Docs"
 description: Learn how to execute swaps and quote prices on Tempo's Stablecoin DEX with exact-in and exact-out swap functions and slippage protection.
 ---
 
-# Executing Swaps
+# Executing swaps | Protocol reference
 
 ## Swap Functions
 

--- a/src/pages/docs/protocol/exchange/index.mdx
+++ b/src/pages/docs/protocol/exchange/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Exchanging Stablecoins
+title: "Exchanging stablecoins: exchange vs. Fee AMM"
+seoTitle: "Exchange vs. Fee AMM for Stablecoins | Docs"
 description: Tempo's enshrined decentralized exchange for trading between stablecoins with optimal pricing, limit orders, and flip orders for liquidity provision.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Exchanging Stablecoins
+# Exchanging stablecoins: exchange vs. Fee AMM
 
 Tempo features an enshrined decentralized exchange (DEX) designed specifically for trading between stablecoins of the same underlying asset (e.g., USDG to USDT). The exchange provides optimal pricing for cross-stablecoin payments while minimizing chain load from excessive market activity.
 

--- a/src/pages/docs/protocol/exchange/providing-liquidity.mdx
+++ b/src/pages/docs/protocol/exchange/providing-liquidity.mdx
@@ -1,9 +1,10 @@
 ---
-title: Providing Liquidity
+title: "Providing liquidity | Protocol reference"
+seoTitle: "Providing Liquidity: Protocol Reference | Docs"
 description: Provide liquidity on Tempo's DEX using limit orders and flip orders. Earn spreads while facilitating stablecoin trades with price-time priority.
 ---
 
-# Providing Liquidity
+# Providing liquidity | Protocol reference
 
 Provide liquidity to the DEX by placing limit orders or flip orders in the onchain orderbook.
 

--- a/src/pages/docs/protocol/exchange/quote-tokens.mdx
+++ b/src/pages/docs/protocol/exchange/quote-tokens.mdx
@@ -1,9 +1,10 @@
 ---
-title: Quote Tokens
+title: "Quote tokens on Tempo: understanding pathUSD"
+seoTitle: "Quote Tokens: pathUSD Explained | Docs"
 description: Quote tokens determine trading pairs on Tempo's DEX. Each TIP-20 specifies a quote token, with pathUSD available as an optional neutral choice.
 ---
 
-# Quote Tokens
+# Quote tokens on Tempo: understanding pathUSD
 
 Each USD TIP-20 on Tempo can choose any other USD TIP-20 as its quote token—the token it is paired against on the native decentralized exchange. This guarantees that there is one path between any two tokens, which reduces fragmentation of liquidity and simplifies routing.
 

--- a/src/pages/docs/protocol/fees/fee-amm/index.mdx
+++ b/src/pages/docs/protocol/fees/fee-amm/index.mdx
@@ -1,11 +1,14 @@
 ---
-title: Fee AMM Overview
+title: "Fee AMM overview: converting stablecoin fees"
+seoTitle: "How the Tempo Fee AMM Converts Fees | Docs"
 description: Understand how the Fee AMM automatically converts transaction fees between stablecoins, enabling users to pay in any supported token.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Fee AMM Overview
+<span id="fee-amm-overview" />
+
+# Fee AMM overview: converting stablecoin fees
 
 The Fee AMM (Automated Market Maker) is a dedicated system for converting transaction fees between different stablecoins. It enables users to pay fees in any supported stablecoin while allowing validators to receive fees in their preferred token.
 

--- a/src/pages/docs/protocol/fees/index.mdx
+++ b/src/pages/docs/protocol/fees/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Transaction Fees
+title: "Understanding transaction fees on Tempo"
+seoTitle: "How Transaction Fees Work on Tempo | Docs"
 description: Pay transaction fees in any USD stablecoin on Tempo. No native token required—fees are paid directly in TIP-20 stablecoins with automatic conversion.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Transaction Fees
+# Understanding transaction fees on Tempo
 
 Tempo has no native token. Instead, transaction fees—including both gas fees and priority fees—can be paid directly in stablecoins. When you send a transaction, you can choose which supported stablecoin to use for fees.
 

--- a/src/pages/docs/protocol/fees/spec-fee-amm.mdx
+++ b/src/pages/docs/protocol/fees/spec-fee-amm.mdx
@@ -1,9 +1,10 @@
 ---
-title: Fee AMM Specification
+title: "Fee AMM specification: how fee conversion works"
+seoTitle: "Tempo Fee AMM Specification | Docs"
 description: Technical specification for the Fee AMM enabling automatic stablecoin conversion for transaction fees with fixed-rate swaps and MEV protection.
 ---
 
-# Fee AMM Specification
+# Fee AMM specification: how fee conversion works
 
 ## Abstract
 

--- a/src/pages/docs/protocol/fees/spec-fee.mdx
+++ b/src/pages/docs/protocol/fees/spec-fee.mdx
@@ -1,9 +1,10 @@
 ---
-title: Fee Specification
+title: "Fee specification: the canonical reference"
+seoTitle: "Tempo Fee Specification | Tempo Docs"
 description: "Technical specification for Tempo's fee system covering multi-token fee payment, fee sponsorship, token preferences, and validator payouts."
 ---
 
-# Fees
+# Fee specification: the canonical reference
 
 ## Abstract
 

--- a/src/pages/docs/protocol/index.mdx
+++ b/src/pages/docs/protocol/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Tempo Protocol
+title: "Tempo protocol: specifications and reference"
+seoTitle: "Tempo Protocol Specifications | Docs"
 description: Read Tempo protocol references for tokens, policies, fees, transactions, blockspace, exchange, zones, network upgrades, TIP specs, and implementation details.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Tempo Protocol
+# Tempo protocol: specifications and reference
 
 Use this section when you need the technical reference for Tempo itself. These pages are written for implementers, auditors, wallet teams, infrastructure operators, and anyone building against protocol-level behavior rather than a single product workflow.
 

--- a/src/pages/docs/protocol/rpc/index.mdx
+++ b/src/pages/docs/protocol/rpc/index.mdx
@@ -1,9 +1,10 @@
 ---
-title: Tempo RPC Reference
+title: "Tempo RPC reference: the tempo_ namespace"
+seoTitle: "Tempo RPC Reference: tempo_ Namespace | Docs"
 description: Reference for Tempo-specific JSON-RPC methods in the tempo, consensus, and admin namespaces, plus modified eth_ behavior.
 ---
 
-# Tempo RPC Reference
+# Tempo RPC reference: the `tempo_` namespace
 
 Tempo nodes expose all standard [Ethereum JSON-RPC methods](https://ethereum.org/developers/docs/apis/json-rpc/) (`eth_`, `net_`, `web3_`, `txpool_`, `trace_`, `debug_`) plus Tempo-specific namespaces for fork scheduling, consensus data, and node administration.
 

--- a/src/pages/docs/protocol/tip20/overview.mdx
+++ b/src/pages/docs/protocol/tip20/overview.mdx
@@ -1,11 +1,12 @@
 ---
-title: TIP-20 Tokens
+title: "TIP-20 tokens: A stablecoin-native standard"
+seoTitle: "TIP-20: Stablecoin-Native Tokens | Docs"
 description: TIP-20 tokens are Tempo's native token standard for stablecoins with built-in fee payment, payment lanes, transfer memos, and compliance policies.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# TIP-20 Tokens
+# TIP-20 tokens: A stablecoin-native standard
 
 TIP-20 tokens are Tempo's native token standard for stablecoins and payment tokens. They are designed for stablecoin payments, and are the foundation for many token-related functions on Tempo including transaction fees, payment lanes, DEX quote tokens, optimized routing for DEX liquidity, optional on-chain token `logoURI` metadata, implicit approvals for listed precompiles, and enshrined payment-channel reserve flows.
 

--- a/src/pages/docs/protocol/tip403/receive-policies.mdx
+++ b/src/pages/docs/protocol/tip403/receive-policies.mdx
@@ -1,12 +1,13 @@
 ---
-title: Receive Policies
+title: "TIP-403 receive policies"
+seoTitle: "TIP-403 Receive Policies | Tempo Docs"
 description: Technical overview of address-level receive policies, token filters, sender policies, blocked receipts, claim paths, and ReceivePolicyGuard events.
 ---
 
 import { Card, Cards } from 'vocs'
 import { MermaidDiagram } from '../../../../components/MermaidDiagram'
 
-# Receive Policies
+# TIP-403 receive policies
 
 Receive policies let a receiver control which [TIP-20](/docs/protocol/tip20/overview) tokens it accepts and which senders may send those tokens to it. This page summarizes the protocol behavior from the [specification](https://tips.sh/1028).
 

--- a/src/pages/docs/protocol/transactions/eip-4337.mdx
+++ b/src/pages/docs/protocol/transactions/eip-4337.mdx
@@ -1,9 +1,10 @@
 ---
-title: EIP-4337 Comparison
+title: "Comparing Tempo Transactions and EIP-4337"
+seoTitle: "Tempo Transactions vs. EIP-4337 | Docs"
 description: "How Tempo Transactions achieve EIP-4337 goals without bundlers, paymasters, or EntryPoint contracts."
 ---
 
-# EIP-4337 and Tempo Transactions
+# Comparing Tempo Transactions and EIP-4337
 
 EIP-4337 introduced account abstraction to Ethereum through a system of bundlers, paymasters, and an EntryPoint contract. Tempo Transactions achieve the same goals through protocol-native features that require no additional infrastructure.
 

--- a/src/pages/docs/protocol/transactions/eip-7702.mdx
+++ b/src/pages/docs/protocol/transactions/eip-7702.mdx
@@ -1,9 +1,10 @@
 ---
-title: EIP-7702 Comparison
+title: "Comparing Tempo Transactions and EIP-7702"
+seoTitle: "Tempo Transactions vs. EIP-7702 | Docs"
 description: "How Tempo Transactions extend EIP-7702 delegation with additional signature schemes and native features."
 ---
 
-# EIP-7702 and Tempo Transactions
+# Comparing Tempo Transactions and EIP-7702
 
 EIP-7702 allows EOAs to delegate to smart contract code temporarily within a transaction. Tempo Transactions build on this foundation and extend it with additional capabilities.
 

--- a/src/pages/docs/protocol/transactions/index.mdx
+++ b/src/pages/docs/protocol/transactions/index.mdx
@@ -1,12 +1,13 @@
 ---
-title: Tempo Transactions
+title: "Tempo Transactions: protocol overview"
+seoTitle: "Tempo Transactions Protocol Overview | Docs"
 description: Learn about Tempo Transactions, a new EIP-2718 transaction type with passkey support, fee sponsorship, batching, and concurrent execution.
 ---
 
 import { Cards, Card } from 'vocs'
 import TempoTxProperties from '../../../../snippets/tempo-tx-properties.mdx'
 
-# Tempo Transactions
+# Tempo Transactions: protocol overview
 
 Tempo Transactions are a new [EIP-2718](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2718.md) transaction type, exclusively available on Tempo.
 

--- a/src/pages/docs/protocol/zones/accounts.mdx
+++ b/src/pages/docs/protocol/zones/accounts.mdx
@@ -1,9 +1,10 @@
 ---
-title: Accounts
+title: "Accounts and private balances in Tempo Zones on testnet"
+seoTitle: "Accounts & Private Balances in Tempo Zones on Testnet | Docs"
 description: Account-scoped access control on Tempo Zones, including private balances, private allowances, and the two-layer privacy model.
 ---
 
-# Accounts
+# Accounts and private balances in Tempo Zones on testnet
 
 :::info
 Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/protocol/zones/bridging.mdx
+++ b/src/pages/docs/protocol/zones/bridging.mdx
@@ -1,9 +1,10 @@
 ---
-title: Zone Bridging
+title: "Zone bridging on Tempo testnet"
+seoTitle: "Zone Bridging: Deposits & Withdrawals on Testnet | Docs"
 description: Deposit and withdraw TIP-20 tokens between Tempo Mainnet and Tempo Zones, including encrypted deposits and composable withdrawal callbacks.
 ---
 
-# Zone Bridging
+# Zone bridging on Tempo testnet
 
 :::info
 Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/protocol/zones/execution.mdx
+++ b/src/pages/docs/protocol/zones/execution.mdx
@@ -1,9 +1,10 @@
 ---
-title: Execution & Gas
+title: "Execution and gas costs within a Tempo Zone on testnet"
+seoTitle: "Execution & Gas in Tempo Zones on Testnet | Docs"
 description: Specification for gas accounting, fee tokens, fixed TIP-20 gas costs, contract creation limits, and token management on Tempo Zones.
 ---
 
-# Execution & Gas
+# Execution and gas costs within a Tempo Zone on testnet
 
 :::info
 Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/protocol/zones/index.mdx
+++ b/src/pages/docs/protocol/zones/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Tempo Zones
+title: "Tempo Zones: testnet private transaction protocol"
+seoTitle: "Tempo Zones: Testnet Privacy Protocol | Docs"
 description: Tempo Zones are private execution environments on Tempo Mainnet where balances, transfers, and transaction history are invisible to the public chain.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Tempo Zones
+# Tempo Zones: testnet private transaction protocol
 
 :::info
 Tempo Zones are still in early development and available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/protocol/zones/proving.mdx
+++ b/src/pages/docs/protocol/zones/proving.mdx
@@ -1,11 +1,12 @@
 ---
-title: Zone Proving
+title: "Planned Tempo Zone proving"
+seoTitle: "Tempo Zone Proving: Planned Design | Docs"
 description: Batch submission and proof verification for Tempo zones, including the state transition function, ZK and TEE deployment modes, and ancestry proofs.
 ---
 
 import { StaticMermaidDiagram } from '../../../../components/StaticMermaidDiagram'
 
-# Zone Proving
+# Planned Tempo Zone proving
 
 :::info
 Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/protocol/zones/rpc.mdx
+++ b/src/pages/docs/protocol/zones/rpc.mdx
@@ -1,9 +1,10 @@
 ---
-title: Zone RPC
+title: "Tempo Zone RPC access control on testnet"
+seoTitle: "Tempo Zone RPC & Authorization Tokens on Testnet | Docs"
 description: Authenticated JSON-RPC interface for Tempo Zones with per-account scoping, timing side channel mitigations, and event filtering.
 ---
 
-# Zone RPC
+# Tempo Zone RPC access control on testnet
 
 :::info
 Tempo Zones is still in early development and is available for testing purposes on Tempo Testnet only. While Tempo Zones are in this stage, expect breaking changes to the design and implementation. Do not use this in production. If you're interested in working with Tempo Labs as a design partner on the development of Tempo Zones, contact us at [tempo.xyz/contact](https://tempo.xyz/contact).

--- a/src/pages/docs/quickstart/connection-details.mdx
+++ b/src/pages/docs/quickstart/connection-details.mdx
@@ -1,5 +1,6 @@
 ---
-title: Connect to the Network
+title: "How to connect to the Tempo network"
+seoTitle: "Connect to Tempo via Browser Wallet | Docs"
 description: Connect to Tempo using browser wallets, CLI tools, or direct RPC endpoints. Get chain ID, URLs, and configuration details.
 mipd: true
 interactive: true
@@ -8,7 +9,7 @@ interactive: true
 import * as Demo from '../../../components/guides/Demo.tsx'
 import { ConnectWallet } from '../../../components/ConnectWallet.tsx'
 
-# Connect to the Network
+# How to connect to the Tempo network
 
 You can connect with Tempo like you would with any other EVM chain.
 

--- a/src/pages/docs/quickstart/developer-tools.mdx
+++ b/src/pages/docs/quickstart/developer-tools.mdx
@@ -1,11 +1,12 @@
 ---
-title: Developer Tools
+title: "Tempo developer tools and infrastructure"
+seoTitle: "Tempo Developer Tools & Infrastructure | Docs"
 description: Explore Tempo's developer ecosystem with indexers, embedded wallets, node infrastructure, and analytics partners for building payment apps.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Developer Tools
+# Tempo developer tools and infrastructure
 
 Integrating with Tempo is easy by leveraging services provided by our infrastructure partners. These partners take advantage of Tempo Transactions, TIP-20 tokens, and more. Visit their documentation for more information on how to get started.
 

--- a/src/pages/docs/quickstart/evm-compatibility.mdx
+++ b/src/pages/docs/quickstart/evm-compatibility.mdx
@@ -1,11 +1,12 @@
 ---
-title: EVM Differences
+title: "Tempo EVM differences"
+seoTitle: "Tempo EVM Differences | Docs"
 description: Learn how Tempo differs from Ethereum. Understand wallet behavior, fee token selection, VM layer changes, and fast finality consensus.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# EVM Differences
+# Tempo EVM differences
 
 Tempo is fully compatible with the Ethereum Virtual Machine (EVM), targeting the **Osaka** EVM hard fork. Developers can deploy and interact with smart contracts using the same tools, languages, and frameworks they use on Ethereum, such as Solidity, Foundry, and Hardhat. All Ethereum JSON-RPC methods work out of the box. 
 

--- a/src/pages/docs/quickstart/faucet.mdx
+++ b/src/pages/docs/quickstart/faucet.mdx
@@ -1,5 +1,6 @@
 ---
-title: Faucet
+title: "Tempo faucet: get testnet funds"
+seoTitle: "Get Testnet Faucet Funds | Tempo Docs"
 description: Get free test stablecoins on Tempo Testnet. Connect your wallet or enter any address to receive pathUSD, AlphaUSD, BetaUSD, and ThetaUSD.
 mipd: true
 interactive: true
@@ -15,7 +16,7 @@ import * as Token from '../../../components/guides/tokens'
 import { Tabs, Tab } from 'vocs'
 
 
-# Faucet
+# Tempo faucet: get testnet funds
 
 Get test stablecoins on Tempo testnet.
 

--- a/src/pages/docs/quickstart/integrate-tempo.mdx
+++ b/src/pages/docs/quickstart/integrate-tempo.mdx
@@ -1,12 +1,13 @@
 ---
-title: Integrate Tempo
+title: "Integrating Tempo: getting started"
+seoTitle: "How to Integrate Tempo | Tempo Docs"
 description: Connect apps and wallets to Tempo with network configuration, faucet funding, EVM compatibility notes, bridges, verification, and ecosystem resources.
 interactive: true
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Integrate Tempo
+# Integrating Tempo: getting started
 
 Use this section when you are connecting an existing app, wallet, contract, bridge, or infrastructure service to Tempo. These pages cover the practical edges of integration: chain configuration, RPC endpoints, faucet funding, wallet support, EVM compatibility, predeploys, contract verification, and ecosystem resources.
 

--- a/src/pages/docs/quickstart/predeployed-contracts.mdx
+++ b/src/pages/docs/quickstart/predeployed-contracts.mdx
@@ -1,9 +1,10 @@
 ---
-title: Predeployed Contracts
+title: "Predeployed contracts on Tempo"
+seoTitle: "Tempo Predeployed Contracts | Docs"
 description: Discover Tempo's predeployed system contracts including TIP-20 Factory, Fee Manager, Stablecoin DEX, and standard utilities like Multicall3.
 ---
 
-# Predeployed Contracts
+# Predeployed contracts on Tempo
 
 ## System Contracts
 

--- a/src/pages/docs/quickstart/verify-contracts.mdx
+++ b/src/pages/docs/quickstart/verify-contracts.mdx
@@ -1,9 +1,10 @@
 ---
-title: Contract Verification
+title: "Contract verification using Foundry"
+seoTitle: "Verify Contracts with Foundry | Docs"
 description: Verify your smart contracts on Tempo using contracts.tempo.xyz. Sourcify-compatible verification with Foundry integration.
 ---
 
-# Contract Verification
+# Contract verification using Foundry
 
 Verify your smart contracts on Tempo using [contracts.tempo.xyz](https://contracts.tempo.xyz), a Sourcify-compatible contract verification service. Verified contracts display source code and ABI in the [Tempo Explorer](https://explore.tempo.xyz), making it easier for users to interact with your contracts.
 

--- a/src/pages/docs/quickstart/wallet-developers.mdx
+++ b/src/pages/docs/quickstart/wallet-developers.mdx
@@ -1,12 +1,13 @@
 ---
-title: Wallet Developer Guide
+title: "Integrating wallet support for Tempo"
+seoTitle: "Wallet Developer Guide | Tempo Docs"
 description: Integrate Tempo into your wallet. Use Tempo Transactions for fee token selection, fee sponsorship, batching, and concurrent execution.
 showOutline: 1
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Wallet Developer Guide
+# Integrating wallet support for Tempo
 
 Tempo is EVM-compatible, so standard transactions work out of the box. However, Tempo has [no native gas token](/docs/quickstart/evm-compatibility#handling-eth-native-token-balance-checks), which means wallet behaviors like balance display and gas quoting need adjustment.
 

--- a/src/pages/docs/sdk/foundry/index.mdx
+++ b/src/pages/docs/sdk/foundry/index.mdx
@@ -1,9 +1,10 @@
 ---
-title: Foundry for Tempo
+title: "Using Foundry with Tempo"
+seoTitle: "Foundry for Tempo | Tempo Docs"
 description: Build, test, and deploy smart contracts on Tempo using Foundry. Access Tempo protocol features with forge, cast, anvil, and chisel.
 ---
 
-# Foundry for Tempo
+# Using Foundry with Tempo
 
 Tempo is supported as a first-class citizen in [Foundry](https://github.com/foundry-rs/foundry): the leading Ethereum development toolkit.
 

--- a/src/pages/docs/sdk/foundry/mpp.mdx
+++ b/src/pages/docs/sdk/foundry/mpp.mdx
@@ -1,11 +1,12 @@
 ---
-title: Foundry Integration
+title: "Using MPP with Foundry"
+seoTitle: "Use MPP with Foundry | Tempo Docs"
 description: Use Foundry tools (cast, forge, anvil, chisel) with MPP-gated RPC endpoints on Tempo — automatic 402 handling with zero config.
 ---
 
 import { Card, Cards } from 'vocs'
 
-# Use MPP with Foundry
+# Using MPP with Foundry
 
 Foundry includes native MPP support on Tempo. When an RPC endpoint returns `402 Payment Required`, Foundry automatically handles the payment challenge with no wrapper scripts, middleware, or code changes.
 

--- a/src/pages/docs/sdk/go/index.mdx
+++ b/src/pages/docs/sdk/go/index.mdx
@@ -1,9 +1,10 @@
 ---
-title: Go SDK
+title: "Tempo Go SDK: installing and using it"
+seoTitle: "Go SDK: Install & Use | Tempo Docs"
 description: Build blockchain apps with the Tempo Go SDK. Send transactions, batch calls, and handle fee sponsorship with idiomatic Go code.
 ---
 
-# Go SDK
+# Tempo Go SDK: installing and using it
 
 Tempo distributes a Go SDK for building application clients. The SDK provides packages for RPC communication, transaction signing, and key management.
 

--- a/src/pages/docs/sdk/index.mdx
+++ b/src/pages/docs/sdk/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Tempo SDKs
+title: "Tempo SDKs: available languages and tools"
+seoTitle: "Tempo SDKs: Go, Python, Rust & TS | Docs"
 description: Integrate Tempo into your applications with SDKs for TypeScript, Go, Rust, and Foundry. Build blockchain apps in your preferred language.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Tempo SDKs
+# Tempo SDKs: available languages and tools
 
 Tempo is building clients in multiple languages to make integration as easy as possible.
 

--- a/src/pages/docs/sdk/python/index.mdx
+++ b/src/pages/docs/sdk/python/index.mdx
@@ -1,9 +1,10 @@
 ---
-title: Python SDK
+title: "Tempo Python SDK: installing and using it"
+seoTitle: "Python SDK: Install & Use | Docs"
 description: Build blockchain apps with the Tempo Python SDK. Send transactions, batch calls, and handle fee sponsorship using web3.py.
 ---
 
-# Python SDK
+# Tempo Python SDK: installing and using it
 
 Tempo distributes a Python SDK as a [web3.py](https://web3py.readthedocs.io/) extension. The SDK adds native support for Tempo Transactions, including call batching, fee sponsorship, and access key management.
 

--- a/src/pages/docs/sdk/rust/index.mdx
+++ b/src/pages/docs/sdk/rust/index.mdx
@@ -1,9 +1,10 @@
 ---
-title: Rust SDK
+title: "Tempo Rust SDK: installing and using it"
+seoTitle: "Rust SDK: Install & Use | Tempo Docs"
 description: Build blockchain apps with the Tempo Rust SDK using Alloy. Query chains, send transactions, and manage tokens with type-safe Rust code.
 ---
 
-# Rust SDK
+# Tempo Rust SDK: installing and using it
 
 Tempo distributes a Rust SDK in the form of an [Alloy](https://alloy.rs) crate. Alloy is a popular Rust crate for interacting with EVM-compatible blockchains.
 

--- a/src/pages/docs/sdk/typescript/index.mdx
+++ b/src/pages/docs/sdk/typescript/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: TypeScript SDKs
+title: "TypeScript SDKs: Viem extension and Account SDK"
+seoTitle: "TypeScript SDKs: Viem & Account SDK | Docs"
 description: Build blockchain apps with Tempo using Viem and Wagmi. Send transactions, manage tokens, and integrate AMM pools with TypeScript.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# TypeScript SDKs
+# TypeScript SDKs: Viem extension and Account SDK
 
 Tempo distributes TypeScript SDKs for:
 - [Viem](https://viem.sh): TypeScript interface for EVM blockchains

--- a/src/pages/docs/sdk/typescript/prool/setup.mdx
+++ b/src/pages/docs/sdk/typescript/prool/setup.mdx
@@ -1,9 +1,10 @@
 ---
-title: Prool Setup
+title: "Prool setup: local Tempo test environment"
+seoTitle: "Set Up a Local Test Env with Prool | Docs"
 description: Set up infinite pooled Tempo node instances in TypeScript with Prool for testing and local development of blockchain applications.
 ---
 
-# Prool Setup
+# Prool setup: local Tempo test environment
 
 Setup infinite pooled Tempo node instances in TypeScript using [`prool`](https://github.com/wevm/prool) by following the steps below.
 

--- a/src/pages/docs/server/index.mdx
+++ b/src/pages/docs/server/index.mdx
@@ -1,11 +1,12 @@
 ---
-title: Server Utilities
+title: "Server utilities: Relay and Fee Payer Handler"
+seoTitle: "Server Utilities: Relay & Fee Payer | Docs"
 description: Run framework-agnostic utilities for server-side protocol operations.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Server Utilities
+# Server utilities: Relay and Fee Payer Handler
 
 Server utilities are distributed through the Tempo API library, [`tapimo`](https://npm.im/tapimo). They work with frameworks that support either:
 

--- a/src/pages/docs/tools.mdx
+++ b/src/pages/docs/tools.mdx
@@ -1,11 +1,12 @@
 ---
-title: Tools & SDKs
+title: "Tempo developer tools and SDKs"
+seoTitle: "Tempo Tools & SDKs | Tempo Docs"
 description: Find Tempo SDKs, CLI commands, API docs, wallet docs, RPC references, and indexer tools for building, testing, and operating production integrations.
 ---
 
 import { Cards, Card } from 'vocs'
 
-# Tools & SDKs
+# Tempo developer tools and SDKs
 
 Use this section when you need the implementation surface for Tempo: libraries, command-line tools, APIs, wallet integration, RPC references, and query access to network data.
 

--- a/src/pages/docs/wallet/index.mdx
+++ b/src/pages/docs/wallet/index.mdx
@@ -1,9 +1,10 @@
 ---
-title: Tempo Wallet CLI
+title: "Tempo Wallet CLI: overview"
+seoTitle: "Tempo Wallet CLI | Tempo Docs"
 description: Use Tempo Wallet CLI from the command line for wallet management, MPP service discovery, paid requests, and AI agent workflows.
 ---
 
-# Tempo Wallet CLI
+# Tempo Wallet CLI: overview
 
 Tempo Wallet CLI is the command-line way to use Tempo Wallet from scripts, terminals, and AI agents. It has two command families:
 

--- a/src/pages/docs/wallet/recipes.mdx
+++ b/src/pages/docs/wallet/recipes.mdx
@@ -1,9 +1,10 @@
 ---
-title: Tempo Wallet CLI Recipes
+title: "Tempo Wallet CLI: core flow recipes"
+seoTitle: "Tempo Wallet CLI Recipes | Docs"
 description: Use Tempo Wallet CLI recipes for agent setup, MPP service discovery, paid requests, credits, sessions, funding, and transfers.
 ---
 
-# Tempo Wallet Recipes
+# Tempo Wallet CLI: core flow recipes
 
 ## Tempo Wallet core flow
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -74,8 +74,11 @@ export default defineConfig({
     text: 'Suggest changes to this page',
   },
   title: 'Tempo Docs',
-  titleTemplate: (path, { title }) => {
+  titleTemplate: (path, { frontmatter, title }) => {
     const pagePath = typeof path === 'string' ? path : '/'
+    const seoTitle =
+      typeof frontmatter?.seoTitle === 'string' ? frontmatter.seoTitle.trim() : undefined
+    if (seoTitle) return seoTitle
     if (pagePath === '/docs') return 'Tempo %s ⋅ Tempo Docs'
     if (pagePath.startsWith('/docs/')) return '%s ⋅ Tempo Docs'
     if (title?.includes('Tempo')) return undefined


### PR DESCRIPTION
## Summary

- Implements the Graphite docs audit across 106 unique routes with exact browser/search titles and sentence-case H1s.
- Adds optional `seoTitle` support through the existing Vocs title template, while social metadata, JSON-LD, search, per-page Markdown, and LLM files continue to use the concise page title.
- Adds the Vocs OpenAPI title workaround for the 15 affected authored API pages, plus source and prerendered regression coverage.

Audit sheet: https://docs.google.com/spreadsheets/d/1wGBu4TryOAszj8_RGphbwNHPG1C8VStuP8KMaHttNu0/edit?gid=597607054#gid=597607054

## Scope decisions

- Preserves jxom's current metadata on authentication, fee payer, indexer, and JSON-RPC from #760.
- Uses the `Promote existing signal` recommendations for the duplicated Go, Python, and Rust SDK rows.
- Leaves all 58 `No changes needed` routes untouched.
- Leaves the sitemap, canonical-link, generated-Markdown, and LLM generation systems from #768, #770, and related merged work unchanged.

## Claim-safe adjustments

A small set of audit recommendations were tightened to match the source docs:

- Provider directory pages do not imply exclusivity.
- Validator onboarding does not imply open enrollment.
- `feePayer` is described as a field, not a primitive.
- Tempo Zones titles state testnet or planned status, and the deposit/withdraw guides name pathUSD.
- TIP-403 receive policies do not claim a compliance outcome.
- Rhetorical titles and em dashes were replaced to match Tempo style.
- The existing Fee AMM anchor remains available for internal and external deep links.

## Validation

- `CI=true pnpm test`: 312 tests passed
- `CI=true VERCEL=1 VERCEL_ENV=production NODE_OPTIONS=--max-old-space-size=4096 pnpm build`
- Generated public-link audit passed across 234 HTML, 233 RSC, 221 Markdown, and 2 LLM files for both Vite and Vercel outputs
- Markdown output audit passed with no unresolved or presentation-only elements
- Vercel sitemap audit passed for 48 canonical API routes
- 15 prerendered SEO and structured-data browser tests passed against the Vercel artifact
- Independent workbook verification confirmed 106 changed audit routes, 58 untouched routes, and 4 preserved jxom routes