### PR TITLE
fix: reorder docs section navigation

### DIFF
--- a/src/components/DocsSectionNav.tsx
+++ b/src/components/DocsSectionNav.tsx
@@ -45,12 +45,6 @@ const sectionNavItems: SectionNavItem[] = [
     ],
   },
   {
-    id: 'protocol',
-    label: 'Tempo Protocol',
-    href: '/docs/protocol',
-    matches: ['/docs/protocol'],
-  },
-  {
     id: 'tools',
     label: 'Tools & SDKs',
     href: '/docs/tools',
@@ -69,6 +63,12 @@ const sectionNavItems: SectionNavItem[] = [
     label: 'Tempo API',
     href: '/docs/api',
     matches: ['/docs/api'],
+  },
+  {
+    id: 'protocol',
+    label: 'Tempo Protocol',
+    href: '/docs/protocol',
+    matches: ['/docs/protocol'],
   },
   {
     id: 'node',


### PR DESCRIPTION
## Summary

- move Tempo Protocol after Tools & SDKs and Tempo API in the docs section navigation

## Validation

- `pnpm check:types`
- `git diff --check`
- test/build startup blocked because the remote OpenAPI spec could not be fetched from this sandbox

Prompted by: @brendanjryan