### PR TITLE
feat(navigation): promote Tempo API

### DIFF
--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -67,6 +67,12 @@ const developersMenu: MegaMenuData = {
           href: TEMPO_DOCS_URL,
           icon: <DocsIcon />,
         },
+        {
+          label: 'Tempo API',
+          desc: 'Hosted APIs for payments',
+          href: '/docs/api',
+          icon: <ApiIcon />,
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary

- add Tempo API to the developer site Resources menu beside Docs
- link directly to the canonical API overview at `/docs/api`