### PR TITLE
feat(navigation): add Tempo API to reference section

### DIFF
--- a/src/lib/vocs-config-seo.test.ts
+++ b/src/lib/vocs-config-seo.test.ts
@@ -127,4 +127,16 @@ describe('vocs.config docs SEO controls', () => {
     expect(sidebar).toContain('https://tips.sh/')
     expect(sidebar).not.toContain('"/docs/protocol/tips"')
   })
+
+  test('links Tempo API from the docs home reference section', () => {
+    const sidebar = vocsConfig.sidebar as Record<
+      string,
+      Array<{ text: string; items?: Array<{ text: string; link: string }> }>
+    >
+    const referenceSection = sidebar['/docs']?.find(
+      (item) => item.text === 'Reference and Operations',
+    )
+
+    expect(referenceSection?.items).toContainEqual({ text: 'Tempo API', link: '/docs/api' })
+  })
 })

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1186,6 +1186,7 @@ export default defineConfig({
         text: 'Reference and Operations',
         items: [
           { text: 'Tools & SDKs', link: '/docs/tools' },
+          { text: 'Tempo API', link: '/docs/api' },
           { text: 'Tempo Protocol', link: '/docs/protocol' },
           { text: 'Run a Tempo Node', link: '/docs/guide/node' },
           { text: 'Use Tempo with AI', link: '/docs/guide/using-tempo-with-ai' },


### PR DESCRIPTION
## Summary

- add Tempo API to the docs home sidebar under Reference and Operations
- link the entry to the existing `/docs/api` overview
- add regression coverage for the sidebar destination

## Why

The docs landing page already exposes Tempo API in its reference cards and section navigation, but the home sidebar omitted it. This makes the navigation consistent and gives readers a direct route to the API documentation.

## Validation

- `CI=true VITE_USE_HTTP=true pnpm exec vitest run src/lib/vocs-config-seo.test.ts`
- `pnpm run check:types`
- `git diff --check`