### PR TITLE
Ensure one title and H1 per docs page

### DIFF
--- a/e2e/document-semantics.test.ts
+++ b/e2e/document-semantics.test.ts
@@ -1,0 +1,94 @@
+import { readdirSync } from 'node:fs'
+import { dirname, join, relative, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from '@playwright/test'
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const publicOutputRoot = join(repositoryRoot, 'dist/public')
+
+// The production build is the route source of truth, including generated OpenAPI pages.
+// Keep local dev runs light; CI builds the artifact before Playwright starts.
+const publicRoutes = process.env.CI ? discoverPublicRoutes(publicOutputRoot) : []
+
+test.skip(!process.env.CI, 'requires the production build output')
+
+for (const route of publicRoutes) {
+  test(`single title and H1 for ${route}`, async ({ page, request }) => {
+    const response = await request.get(route)
+    expect(response.status(), `${route} should be served`).toBe(200)
+
+    const html = await response.text()
+    const rawHead = html.match(/<head\b[^>]*>([\s\S]*?)<\/head>/i)?.[1]
+    expect(rawHead, `${route} should have a prerendered head`).toBeDefined()
+    expect(
+      rawHead?.match(/<title(?:\s[^>]*)?>[\s\S]*?<\/title>/gi) ?? [],
+      `${route} should have one prerendered document title`,
+    ).toHaveLength(1)
+
+    await page.goto(route, { waitUntil: 'networkidle' })
+
+    // Scope document titles to the head. SVG <title> nodes in the body provide
+    // accessible names and are valid, unrelated markup.
+    await expect(page.locator('head > title'), `${route} document title`).toHaveCount(1)
+    await expect(page.locator('h1'), `${route} primary heading`).toHaveCount(1)
+    await expect(
+      page.locator('head > meta[name="description"]'),
+      `${route} description`,
+    ).toHaveCount(1)
+    await expect(
+      page.locator('head > meta[property="og:title"]'),
+      `${route} Open Graph title`,
+    ).toHaveCount(1)
+    // E2E builds intentionally omit baseUrl, so canonical may be absent. It must never duplicate.
+    expect(
+      await page.locator('head > link[rel="canonical"]').count(),
+      `${route} canonical URL`,
+    ).toBeLessThanOrEqual(1)
+  })
+}
+
+test('keeps one route title through docs and OpenAPI client navigation', async ({ page }) => {
+  await page.goto('/docs/quickstart/integrate-tempo', { waitUntil: 'networkidle' })
+  await expectSingleTitle(page, 'How to Integrate Tempo | Tempo Docs')
+
+  await page.locator('a[href="/docs/api"]:visible').first().click()
+  await page.waitForURL(/\/docs\/api\/?$/)
+  await expectSingleTitle(page, 'Start with the Tempo API | Tempo Docs')
+
+  await page.locator('a[href="/docs/api/transactions"]:visible').first().click()
+  await page.waitForURL(/\/docs\/api\/transactions\/?$/)
+  await expectSingleTitle(page, 'Tempo Transactions API Reference | Docs')
+
+  await page.locator('a[href="/docs/api/transfers"]:visible').first().click()
+  await page.waitForURL(/\/docs\/api\/transfers\/?$/)
+  await expectSingleTitle(page, 'Stablecoin Transfers API | Tempo Docs')
+})
+
+test('gives missing pages one noindex title and one H1', async ({ page }) => {
+  const response = await page.goto('/this-page-does-not-exist', { waitUntil: 'networkidle' })
+  expect(response?.status()).toBe(404)
+  await expectSingleTitle(page, 'Page not found ⋅ Tempo Docs')
+  await expect(page.locator('h1')).toHaveCount(1)
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'noindex, nofollow')
+})
+
+async function expectSingleTitle(page: import('@playwright/test').Page, expectedTitle: string) {
+  await expect(page.locator('head > title')).toHaveCount(1)
+  await expect(page).toHaveTitle(expectedTitle)
+}
+
+function discoverPublicRoutes(directory: string): string[] {
+  return findIndexFiles(directory)
+    .map((file) => relative(directory, dirname(file)))
+    .filter((route) => !route.split(sep).some((segment) => segment.endsWith('.d')))
+    .map((route) => (route ? `/${route.split(sep).join('/')}` : '/'))
+    .sort((a, b) => a.localeCompare(b))
+}
+
+function findIndexFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name)
+    if (entry.isDirectory()) return findIndexFiles(entryPath)
+    return entry.isFile() && entry.name === 'index.html' ? [entryPath] : []
+  })
+}

--- a/e2e/seo-head.test.ts
+++ b/e2e/seo-head.test.ts
@@ -31,6 +31,10 @@ function metaContent(head: string, selector: string) {
   return match?.[1] ?? attrFirst?.[1]
 }
 
+function titleElements(head: string) {
+  return head.match(/<title(?:\s[^>]*)?>[\s\S]*?<\/title>/gi) ?? []
+}
+
 const cases: {
   path: string
   title: string
@@ -100,7 +104,9 @@ for (const c of cases) {
   test(`prerendered head for ${c.path}`, async ({ request }) => {
     const head = await fetchHead(request, c.path)
 
-    expect(head).toContain(`<title>${c.title}</title>`)
+    expect(titleElements(head), `${c.path} should have one exact document title`).toEqual([
+      `<title>${c.title}</title>`,
+    ])
     expect(metaContent(head, 'og:title')).toBe(c.ogTitle)
     expect(metaContent(head, 'description')).toContain(c.descriptionIncludes)
     expect(metaContent(head, 'og:description')).toContain(c.descriptionIncludes)

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "unplugin-auto-import": "^21.0.0",
     "unplugin-icons": "^23.0.1",
     "viem": "^2.54.6",
-    "vocs": "^2.7.2",
+    "vocs": "2.7.2",
     "wagmi": "3.6.20",
     "waku": "^1.0.0-beta.6",
     "webauthx": "~0.1.2",

--- a/patches/vocs@2.7.2.patch
+++ b/patches/vocs@2.7.2.patch
@@ -1,0 +1,368 @@
+diff --git a/dist/react/Head.d.ts b/dist/react/Head.d.ts
+index 8ad0e7d1635b9ca6b13ef2fb4ac9dd1ca9b6fbff..0131bb7f9ccff37b90550a98e7e47d3e69f3ea66 100644
+--- a/dist/react/Head.d.ts
++++ b/dist/react/Head.d.ts
+@@ -3,6 +3,7 @@ export declare function Head(props: Head.Props): import("react/jsx-runtime").JSX
+ export declare namespace Head {
+     type Props = {
+         includeJsonLd?: boolean | undefined;
++        includeTitle?: boolean | undefined;
+     };
+ }
+ export declare function resolveTitleTemplate(config: Pick<Config.Config, 'title' | 'titleTemplate'>, path: string, title: string | undefined, frontmatter: Config.Frontmatter | undefined): string | undefined;
+diff --git a/dist/react/Head.js b/dist/react/Head.js
+index 9c7425584c057838cf328fcbff9b64005122268a..c219650a597c1a21db65c64c4410b6c7de967e44 100644
+--- a/dist/react/Head.js
++++ b/dist/react/Head.js
+@@ -6,7 +6,7 @@ import * as JsonLd from './json-ld.js';
+ import * as MdxPageContext from './MdxPageContext.js';
+ import { useConfig } from './useConfig.js';
+ export function Head(props) {
+-    const { includeJsonLd = true } = props;
++    const { includeJsonLd = true, includeTitle = true } = props;
+     const config = useConfig();
+     const { path: pathname } = useRouter();
+     const { frontmatter } = MdxPageContext.use();
+@@ -90,7 +90,7 @@ export function Head(props) {
+                 // biome-ignore lint/security/noDangerouslySetInnerHtml: blocking script to prevent FOUC
+                 dangerouslySetInnerHTML: {
+                     __html: `(function(){try{var e=document.documentElement;var s=function(t){e.setAttribute('data-vocs-theme',t);e.style.colorScheme=t};var t=localStorage.getItem('vocs-theme');if(t==='light'||t==='dark'){s(t)}else if(window.matchMedia('(prefers-color-scheme:dark)').matches){s('dark')}else if(window.matchMedia('(prefers-color-scheme:light)').matches){s('light')}else{s('dark')}}catch(e){}})()`,
+-                } })), _jsx("meta", { name: "color-scheme", content: colorScheme }), !disabled && (_jsxs(_Fragment, { children: [fullTitle && _jsx("title", { children: fullTitle }, "title"), base && _jsx("base", { href: base }), canonical && _jsx("link", { rel: "canonical", href: canonical }), icons && iconUrl && typeof iconUrl === 'string' && (_jsx("link", { rel: "icon", href: iconUrl, type: getIconType(iconUrl) })), icons && iconUrl && typeof iconUrl !== 'string' && (_jsx("link", { rel: "icon", href: iconUrl.light, type: getIconType(iconUrl.light) })), icons && iconUrl && typeof iconUrl !== 'string' && (_jsx("link", { rel: "icon", href: iconUrl.dark, type: getIconType(iconUrl.dark), media: "(prefers-color-scheme: dark)" })), metaTags.map((tag, index) => {
++                } })), _jsx("meta", { name: "color-scheme", content: colorScheme }), !disabled && (_jsxs(_Fragment, { children: [includeTitle && fullTitle && _jsx("title", { children: fullTitle }, "title"), base && _jsx("base", { href: base }), canonical && _jsx("link", { rel: "canonical", href: canonical }), icons && iconUrl && typeof iconUrl === 'string' && (_jsx("link", { rel: "icon", href: iconUrl, type: getIconType(iconUrl) })), icons && iconUrl && typeof iconUrl !== 'string' && (_jsx("link", { rel: "icon", href: iconUrl.light, type: getIconType(iconUrl.light) })), icons && iconUrl && typeof iconUrl !== 'string' && (_jsx("link", { rel: "icon", href: iconUrl.dark, type: getIconType(iconUrl.dark), media: "(prefers-color-scheme: dark)" })), metaTags.map((tag, index) => {
+                         const { charset: charSet, content, 'http-equiv': httpEquiv, media, name, property, } = tag;
+                         return (_jsx("meta", { charSet: charSet, httpEquiv: httpEquiv, name: name, property: property, content: content != null ? String(content) : undefined, media: media }, `${name ?? property ?? httpEquiv ?? charSet}-${index}`));
+                     }), jsonLd && (_jsx("script", { type: "application/ld+json",
+diff --git a/dist/react/Layout.d.ts b/dist/react/Layout.d.ts
+index 05018ae8161c97a55f2a20a9d43336d09b743dd1..ceb3eccc4b72bf23495ee73984f573321d6add7d 100644
+--- a/dist/react/Layout.d.ts
++++ b/dist/react/Layout.d.ts
+@@ -3,6 +3,7 @@ export declare namespace Layout {
+     type Props = {
+         children: React.ReactNode;
+         includeJsonLd?: boolean | undefined;
++        includeTitle?: boolean | undefined;
+     };
+ }
+ //# sourceMappingURL=Layout.d.ts.map
+diff --git a/dist/react/Layout.js b/dist/react/Layout.js
+index dd8f3a8162c7c39e4fb39b58cc2cdca86cdfd01b..4d95f74ad43abafedb9828b74af25f64c517c68a 100644
+--- a/dist/react/Layout.js
++++ b/dist/react/Layout.js
+@@ -2,7 +2,7 @@ import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-run
+ import { Head } from './Head.js';
+ import * as Layout_client from './Layout.client.js';
+ export function Layout(props) {
+-    const { children, includeJsonLd } = props;
+-    return (_jsxs(_Fragment, { children: [_jsx(Head, { includeJsonLd: includeJsonLd }), _jsx(Layout_client.Main, { children: children })] }));
++    const { children, includeJsonLd, includeTitle } = props;
++    return (_jsxs(_Fragment, { children: [_jsx(Head, { includeJsonLd: includeJsonLd, includeTitle: includeTitle }), _jsx(Layout_client.Main, { children: children })] }));
+ }
+ //# sourceMappingURL=Layout.js.map
+diff --git a/dist/react/Root.js b/dist/react/Root.js
+index 641cee118919e649fc5d977bcfc3f4e62b003007..ca0c37a66be101dca6a311fea394592f21bdb95e 100644
+--- a/dist/react/Root.js
++++ b/dist/react/Root.js
+@@ -3,13 +3,12 @@ import { config } from 'virtual:vocs/config';
+ import groupIconsStylesUrl from 'virtual:vocs/group-icons.css?url';
+ import userStylesUrl from 'virtual:vocs/user-styles';
+ import stylesUrl from '../styles/index.css?url';
+-import { Head } from './Head.js';
+ import { Root_client } from './Root.client.js';
+ import { ScrollRestoration } from './ScrollRestoration.js';
+ export async function Root({ children }) {
+     const { colorScheme, accentColor } = config;
+     return (_jsxs("html", { "data-vocs": true, ...(colorScheme === 'light' || colorScheme === 'dark'
+             ? { 'data-vocs-theme': colorScheme }
+-            : {}), lang: "en", style: { colorScheme, '--vocs-color-accent': accentColor }, suppressHydrationWarning: true, children: [_jsxs("head", { children: [_jsx("link", { rel: "stylesheet", href: stylesUrl }), userStylesUrl && _jsx("link", { rel: "stylesheet", href: userStylesUrl }), groupIconsStylesUrl && _jsx("link", { rel: "stylesheet", href: groupIconsStylesUrl }), _jsx(Head, { includeJsonLd: false })] }), _jsxs("body", { "data-version": "1.0", children: [_jsx(Root_client, { children: children }), _jsx(ScrollRestoration, {})] })] }));
++            : {}), lang: "en", style: { colorScheme, '--vocs-color-accent': accentColor }, suppressHydrationWarning: true, children: [_jsxs("head", { children: [_jsx("link", { rel: "stylesheet", href: stylesUrl }), userStylesUrl && _jsx("link", { rel: "stylesheet", href: userStylesUrl }), groupIconsStylesUrl && _jsx("link", { rel: "stylesheet", href: groupIconsStylesUrl })] }), _jsxs("body", { "data-version": "1.0", children: [_jsx(Root_client, { children: children }), _jsx(ScrollRestoration, {})] })] }));
+ }
+ //# sourceMappingURL=Root.js.map
+diff --git a/dist/react/internal/NotFound.js b/dist/react/internal/NotFound.js
+index b189ea50873a5ef76bf044003476bf4660e9e245..c6c80e0ecde6655ea8fdda0f60e07aef0c237824 100644
+--- a/dist/react/internal/NotFound.js
++++ b/dist/react/internal/NotFound.js
+@@ -1,8 +1,9 @@
+-import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
++import { jsx as _jsx, Fragment as _Fragment, jsxs as _jsxs } from "react/jsx-runtime";
++import { config } from 'virtual:vocs/config';
+ import { Link } from 'waku';
+ import LucideFileQuestion from '~icons/lucide/file-question';
+ import LucideHome from '~icons/lucide/home';
+ export function NotFound() {
+-    return (_jsxs("div", { className: "vocs:flex vocs:flex-col vocs:items-center vocs:justify-center vocs:min-h-[60vh] vocs:px-6 vocs:py-16 vocs:text-center", "data-v-not-found": true, children: [_jsx("div", { className: "vocs:flex vocs:items-center vocs:justify-center vocs:size-20 vocs:rounded-full vocs:bg-surface vocs:border vocs:border-primary vocs:text-secondary vocs:mb-6", "data-v-not-found-icon": true, children: _jsx(LucideFileQuestion, { className: "vocs:size-10" }) }), _jsx("h1", { className: "vocs:text-heading vocs:text-h1 vocs:font-medium vocs:tracking-[-0.04em] vocs:leading-h1 vocs:mb-3", "data-v-not-found-title": true, children: "Page not found" }), _jsx("p", { className: "vocs:text-secondary vocs:leading-p vocs:tracking-normal vocs:max-w-md vocs:mb-8", "data-v-not-found-description": true, children: "The page you're looking for doesn't exist or has been moved." }), _jsxs(Link, { className: "vocs:inline-flex vocs:items-center vocs:gap-2 vocs:px-5 vocs:py-2.5 vocs:rounded-lg vocs:bg-surface vocs:border vocs:border-primary vocs:text-heading vocs:font-medium vocs:transition-colors vocs:duration-150 vocs:hover:bg-surfaceMuted", "data-v-not-found-link": true, to: "/", children: [_jsx(LucideHome, { className: "vocs:size-4 vocs:text-secondary" }), "Back to home"] })] }));
++    return (_jsxs(_Fragment, { children: [_jsx("title", { children: `Page not found ⋅ ${config.title}` }), _jsx("meta", { name: "robots", content: "noindex, nofollow" }), _jsxs("div", { className: "vocs:flex vocs:flex-col vocs:items-center vocs:justify-center vocs:min-h-[60vh] vocs:px-6 vocs:py-16 vocs:text-center", "data-v-not-found": true, children: [_jsx("div", { className: "vocs:flex vocs:items-center vocs:justify-center vocs:size-20 vocs:rounded-full vocs:bg-surface vocs:border vocs:border-primary vocs:text-secondary vocs:mb-6", "data-v-not-found-icon": true, children: _jsx(LucideFileQuestion, { className: "vocs:size-10" }) }), _jsx("h1", { className: "vocs:text-heading vocs:text-h1 vocs:font-medium vocs:tracking-[-0.04em] vocs:leading-h1 vocs:mb-3", "data-v-not-found-title": true, children: "Page not found" }), _jsx("p", { className: "vocs:text-secondary vocs:leading-p vocs:tracking-normal vocs:max-w-md vocs:mb-8", "data-v-not-found-description": true, children: "The page you're looking for doesn't exist or has been moved." }), _jsxs(Link, { className: "vocs:inline-flex vocs:items-center vocs:gap-2 vocs:px-5 vocs:py-2.5 vocs:rounded-lg vocs:bg-surface vocs:border vocs:border-primary vocs:text-heading vocs:font-medium vocs:transition-colors vocs:duration-150 vocs:hover:bg-surfaceMuted", "data-v-not-found-link": true, to: "/", children: [_jsx(LucideHome, { className: "vocs:size-4 vocs:text-secondary" }), "Back to home"] })] })] }));
+ }
+ //# sourceMappingURL=NotFound.js.map
+diff --git a/dist/react/internal/openapi/OpenApiPage.js b/dist/react/internal/openapi/OpenApiPage.js
+index 06cc466393643245bf0dfcc0c946e013c717a75c..e5b39e12c9e2017238a9744412943e2ea489e2fb 100644
+--- a/dist/react/internal/openapi/OpenApiPage.js
++++ b/dist/react/internal/openapi/OpenApiPage.js
+@@ -21,7 +21,7 @@ function OpenApiLayout(props) {
+             ...props.frontmatter,
+             content: { ...props.frontmatter?.content, width: props.width ?? 'full' },
+             outline: props.outline ?? true,
+-        }, children: _jsx(Layout, { includeJsonLd: false, children: props.children }) }));
++        }, children: _jsxs(Layout, { includeJsonLd: false, includeTitle: !props.documentTitle, children: [props.documentTitle ? _jsx("title", { children: props.documentTitle }) : null, props.children] }) }));
+ }
+ /**
+  * Renders a consumer-authored "guide" page (a normal MDX page mounted under an
+@@ -44,7 +44,7 @@ function OpenApiLayout(props) {
+ export function OpenApiGuide(props) {
+     const title = props.title ?? props.frontmatter?.title;
+     const description = props.description ?? props.frontmatter?.description;
+-    return (_jsxs(OpenApiLayout, { frontmatter: { ...props.frontmatter, description, title }, width: "full", children: [title ? _jsx("title", { children: title }) : null, _jsxs("div", { "data-v-openapi-guide": true, children: [props.header && title ? (_jsxs("header", { "data-v-openapi-header": true, children: [_jsxs("h1", { "data-v": true, "data-v-openapi-h1": true, id: props.id, children: [title, props.id ? _jsx(HeadingAnchor, { id: props.id }) : null] }), description ? _jsx(Prose, { markdown: description, attr: "description" }) : null] })) : null, props.children] })] }));
++    return (_jsx(OpenApiLayout, { documentTitle: resolveDocumentTitle(props.frontmatter, title), frontmatter: { ...props.frontmatter, description, title }, width: "full", children: _jsxs("div", { "data-v-openapi-guide": true, children: [props.header && title ? (_jsxs("header", { "data-v-openapi-header": true, children: [_jsxs("h1", { "data-v": true, "data-v-openapi-h1": true, id: props.id, children: [title, props.id ? _jsx(HeadingAnchor, { id: props.id }) : null] }), description ? _jsx(Prose, { markdown: description, attr: "description" }) : null] })) : null, props.children] }) }));
+ }
+ /**
+  * Renders an isolated, auto-generated OpenAPI reference section (Vite/RSC site
+@@ -73,10 +73,14 @@ export function OpenApiPage(props) {
+             return (_jsx(OpenApiLayout, { frontmatter: props.frontmatter, children: _jsxs("p", { children: ["No category \u201C", props.group, "\u201D exists in the API mounted at ", props.mount, "."] }) }));
+         const description = props.frontmatter?.description ?? group.description;
+         const title = props.title ?? props.frontmatter?.title ?? `${group.name} · ${ir.info.title}`;
+-        return (_jsxs(OpenApiLayout, { frontmatter: { ...props.frontmatter, description, title }, outline: false, children: [_jsx("title", { children: title }), _jsx(PlaygroundProvider, { mount: ir.path, children: _jsx(ReferenceGroup, { ir: ir, group: group, intro: props.intro, modelSource: props.inlineSchemaModels ? undefined : schemaModelSource(ir.path, group.id) }) })] }));
++        return (_jsx(OpenApiLayout, { documentTitle: resolveDocumentTitle(props.frontmatter, title), frontmatter: { ...props.frontmatter, description, title }, outline: false, children: _jsx(PlaygroundProvider, { mount: ir.path, children: _jsx(ReferenceGroup, { ir: ir, group: group, intro: props.intro, modelSource: props.inlineSchemaModels ? undefined : schemaModelSource(ir.path, group.id) }) }) }));
+     }
+     // Overview / landing page.
+     const title = props.title ?? props.frontmatter?.title ?? ir.info.title;
+-    return (_jsxs(OpenApiLayout, { frontmatter: { ...props.frontmatter, title }, width: "full", children: [_jsx("title", { children: title }), _jsx(ReferenceOverview, { ir: ir, intro: props.intro, endpoints: props.endpoints ? _jsx(Endpoints, { path: ir.path || undefined }) : undefined })] }));
++    return (_jsx(OpenApiLayout, { documentTitle: resolveDocumentTitle(props.frontmatter, title), frontmatter: { ...props.frontmatter, title }, width: "full", children: _jsx(ReferenceOverview, { ir: ir, intro: props.intro, endpoints: props.endpoints ? _jsx(Endpoints, { path: ir.path || undefined }) : undefined }) }));
++}
++function resolveDocumentTitle(frontmatter, fallback) {
++    const seoTitle = typeof frontmatter?.seoTitle === 'string' ? frontmatter.seoTitle.trim() : '';
++    return seoTitle || fallback;
+ }
+ //# sourceMappingURL=OpenApiPage.js.map
+diff --git a/src/react/Head.tsx b/src/react/Head.tsx
+index e7b51ed6d9642a903399dc0d18253a0f3cc955e8..004c4722f97ab7a9db4f0c876ca19b3fa9b97eab 100644
+--- a/src/react/Head.tsx
++++ b/src/react/Head.tsx
+@@ -9,7 +9,7 @@ import * as MdxPageContext from './MdxPageContext.js'
+ import { useConfig } from './useConfig.js'
+
+ export function Head(props: Head.Props) {
+-  const { includeJsonLd = true } = props
++  const { includeJsonLd = true, includeTitle = true } = props
+   const config = useConfig()
+   const { path: pathname } = useRouter()
+   const { frontmatter } = MdxPageContext.use()
+@@ -122,7 +122,7 @@ export function Head(props: Head.Props) {
+       {!disabled && (
+         <>
+           {/* Title */}
+-          {fullTitle && <title key="title">{fullTitle}</title>}
++          {includeTitle && fullTitle && <title key="title">{fullTitle}</title>}
+
+           {/* Base URL */}
+           {base && <base href={base} />}
+@@ -225,6 +225,7 @@ export function Head(props: Head.Props) {
+ export declare namespace Head {
+   export type Props = {
+     includeJsonLd?: boolean | undefined
++    includeTitle?: boolean | undefined
+   }
+ }
+
+diff --git a/src/react/Layout.tsx b/src/react/Layout.tsx
+index ca77c7aeca381f65af6d7a73f6a79d61890adcb3..4c8fbb9d3ef6566c4c1f7ff1f80cf8d8705ed7d7 100644
+--- a/src/react/Layout.tsx
++++ b/src/react/Layout.tsx
+@@ -2,10 +2,10 @@ import { Head } from './Head.js'
+ import * as Layout_client from './Layout.client.js'
+
+ export function Layout(props: Layout.Props) {
+-  const { children, includeJsonLd } = props
++  const { children, includeJsonLd, includeTitle } = props
+   return (
+     <>
+-      <Head includeJsonLd={includeJsonLd} />
++      <Head includeJsonLd={includeJsonLd} includeTitle={includeTitle} />
+       <Layout_client.Main>{children}</Layout_client.Main>
+     </>
+   )
+@@ -15,5 +15,6 @@ export namespace Layout {
+   export type Props = {
+     children: React.ReactNode
+     includeJsonLd?: boolean | undefined
++    includeTitle?: boolean | undefined
+   }
+ }
+diff --git a/src/react/Root.tsx b/src/react/Root.tsx
+index e65e8dfcd6c18b996166a57fdb896791532a769d..91c84df982fb44c95a337cdb7ca298bbffc7d600 100644
+--- a/src/react/Root.tsx
++++ b/src/react/Root.tsx
+@@ -2,7 +2,6 @@ import { config } from 'virtual:vocs/config'
+ import groupIconsStylesUrl from 'virtual:vocs/group-icons.css?url'
+ import userStylesUrl from 'virtual:vocs/user-styles'
+ import stylesUrl from '../styles/index.css?url'
+-import { Head } from './Head.js'
+ import { Root_client } from './Root.client.js'
+ import { ScrollRestoration } from './ScrollRestoration.js'
+
+@@ -22,7 +21,6 @@ export async function Root({ children }: { children: React.ReactNode }) {
+         <link rel="stylesheet" href={stylesUrl} />
+         {userStylesUrl && <link rel="stylesheet" href={userStylesUrl} />}
+         {groupIconsStylesUrl && <link rel="stylesheet" href={groupIconsStylesUrl} />}
+-        <Head includeJsonLd={false} />
+       </head>
+       <body data-version="1.0">
+         <Root_client>{children}</Root_client>
+diff --git a/src/react/internal/NotFound.tsx b/src/react/internal/NotFound.tsx
+index ccbf3ac5dbb4218fb4d6943a87e8bbb5f2a2c3e3..409c67cd99bf6e16588a1fbe5e0ed82a5cc4dd60 100644
+--- a/src/react/internal/NotFound.tsx
++++ b/src/react/internal/NotFound.tsx
+@@ -1,43 +1,48 @@
++import { config } from 'virtual:vocs/config'
+ import { Link } from 'waku'
+ import LucideFileQuestion from '~icons/lucide/file-question'
+ import LucideHome from '~icons/lucide/home'
+
+ export function NotFound() {
+   return (
+-    <div
+-      className="vocs:flex vocs:flex-col vocs:items-center vocs:justify-center vocs:min-h-[60vh] vocs:px-6 vocs:py-16 vocs:text-center"
+-      data-v-not-found
+-    >
++    <>
++      <title>{`Page not found ⋅ ${config.title}`}</title>
++      <meta name="robots" content="noindex, nofollow" />
+       <div
+-        className="vocs:flex vocs:items-center vocs:justify-center vocs:size-20 vocs:rounded-full vocs:bg-surface vocs:border vocs:border-primary vocs:text-secondary vocs:mb-6"
+-        data-v-not-found-icon
++        className="vocs:flex vocs:flex-col vocs:items-center vocs:justify-center vocs:min-h-[60vh] vocs:px-6 vocs:py-16 vocs:text-center"
++        data-v-not-found
+       >
+-        <LucideFileQuestion className="vocs:size-10" />
+-      </div>
++        <div
++          className="vocs:flex vocs:items-center vocs:justify-center vocs:size-20 vocs:rounded-full vocs:bg-surface vocs:border vocs:border-primary vocs:text-secondary vocs:mb-6"
++          data-v-not-found-icon
++        >
++          <LucideFileQuestion className="vocs:size-10" />
++        </div>
+
+-      <h1
+-        className="vocs:text-heading vocs:text-h1 vocs:font-medium vocs:tracking-[-0.04em] vocs:leading-h1 vocs:mb-3"
+-        data-v-not-found-title
+-      >
+-        Page not found
+-      </h1>
++        <h1
++          className="vocs:text-heading vocs:text-h1 vocs:font-medium vocs:tracking-[-0.04em] vocs:leading-h1 vocs:mb-3"
++          data-v-not-found-title
++        >
++          Page not found
++        </h1>
+
+-      <p
+-        className="vocs:text-secondary vocs:leading-p vocs:tracking-normal vocs:max-w-md vocs:mb-8"
+-        data-v-not-found-description
+-      >
+-        The page you're looking for doesn't exist or has been moved.
+-      </p>
++        <p
++          className="vocs:text-secondary vocs:leading-p vocs:tracking-normal vocs:max-w-md vocs:mb-8"
++          data-v-not-found-description
++        >
++          The page you're looking for doesn't exist or has been moved.
++        </p>
+
+-      <Link
+-        className="vocs:inline-flex vocs:items-center vocs:gap-2 vocs:px-5 vocs:py-2.5 vocs:rounded-lg vocs:bg-surface vocs:border vocs:border-primary vocs:text-heading vocs:font-medium vocs:transition-colors vocs:duration-150 vocs:hover:bg-surfaceMuted"
+-        data-v-not-found-link
+-        to="/"
+-      >
+-        <LucideHome className="vocs:size-4 vocs:text-secondary" />
+-        Back to home
+-      </Link>
+-    </div>
++        <Link
++          className="vocs:inline-flex vocs:items-center vocs:gap-2 vocs:px-5 vocs:py-2.5 vocs:rounded-lg vocs:bg-surface vocs:border vocs:border-primary vocs:text-heading vocs:font-medium vocs:transition-colors vocs:duration-150 vocs:hover:bg-surfaceMuted"
++          data-v-not-found-link
++          to="/"
++        >
++          <LucideHome className="vocs:size-4 vocs:text-secondary" />
++          Back to home
++        </Link>
++      </div>
++    </>
+   )
+ }
+
+diff --git a/src/react/internal/openapi/OpenApiPage.tsx b/src/react/internal/openapi/OpenApiPage.tsx
+index 939c937581ec434975aee43e7284c6c2d48add93..4622655fa2c046435180c35f012b6a3160837b66 100644
+--- a/src/react/internal/openapi/OpenApiPage.tsx
++++ b/src/react/internal/openapi/OpenApiPage.tsx
+@@ -20,6 +20,7 @@ import { Prose, ReferenceGroup, ReferenceOverview } from './Reference.js'
+  */
+ function OpenApiLayout(props: {
+   children: React.ReactNode
++  documentTitle?: string | undefined
+   frontmatter?: Frontmatter | undefined
+   outline?: boolean | undefined
+   width?: 'default' | 'full'
+@@ -32,7 +33,10 @@ function OpenApiLayout(props: {
+         outline: props.outline ?? true,
+       }}
+     >
+-      <Layout includeJsonLd={false}>{props.children}</Layout>
++      <Layout includeJsonLd={false} includeTitle={!props.documentTitle}>
++        {props.documentTitle ? <title>{props.documentTitle}</title> : null}
++        {props.children}
++      </Layout>
+     </MdxPageContext.Provider>
+   )
+ }
+@@ -60,8 +64,11 @@ export function OpenApiGuide(props: OpenApiGuide.Props) {
+   const description = props.description ?? props.frontmatter?.description
+
+   return (
+-    <OpenApiLayout frontmatter={{ ...props.frontmatter, description, title }} width="full">
+-      {title ? <title>{title}</title> : null}
++    <OpenApiLayout
++      documentTitle={resolveDocumentTitle(props.frontmatter, title)}
++      frontmatter={{ ...props.frontmatter, description, title }}
++      width="full"
++    >
+       <div data-v-openapi-guide>
+         {props.header && title ? (
+           <header data-v-openapi-header>
+@@ -140,8 +147,11 @@ export function OpenApiPage(props: OpenApiPage.Props) {
+     const title = props.title ?? props.frontmatter?.title ?? `${group.name} · ${ir.info.title}`
+
+     return (
+-      <OpenApiLayout frontmatter={{ ...props.frontmatter, description, title }} outline={false}>
+-        <title>{title}</title>
++      <OpenApiLayout
++        documentTitle={resolveDocumentTitle(props.frontmatter, title)}
++        frontmatter={{ ...props.frontmatter, description, title }}
++        outline={false}
++      >
+         <PlaygroundProvider mount={ir.path}>
+           <ReferenceGroup
+             ir={ir}
+@@ -160,8 +170,11 @@ export function OpenApiPage(props: OpenApiPage.Props) {
+   const title = props.title ?? props.frontmatter?.title ?? ir.info.title
+
+   return (
+-    <OpenApiLayout frontmatter={{ ...props.frontmatter, title }} width="full">
+-      <title>{title}</title>
++    <OpenApiLayout
++      documentTitle={resolveDocumentTitle(props.frontmatter, title)}
++      frontmatter={{ ...props.frontmatter, title }}
++      width="full"
++    >
+       <ReferenceOverview
+         ir={ir}
+         intro={props.intro}
+@@ -171,6 +184,11 @@ export function OpenApiPage(props: OpenApiPage.Props) {
+   )
+ }
+
++function resolveDocumentTitle(frontmatter: Frontmatter | undefined, fallback: string | undefined) {
++  const seoTitle = typeof frontmatter?.seoTitle === 'string' ? frontmatter.seoTitle.trim() : ''
++  return seoTitle || fallback
++}
++
+ export declare namespace OpenApiPage {
+   type Props = {
+     /** Mount path identifying which spec to render (e.g. `/api`). */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ patchedDependencies:
   dayjs@1.11.20:
     hash: 47bfcf62e3c84ba85d881815422a02e23f372df46bddb9b022eb3705361fd165
     path: patches/dayjs@1.11.20.patch
+  vocs@2.7.2:
+    hash: 0877ba0b3b9cc95e4fac0362c563038291536674597a4cfb1b121b05cb752893
+    path: patches/vocs@2.7.2.patch
 
 importers:
 
@@ -139,8 +142,8 @@ importers:
         specifier: ^2.54.6
         version: 2.54.6(typescript@6.0.3)(zod@4.4.3)
       vocs:
-        specifier: ^2.7.2
-        version: 2.7.2(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
+        specifier: 2.7.2
+        version: 2.7.2(patch_hash=0877ba0b3b9cc95e4fac0362c563038291536674597a4cfb1b121b05cb752893)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
       wagmi:
         specifier: 3.6.20
         version: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
@@ -9952,7 +9955,7 @@ snapshots:
       stripe: 19.3.0(@types/node@26.0.1)
       tidx.ts: 0.1.1(typescript@6.0.3)
       viem: 2.54.6(typescript@6.0.3)(zod@4.4.3)
-      vocs: 2.7.2(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
+      vocs: 2.7.2(patch_hash=0877ba0b3b9cc95e4fac0362c563038291536674597a4cfb1b121b05cb752893)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -10400,7 +10403,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@2.7.2(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1)):
+  vocs@2.7.2(patch_hash=0877ba0b3b9cc95e4fac0362c563038291536674597a4cfb1b121b05cb752893)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1)):
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ overrides:
 patchedDependencies:
   '@braintree/sanitize-url@7.1.2': patches/@braintree__sanitize-url@7.1.2.patch
   dayjs@1.11.20: patches/dayjs@1.11.20.patch
+  vocs@2.7.2: patches/vocs@2.7.2.patch
 
 strictDepBuilds: true
 

--- a/scripts/check-vercel-sitemap.ts
+++ b/scripts/check-vercel-sitemap.ts
@@ -3,45 +3,43 @@ import path from 'node:path'
 
 const vercelStaticDirectory = path.resolve('.vercel/output/static')
 const sitemapPath = path.join(vercelStaticDirectory, 'sitemap.xml')
-const apiOutputDirectory = path.join(vercelStaticDirectory, 'docs/api')
+const docsOutputDirectory = path.join(vercelStaticDirectory, 'docs')
 
-const [sitemap, apiRouteFiles] = await Promise.all([
+const [sitemap, docsRouteFiles] = await Promise.all([
   fs.readFile(sitemapPath, 'utf-8'),
-  findRouteIndexFiles(apiOutputDirectory),
+  findRouteIndexFiles(docsOutputDirectory),
 ])
 
 const sitemapLocations = new Set(
   Array.from(sitemap.matchAll(/<loc>([^<]+)<\/loc>/g), ([, location]) => location),
 )
-const openApiIndexUrl = Array.from(sitemapLocations).find((location) =>
-  /\/docs\/api\/?$/.test(location),
-)
+const docsIndexUrl = Array.from(sitemapLocations).find((location) => /\/docs\/?$/.test(location))
 
-if (!openApiIndexUrl) {
-  throw new Error(`Could not resolve the OpenAPI base URL from ${sitemapPath}`)
+if (!docsIndexUrl) {
+  throw new Error(`Could not resolve the docs base URL from ${sitemapPath}`)
 }
 
-if (apiRouteFiles.length === 0) {
-  throw new Error(`Could not find generated API routes in ${apiOutputDirectory}`)
+if (docsRouteFiles.length === 0) {
+  throw new Error(`Could not find generated docs routes in ${docsOutputDirectory}`)
 }
 
-const normalizedOpenApiIndexUrl = openApiIndexUrl.replace(/\/$/, '')
-const canonicalBaseUrl = normalizedOpenApiIndexUrl.slice(0, -'/docs/api'.length)
-const canonicalApiUrls = apiRouteFiles
+const normalizedDocsIndexUrl = docsIndexUrl.replace(/\/$/, '')
+const canonicalBaseUrl = normalizedDocsIndexUrl.slice(0, -'/docs'.length)
+const canonicalDocsUrls = docsRouteFiles
   .map((file) => path.relative(vercelStaticDirectory, path.dirname(file)))
   .map((route) => route.split(path.sep).map(encodeURIComponent).join('/'))
   .map((route) => `${canonicalBaseUrl}/${route}`)
   .sort((a, b) => a.localeCompare(b))
-const missingApiUrls = canonicalApiUrls.filter((location) => !sitemapLocations.has(location))
+const missingDocsUrls = canonicalDocsUrls.filter((location) => !sitemapLocations.has(location))
 
-if (missingApiUrls.length > 0) {
+if (missingDocsUrls.length > 0) {
   throw new Error(
-    `Vercel sitemap is missing ${missingApiUrls.length} canonical API routes:\n${missingApiUrls.join('\n')}`,
+    `Vercel sitemap is missing ${missingDocsUrls.length} canonical docs routes:\n${missingDocsUrls.join('\n')}`,
   )
 }
 
 console.log(
-  `Validated ${canonicalApiUrls.length} canonical API routes in ${path.relative(process.cwd(), sitemapPath)}.`,
+  `Validated ${canonicalDocsUrls.length} canonical docs routes in ${path.relative(process.cwd(), sitemapPath)}.`,
 )
 
 async function findRouteIndexFiles(directory: string): Promise<string[]> {

--- a/src/components/PageHead.tsx
+++ b/src/components/PageHead.tsx
@@ -6,13 +6,9 @@ import { Head, MdxPageContextProvider } from 'vocs'
 /**
  * Per-page head tags for non-MDX (marketing/blog) pages.
  *
- * Vocs renders a site-generic `<Head>` in the document root, then dedupes head
- * tags in the prerendered HTML keeping the last occurrence of each identity.
- * MDX pages win that dedupe by rendering a second `<Head>` from the page
- * subtree (with frontmatter in context), which hoists into `<head>` after the
- * generic one. This component gives `.tsx` pages the same mechanism — raw
- * `<meta>` tags rendered directly by a page hoist *before* the generic head
- * and lose the dedupe instead.
+ * MDX routes get one route-aware `<Head>` from their layout. This component
+ * gives `.tsx` routes the same single per-page owner with their metadata in
+ * context.
  *
  * `children` render after `<Head>` so they can override tags it emits (e.g.
  * `og:type`) as well as add new ones.

--- a/src/lib/docs-seo-metadata.test.ts
+++ b/src/lib/docs-seo-metadata.test.ts
@@ -1,10 +1,14 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import remarkMdx from 'remark-mdx'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
 import { describe, expect, test } from 'vitest'
 
 const docsRoot = path.resolve('src/pages/docs')
+const markdownParser = unified().use(remarkParse).use(remarkMdx)
 
-const openApiTitleFiles = [
+const migratedOpenApiTitleFiles = [
   'api.mdx',
   'api/console.mdx',
   'api/console/api-keys.mdx',
@@ -15,6 +19,7 @@ const openApiTitleFiles = [
   'api/errors.mdx',
   'api/pagination.mdx',
   'api/rate-limits.mdx',
+  'api/reference.mdx',
   'api/transactions-and-transfers.mdx',
   'api/transactions.mdx',
   'api/transfers.mdx',
@@ -29,30 +34,60 @@ const preservedJxomFiles = [
   'api/json-rpc.mdx',
 ]
 
-function mdxFiles(directory: string): string[] {
+type MarkdownNode = {
+  children?: MarkdownNode[] | undefined
+  depth?: number | undefined
+  name?: string | null | undefined
+  type: string
+  value?: string | undefined
+}
+
+function markdownFiles(directory: string): string[] {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const filepath = path.join(directory, entry.name)
-    if (entry.isDirectory()) return mdxFiles(filepath)
-    return entry.isFile() && filepath.endsWith('.mdx') ? [filepath] : []
+    if (entry.isDirectory()) return markdownFiles(filepath)
+    return entry.isFile() && /\.mdx?$/.test(filepath) ? [filepath] : []
   })
 }
 
 function frontmatterString(source: string, key: string): string | undefined {
-  const frontmatter = source.match(/^---\n([\s\S]*?)\n---/)?.[1]
+  const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1]
   const serialized = frontmatter?.match(new RegExp(`^${key}: (.+)$`, 'm'))?.[1]
   if (!serialized) return undefined
   return JSON.parse(serialized)
 }
 
+function parseMarkdown(source: string): MarkdownNode {
+  const withoutFrontmatter = source.replace(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/, '')
+  return markdownParser.parse(withoutFrontmatter) as MarkdownNode
+}
+
+function findNodes(node: MarkdownNode, predicate: (node: MarkdownNode) => boolean): MarkdownNode[] {
+  const matches = predicate(node) ? [node] : []
+  return [...matches, ...(node.children ?? []).flatMap((child) => findNodes(child, predicate))]
+}
+
+function nodeText(node: MarkdownNode): string {
+  if (typeof node.value === 'string') return node.value
+  return (node.children ?? []).map(nodeText).join('')
+}
+
 function authoredH1(source: string): string | undefined {
-  return source.match(/^# (.+?)(?:\s+\{#[^}]+\})?$/m)?.[1].replaceAll('`', '')
+  const heading = findNodes(
+    parseMarkdown(source),
+    (node) => node.type === 'heading' && node.depth === 1,
+  )[0]
+  return heading ? nodeText(heading) : undefined
 }
 
 describe('docs SEO metadata', () => {
   test('keeps audited page titles, H1s, and SEO titles aligned', () => {
-    const auditedPages = mdxFiles(docsRoot)
+    const auditedPages = markdownFiles(docsRoot)
       .map((file) => ({ file, source: fs.readFileSync(file, 'utf8') }))
-      .filter(({ source }) => /^seoTitle:/m.test(source))
+      .filter(
+        ({ file, source }) =>
+          /^seoTitle:/m.test(source) && path.relative(docsRoot, file) !== 'api/reference.mdx',
+      )
 
     expect(auditedPages).toHaveLength(106)
 
@@ -75,14 +110,27 @@ describe('docs SEO metadata', () => {
     }
   })
 
-  test('works around OpenAPI title overrides without leaking tags into source titles', () => {
-    for (const file of openApiTitleFiles) {
+  test('stores optimized OpenAPI document titles in frontmatter', () => {
+    for (const file of migratedOpenApiTitleFiles) {
       const source = fs.readFileSync(path.join(docsRoot, file), 'utf8')
-      const seoTitle = frontmatterString(source, 'seoTitle')
-      const literalTitle = `<title>${seoTitle}</title>`
+      expect(frontmatterString(source, 'seoTitle'), file).toBeTruthy()
+    }
+  })
 
-      expect(seoTitle, file).toBeTruthy()
-      expect(source.lastIndexOf(literalTitle), file).toBeGreaterThan(source.lastIndexOf('<OpenApi'))
+  test('gives every authored docs page exactly one H1 and no literal title element', () => {
+    for (const file of markdownFiles(docsRoot)) {
+      const source = fs.readFileSync(file, 'utf8')
+      const tree = parseMarkdown(source)
+      const h1s = findNodes(tree, (node) => node.type === 'heading' && node.depth === 1)
+      const titleElements = findNodes(
+        tree,
+        (node) =>
+          (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') &&
+          node.name?.toLowerCase() === 'title',
+      )
+
+      expect(h1s.map(nodeText), file).toHaveLength(1)
+      expect(titleElements, file).toHaveLength(0)
     }
   })
 })

--- a/src/lib/markdown-headings.test.ts
+++ b/src/lib/markdown-headings.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { demoteMarkdownHeadings } from './markdown-headings'
+
+describe('demoteMarkdownHeadings', () => {
+  test('nests ATX and setext headings below the release title', () => {
+    expect(
+      demoteMarkdownHeadings(
+        '# Release\n\n## Changes\n\n##### Detail\n\n###### Limit\n\nSetext title\n===\n\nSetext subtitle\n---',
+      ),
+    ).toBe(
+      '### Release\n\n#### Changes\n\n###### Detail\n\n###### Limit\n\n### Setext title\n\n#### Setext subtitle',
+    )
+  })
+
+  test('preserves code fences and handles nested headings', () => {
+    expect(
+      demoteMarkdownHeadings(
+        '> # Quoted\n\n- # Listed\n\n> Setext quote\n> ---\n\n```sh\n# shell comment\n## still code\n```',
+      ),
+    ).toBe(
+      '> ### Quoted\n\n- ### Listed\n\n> #### Setext quote\n\n```sh\n# shell comment\n## still code\n```',
+    )
+  })
+
+  test('uses the minimum shift needed to nest headings below a release title', () => {
+    expect(demoteMarkdownHeadings('## Changes\n\n### Fixes')).toBe('### Changes\n\n#### Fixes')
+    expect(demoteMarkdownHeadings('### Changes\n\n#### Fixes')).toBe('### Changes\n\n#### Fixes')
+  })
+})

--- a/src/lib/markdown-headings.ts
+++ b/src/lib/markdown-headings.ts
@@ -1,0 +1,84 @@
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+type MarkdownNode = {
+  children?: MarkdownNode[] | undefined
+  depth?: number | undefined
+  position?:
+    | {
+        end: { offset?: number | undefined }
+        start: { offset?: number | undefined }
+      }
+    | undefined
+  type: string
+}
+
+type Edit = {
+  end: number
+  replacement: string
+  start: number
+}
+
+const parser = unified().use(remarkParse)
+
+/**
+ * Nests rendered Markdown headings below an H2 release title without reserializing the body.
+ * This preserves relative hierarchy and release-note formatting while ignoring heading-like
+ * text in code fences.
+ */
+export function demoteMarkdownHeadings(markdown: string): string {
+  const tree = parser.parse(markdown) as MarkdownNode
+  const edits: Edit[] = []
+  const headings: MarkdownNode[] = []
+
+  visit(tree, (node) => {
+    if (node.type === 'heading' && node.depth) headings.push(node)
+  })
+
+  const minimumDepth = Math.min(...headings.map((heading) => heading.depth ?? 6))
+  const depthShift = Math.max(0, 3 - minimumDepth)
+  if (depthShift === 0) return markdown
+
+  for (const node of headings) {
+    if (!node.depth || node.depth >= 6) continue
+
+    const start = node.position?.start.offset
+    const end = node.position?.end.offset
+    if (start === undefined || end === undefined) continue
+
+    const targetDepth = Math.min(6, node.depth + depthShift)
+    const appliedShift = targetDepth - node.depth
+    if (appliedShift === 0) continue
+
+    if (markdown[start] === '#') {
+      edits.push({ end: start, replacement: '#'.repeat(appliedShift), start })
+      continue
+    }
+
+    const source = markdown.slice(start, end)
+    const underline = /([=-]+)[\t ]*$/.exec(source)
+    if (!underline || underline.index === undefined) continue
+
+    if (targetDepth < 3) continue
+
+    const newlineIndex = source.lastIndexOf('\n', underline.index)
+    if (newlineIndex === -1) continue
+
+    const lineBreakStart = source[newlineIndex - 1] === '\r' ? newlineIndex - 1 : newlineIndex
+    edits.push({ end: start, replacement: `${'#'.repeat(targetDepth)} `, start })
+    edits.push({ end, replacement: '', start: start + lineBreakStart })
+  }
+
+  return edits
+    .sort((a, b) => b.start - a.start)
+    .reduce(
+      (output, edit) =>
+        `${output.slice(0, edit.start)}${edit.replacement}${output.slice(edit.end)}`,
+      markdown,
+    )
+}
+
+function visit(node: MarkdownNode, visitor: (node: MarkdownNode) => void) {
+  visitor(node)
+  for (const child of node.children ?? []) visit(child, visitor)
+}

--- a/src/pages/docs/api.mdx
+++ b/src/pages/docs/api.mdx
@@ -90,7 +90,6 @@ Check out an endpoint below and click "Try" to run it directly against the API. 
 
 Browse the [complete Tempo API reference](/docs/api/reference) to find every API group and endpoint.
 
-<title>Start with the Tempo API | Tempo Docs</title>
 
 ## Next API integration steps
 

--- a/src/pages/docs/api/console.mdx
+++ b/src/pages/docs/api/console.mdx
@@ -102,5 +102,3 @@ Select [**Usage**](https://console.tempo.xyz/?to=/:org/usage%3Fenv%3Dsandbox) an
     icon="lucide:users"
   />
 </Cards>
-
-<title>How to Use the Tempo API Console | Docs</title>

--- a/src/pages/docs/api/console/api-keys.mdx
+++ b/src/pages/docs/api/console/api-keys.mdx
@@ -94,5 +94,3 @@ Return to [**API Keys**](https://console.tempo.xyz/?to=/:org/api-keys), open the
 | The plaintext token was lost | Create a replacement key. Existing tokens cannot be revealed again. |
 
 For complete credential and chain-selection behavior, see [API authentication](/docs/api/authentication).
-
-<title>Create & Manage API Keys | Tempo Docs</title>

--- a/src/pages/docs/api/console/projects-and-environments.mdx
+++ b/src/pages/docs/api/console/projects-and-environments.mdx
@@ -67,5 +67,3 @@ API Keys and Usage are organization-wide by default. Use their project filter to
 - **Billing** remains organization-wide and environment-specific.
 
 Unknown or removed project filters fall back to the organization-wide view.
-
-<title>Tempo API Projects & Environments | Docs</title>

--- a/src/pages/docs/api/console/team.mdx
+++ b/src/pages/docs/api/console/team.mdx
@@ -57,5 +57,3 @@ Role changes take effect for organization access after the update succeeds. They
 - **Leave an organization:** open your own actions menu and select **Leave organization**. The last owner cannot leave until another owner exists.
 
 Removing a member does not automatically revoke project API keys. Review [**API Keys**](https://console.tempo.xyz/?to=/:org/api-keys) separately when offboarding someone who managed integration credentials.
-
-<title>Teams & Access in the API Console | Docs</title>

--- a/src/pages/docs/api/console/usage-and-billing.mdx
+++ b/src/pages/docs/api/console/usage-and-billing.mdx
@@ -73,5 +73,3 @@ Production fee sponsorship requires an active billing source. A spend or sponsor
 5. Review the Billing page and adjust spend or sponsorship limits if needed.
 
 See [API rate limits](/docs/api/rate-limits) for request quotas and response headers. For sponsored transaction integration, follow the [fee sponsorship guide](https://viem.sh/tempo/guides/sponsor-fees#sponsor-via-a-relay).
-
-<title>Monitor API Usage & Billing | Tempo Docs</title>

--- a/src/pages/docs/api/conventions.mdx
+++ b/src/pages/docs/api/conventions.mdx
@@ -100,5 +100,3 @@ Errors use a single, consistent envelope with a conventional HTTP status code an
 ## API rate-limit conventions
 
 Every response carries standard `RateLimit-*` headers, and requests that exceed quota receive `429 Too Many Requests` with a `Retry-After` header. See [Rate Limits](/docs/api/rate-limits) for the full model and best practices.
-
-<title>API Conventions & Base URL | Tempo Docs</title>

--- a/src/pages/docs/api/errors.mdx
+++ b/src/pages/docs/api/errors.mdx
@@ -125,5 +125,3 @@ Something went wrong on Tempo's side. These are transient. Retry with [exponenti
 :::warning
 For non-idempotent requests (such as `POST`), a `5xx` response does not guarantee the operation failed; it may have succeeded on the backend. Treat the outcome as **unknown** and reconcile state before blindly retrying. Read requests (`GET`) are always safe to retry.
 :::
-
-<title>API Errors & Response Format | Docs</title>

--- a/src/pages/docs/api/pagination.mdx
+++ b/src/pages/docs/api/pagination.mdx
@@ -153,5 +153,3 @@ The count is computed by a capped subquery up to `10,000` matched rows:
 - Pass cursors back verbatim, and URL-encode them when placing them in a query string.
 - Stop only when `nextCursor` is `null`.
 - Use page pagination only for shallow UI navigation where duplicate or skipped rows on a live feed are acceptable.
-
-<title>API Pagination Modes | Tempo Docs</title>

--- a/src/pages/docs/api/rate-limits.mdx
+++ b/src/pages/docs/api/rate-limits.mdx
@@ -99,5 +99,3 @@ async function withRetry<T>(fn: () => Promise<Response>): Promise<Response> {
 ### Authenticate for higher API quotas
 
 Anonymous traffic is held to the lower IP-based limit. Send an [API key](/docs/api/authentication) to get a per-key, per-scope quota, and request a higher limit if your workload needs it.
-
-<title>API Rate Limits & Quota Structure | Docs</title>

--- a/src/pages/docs/api/reference.mdx
+++ b/src/pages/docs/api/reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tempo API Reference
+seoTitle: "Tempo API Reference ⋅ Tempo Docs"
 description: Browse every Tempo API endpoint for blockchain data, funding, exchange, webhooks, organizations, billing, MPP, MCP, and JSON-RPC requests and responses.
 ---
 
@@ -12,5 +13,3 @@ Browse every Tempo API group and endpoint. Choose a group to see its operations,
 ## Tempo API endpoints
 
 <OpenApi.Endpoints path="/docs/api" />
-
-<title>Tempo API Reference ⋅ Tempo Docs</title>

--- a/src/pages/docs/api/transactions-and-transfers.mdx
+++ b/src/pages/docs/api/transactions-and-transfers.mdx
@@ -39,5 +39,3 @@ A transaction that calls a contract might emit several transfers (for example, a
 | **Endpoint** | [`/v1/transactions`](/docs/api/transactions) | [`/v1/transfers`](/docs/api/transfers) |
 | **Use it for** | Inspecting submitted transactions, fees, and status | Tracking who received which tokens, and reconciling balances |
 | **Key link** | Its hash appears on every transfer it produced | `transactionHash` points back to its transaction |
-
-<title>Transactions & Transfers Data Model | Docs</title>

--- a/src/pages/docs/api/transactions.mdx
+++ b/src/pages/docs/api/transactions.mdx
@@ -11,5 +11,3 @@ A transaction is what a user submits to Tempo: a signed envelope that moves valu
 :::info
 See [Transactions & Transfers](/docs/api/transactions-and-transfers) for how a transaction relates to the transfers it produces.
 :::
-
-<title>Tempo Transactions API Reference | Docs</title>

--- a/src/pages/docs/api/transfers.mdx
+++ b/src/pages/docs/api/transfers.mdx
@@ -11,5 +11,3 @@ A transfer is an effect of executing a [transaction](/docs/api/transactions): a 
 :::info
 See [Transactions & Transfers](/docs/api/transactions-and-transfers) for how a transfer relates to the transaction that produced it.
 :::
-
-<title>Stablecoin Transfers API | Tempo Docs</title>

--- a/src/pages/docs/api/typed-client.mdx
+++ b/src/pages/docs/api/typed-client.mdx
@@ -170,5 +170,3 @@ if (response.status === 200) {
   // results is typed as one JSON-RPC response or an array of JSON-RPC responses.
 }
 ```
-
-<title>TypeScript Typed Client | Tempo Docs</title>

--- a/src/pages/docs/api/versioning-policy.mdx
+++ b/src/pages/docs/api/versioning-policy.mdx
@@ -62,5 +62,3 @@ Link: <https://tempo.xyz/developers/docs/api/versioning-policy>; rel="deprecatio
 
 - All breaking changes and meaningful additions are recorded in the changelog with affected endpoints, migration notes, and any sunset date.
 - Deprecated operations and fields are flagged in this OpenAPI document.
-
-<title>Tempo API Versioning Policy | Docs</title>

--- a/src/pages/docs/protocol/tip403/spec.mdx
+++ b/src/pages/docs/protocol/tip403/spec.mdx
@@ -17,13 +17,13 @@ TIP-403 addresses this by providing a centralized registry that tokens can refer
 
 ---
 
-# Specification
+## Specification
 
 The TIP-403 registry stores policies that TIP-20 tokens check against on any token transfer. Policies are associated with a unique `policyId`, can either be a blacklist or a whitelist policy, and contain a list of addresses. This list of addresses can be updated by the policy `admin`.
 
 The TIP403Registry is deployed at address `0x403c000000000000000000000000000000000000`.
 
-## Built-in Policies
+### Built-in Policies
 
 Custom policies start with `policyId = 2`. The registry reserves the first two ids for built-in policies:
 - `policyId = 0` is the `always-reject` policy and rejects all token transfers
@@ -31,14 +31,14 @@ Custom policies start with `policyId = 2`. The registry reserves the first two i
 
 The `policyIdCounter` starts at `2` and increments with each new policy creation.
 
-## Policy Types
+### Policy Types
 
 TIP-403 supports two policy types:
 
 * **Whitelist Policies:** Only addresses in the whitelist can transfer tokens. All other addresses are blocked
 * **Blacklist Policies:** Addresses in the blacklist are blocked from transferring tokens. All other addresses can transfer
 
-## Storage and State
+### Storage and State
 
 The registry maintains the following state:
 
@@ -46,7 +46,7 @@ The registry maintains the following state:
 - `policyData`: Mapping from `policyId` to `PolicyData` struct containing policy type and admin address.
 - `policySet`: Internal mapping from `policyId` to address to boolean, tracking which addresses are in each policy's set.
 
-## Interface Definition
+### Interface Definition
 
 The complete TIP403Registry interface is defined below:
 
@@ -224,7 +224,7 @@ interface ITIP403Registry {
 }
 ```
 
-## Usage with TIP-20 Tokens
+### Usage with TIP-20 Tokens
 
 TIP-20 tokens store the current TIP403 registry policy ID they adhere to in their storage. On any token transfer, they perform a TIP-403 policy check by calling `isAuthorized()` for both sender and recipient addresses. The policy to use for the token can only be set by the admin of the token.
 
@@ -234,7 +234,7 @@ TIP-20 tokens store the current TIP403 registry policy ID they adhere to in thei
 
 **Virtual addresses:** Policy-configuration functions that accept literal member addresses (`createPolicyWithAccounts`, `modifyPolicyWhitelist`, `modifyPolicyBlacklist`) reject [virtual addresses](/docs/protocol/tip20/virtual-addresses). TIP-20 policy checks for transfers and mints to a virtual address run against the resolved master wallet rather than the forwarding alias, so policy membership must be configured on the master address.
 
-### Example Usage
+#### Example Usage
 
 Creating and setting a policy:
 
@@ -251,7 +251,7 @@ tip403Registry.modifyPolicyWhitelist(policyId, authorizedUser, true);
 token.changeTransferPolicyId(policyId);
 ```
 
-## Authorization Logic
+### Authorization Logic
 
 The `isAuthorized()` function implements the following logic:
 
@@ -265,7 +265,7 @@ return data.policyType == PolicyType.WHITELIST
     : !policySet[policyId][user];
 ```
 
-# Invariants
+## Invariants
 - When policyId = 0, all authorization checks must return false for every address.
 - When policyId = 1, all authorization checks must return true for every address.
 - Only the policy’s current admin may update the admin address for that policy.

--- a/src/pages/docs/protocol/tips/tip-0000.mdx
+++ b/src/pages/docs/protocol/tips/tip-0000.mdx
@@ -21,9 +21,9 @@ This process gives the team one shared path from idea to production. A consisten
 
 ---
 
-# Specification
+## Specification
 
-## Status Lifecycle
+### Status Lifecycle
 
 `Draft` → `In Review` / `Rejected`
 
@@ -35,7 +35,7 @@ This process gives the team one shared path from idea to production. A consisten
 
 `Approved` → `Scheduled` → `Testnet` → `Mainnet`
 
-## Status Definitions
+### Status Definitions
 
 - `Draft`: The idea is being developed into a complete TIP and is not yet in formal review.
 - `In Review`: The TIP is under structured technical, security, and implications review.
@@ -47,7 +47,7 @@ This process gives the team one shared path from idea to production. A consisten
 - `Mainnet`: The TIP is released on mainnet.
 - `Rejected`: The TIP does not move forward in its current form.
 
-## 1. Propose a TIP
+### 1. Propose a TIP
 
 Goal: Turn an idea into a complete, reviewable specification.
 
@@ -58,7 +58,7 @@ Goal: Turn an idea into a complete, reviewable specification.
 5. Complete the draft with: problem statement, design, assumptions, alternatives considered, threat model, expected tooling/user impact, and success criteria.
 6. When ready, set status to `In Review` and request stakeholder review.
 
-## 2. Review the TIP
+### 2. Review the TIP
 
 Goal: Validate the proposal's value, feasibility, and risk.
 
@@ -71,7 +71,7 @@ Goal: Validate the proposal's value, feasibility, and risk.
 7. Obtain engineering, research, and security approval.
 8. Before merging, set status to `Ready for Consideration`, then merge.
 
-## 3. Consideration and Decision (Network Upgrade Call)
+### 3. Consideration and Decision (Network Upgrade Call)
 
 Goal: Move each `Ready for Consideration` TIP to a clear decision.
 
@@ -81,7 +81,7 @@ Goal: Move each `Ready for Consideration` TIP to a clear decision.
 4. If `Approved`, confirm a target upgrade when possible.
 5. If `Backlog`, record what signal is needed to revisit it.
 
-## 4. Scheduling Criteria
+### 4. Scheduling Criteria
 
 A TIP can move from `Approved` to `Scheduled` only if:
 
@@ -90,7 +90,7 @@ A TIP can move from `Approved` to `Scheduled` only if:
 3. Inclusion timing is explicit (`Why include? Why now?`).
 4. The TIP spec is complete and implementation-ready.
 
-## 5. Ship a TIP
+### 5. Ship a TIP
 
 Goal: Implement the approved TIP and prepare it for rollout.
 
@@ -98,7 +98,7 @@ Goal: Implement the approved TIP and prepare it for rollout.
 2. Implementation can still surface learnings; updates and scoped changes are welcome.
 3. If implementation materially changes the TIP, request another approval from the same engineering, research, and security stakeholders. This second approval should be fast and focused on the implementation delta.
 
-## 6. Testnet Release Readiness
+### 6. Testnet Release Readiness
 
 Before moving an upgrade to `Testnet`:
 

--- a/src/pages/docs/protocol/tips/tip-1000.mdx
+++ b/src/pages/docs/protocol/tips/tip-1000.mdx
@@ -42,11 +42,11 @@ These units provide precise economic accounting while maintaining human-readable
 
 ---
 
-# Specification
+## Specification
 
-## Gas Cost Changes
+### Gas Cost Changes
 
-### New State Element Creation
+#### New State Element Creation
 
 **Current Behavior:**
 - Writing a new state element (SSTORE to a zero slot) costs 20,000 gas
@@ -67,7 +67,7 @@ This applies to all storage slot writes that transition from zero to non-zero, i
 
 **Note:** Since Tempo-specific operations (nonce keys, rewards processing, etc.) ultimately use EVM storage operations (SSTORE), they are automatically subject to the new state creation pricing. The implementation must ensure all new state element creation is correctly charged at 250,000 gas, regardless of which precompile or contract creates the state.
 
-### Account Creation
+#### Account Creation
 
 **Current Behavior:**
 - Account creation has no explicit gas cost
@@ -86,7 +86,7 @@ This applies to all storage slot writes that transition from zero to non-zero, i
 - **Important:** When tokens are transferred TO a new address, the recipient's nonce remains 0, so no account creation cost is charged. The account creation cost only applies when the account is first used (sends a transaction).
 - The charge is in addition to any other gas costs for the transaction
 
-### Contract Creation
+#### Contract Creation
 
 **Current Behavior:**
 - Contract creation (CREATE/CREATE2) has a base cost of 32,000 gas plus 200 gas per byte of contract code
@@ -107,7 +107,7 @@ This applies to all storage slot writes that transition from zero to non-zero, i
 - Applies to both CREATE and CREATE2 operations
 - The fixed 500,000 gas covers the contract account creation; there is no separate account creation charge for the contract
 
-### Intrinsic transaction gas 
+#### Intrinsic transaction gas
 
 A transaction is invalid if the minimal costs of a (reverting) transaction can't be covered by caller's balance. Those checks are done in the transaction pool as a DOS prevention measure as well as when a transaction is first executed as part of a block.
 
@@ -122,13 +122,13 @@ A transaction is invalid if the minimal costs of a (reverting) transaction can't
   * If the first transaction in a batch is a CREATE transaction, the additional cost of 500,000 needs to be charged
 
 
-### Other changes
+#### Other changes
 
 The transaction gas cap is changed from 16M to 30M to accommodate the deployment of 24kb contracts.
 
 Tempo transaction key authorisations can't determine whether it is going to create new storage or not. If the transaction cannot pay for the key authorization storage costs, the transaction reverts any authorization key that has been set.
 
-## Gas Schedule Summary
+### Gas Schedule Summary
 
 | Operation | Current Gas Cost | Proposed Gas Cost | Change |
 |-----------|------------------|-------------------|--------|
@@ -139,9 +139,9 @@ Tempo transaction key authorisations can't determine whether it is going to crea
 | Existing state element (SSTORE non-zero → non-zero) | 5,000 | 5,000 | No change |
 | Existing state element (SSTORE non-zero → zero) | -15,000 (refund) | -15,000 (refund) | No change |
 
-## Economic Impact Analysis
+### Economic Impact Analysis
 
-### Cost Calculations
+#### Cost Calculations
 
 Based on the assumptions:
 - TIP-20 transfer cost (to existing address, including base transaction and state update): 50,000 gas = 0.1 cent (1,000 microdollars)
@@ -160,7 +160,7 @@ Based on the assumptions:
 - Fixed upfront cost: 500,000 gas = **1.0 cent (10,000 microdollars)**
 - Example: 1,000 byte contract = (1,000 × 1,000) + 500,000 = 1,500,000 gas = **3.0 cents (30,000 microdollars)**
 
-### Attack Cost Analysis
+#### Attack Cost Analysis
 
 **Creating 1 TB of state:**
 - 1 TB = 1,000,000,000,000 bytes
@@ -174,9 +174,9 @@ Based on the assumptions:
 
 These costs serve as a significant economic deterrent against state growth spam attacks.
 
-## Impact on Normal Operations
+### Impact on Normal Operations
 
-### Transfer to New Address
+#### Transfer to New Address
 
 **Current Cost:**
 - TIP-20 transfer (base + operation): 50,000 gas
@@ -192,7 +192,7 @@ These costs serve as a significant economic deterrent against state growth spam 
 
 **Impact:** A transfer to a new address increases from 0.14 cents to 0.6 cents, representing a 4.3x increase. The account creation cost (0.5 cents) will be charged separately when the recipient first uses their account.
 
-### First Use of New Account
+#### First Use of New Account
 
 **Current Cost:**
 - TIP-20 transfer (base + operation + state update): 50,000 gas
@@ -206,7 +206,7 @@ These costs serve as a significant economic deterrent against state growth spam 
 
 **Impact:** The first transaction from a new account increases from 0.1 cents to 0.6 cents, representing a 6x increase. Combined with the initial transfer cost (0.6 cents), the total onboarding cost for a new user is approximately 1.2 cents.
 
-### Transfer to Existing Address
+#### Transfer to Existing Address
 
 **Current Cost:**
 - TIP-20 transfer (base + operation + state update): 50,000 gas
@@ -218,7 +218,7 @@ These costs serve as a significant economic deterrent against state growth spam 
 
 **Impact:** No change for transfers to existing addresses.
 
-### Contract Deployment
+#### Contract Deployment
 
 **Current Cost:**
 - Contract code storage: 32,000 gas base + 200 gas per byte
@@ -231,9 +231,9 @@ These costs serve as a significant economic deterrent against state growth spam 
 
 **Impact:** Contract deployment costs increase significantly, especially for larger contracts. A 100 byte contract costs (100 × 1,000) + 500,000 = 600,000 gas = 1.2 cents.
 
-## Implementation Requirements
+### Implementation Requirements
 
-### Node Implementation
+#### Node Implementation
 
 The node implementation must:
 
@@ -257,7 +257,7 @@ The node implementation must:
    - Existing state operations (non-zero to non-zero, non-zero to zero) remain unchanged
    - Gas refunds for storage clearing remain unchanged
 
-### Test Suite Requirements
+#### Test Suite Requirements
 
 The test suite must verify:
 
@@ -303,7 +303,7 @@ The test suite must verify:
 
 ---
 
-# Invariants
+## Invariants
 
 The following invariants must always hold:
 
@@ -321,7 +321,7 @@ The following invariants must always hold:
 
 7. **Economic Deterrent Invariant:** The cost to create 1 TB of state MUST be at least $50 million, and the cost to create 10 TB of state MUST be at least $500 million, based on the assumed gas price of 1 cent per 500,000 gas.
 
-## Critical Test Cases
+### Critical Test Cases
 
 The test suite must cover:
 

--- a/src/pages/docs/protocol/tips/tip-1001.mdx
+++ b/src/pages/docs/protocol/tips/tip-1001.mdx
@@ -20,9 +20,9 @@ By allowing pair creation against `nextQuoteToken()`, this change allows users a
 
 ---
 
-# Specification
+## Specification
 
-## New functions
+### New functions
 
 Add the following functions to the Stablecoin DEX interface:
 
@@ -57,9 +57,9 @@ function place(bytes32 bookKey, address token, uint128 amount, bool isBid, int16
 function placeFlip(bytes32 bookKey, address token, uint128 amount, bool isBid, int16 tick, int16 flipTick, bool internalBalanceOnly) external returns (uint128 orderId);
 ```
 
-## Behavior
+### Behavior
 
-### Pair creation
+#### Pair creation
 
 `createNextPair(base)` creates a pair between `base` and `base.nextQuoteToken()`. The function:
 
@@ -69,7 +69,7 @@ function placeFlip(bytes32 bookKey, address token, uint128 amount, bool isBid, i
 4. Creates the pair using the same mechanism as `createPair`
 5. Emits `PairCreated(key, base, nextQuoteToken)`
 
-### Place-only mode
+#### Place-only mode
 
 Once the pair exists, it supports the full order lifecycle:
 
@@ -81,7 +81,7 @@ The new `place` and `placeFlip` overloads are required because the existing func
 
 Swap functions (`swapExactAmountIn`, `swapExactAmountOut`) and quote functions (`quoteSwapExactAmountIn`, `quoteSwapExactAmountOut`) do not route through this pair because routing uses `quoteToken()` to find paths between tokens.
 
-### After quote token update
+#### After quote token update
 
 When the token issuer calls `completeQuoteTokenUpdate()`:
 
@@ -92,20 +92,20 @@ When the token issuer calls `completeQuoteTokenUpdate()`:
 
 The old pair (against the previous quote token) remains but will no longer be used for routing swaps involving this base token. Orders on it can be canceled using their ID.
 
-## New error
+### New error
 
 ```solidity
 /// @notice The base token has no next quote token staged
 error NO_NEXT_QUOTE_TOKEN();
 ```
 
-## Events
+### Events
 
 No new events. The existing `PairCreated` event is emitted by `createNextPair`, and the existing `OrderPlaced` event is emitted by the `place` and `placeFlip` overloads. 
 
 ---
 
-# Invariants
+## Invariants
 
 - A pair created via `createNextPair` must be identical to one created via `createPair` once `completeQuoteTokenUpdate` is called
 - `createNextPair` must revert if `nextQuoteToken()` returns `address(0)`

--- a/src/pages/docs/protocol/tips/tip-1002.mdx
+++ b/src/pages/docs/protocol/tips/tip-1002.mdx
@@ -30,16 +30,16 @@ Currently, `placeFlip` requires `flipTick` to be strictly on the opposite side o
 
 ---
 
-# Specification
+## Specification
 
-## Modified behavior
+### Modified behavior
 
 The `place` and `placeFlip` functions (including the `bookKey` overloads from TIP-1001) are modified to check for crossing before accepting an order:
 
 - **For bids**: Revert if `tick > best_ask_tick` (when `best_ask_tick` exists)
 - **For asks**: Revert if `tick < best_bid_tick` (when `best_bid_tick` exists)
 
-### Same-tick orders
+#### Same-tick orders
 
 Orders at the same tick as the best order on the opposite side are **allowed**. This means:
 
@@ -48,7 +48,7 @@ Orders at the same tick as the best order on the opposite side are **allowed**. 
 
 While this is non-standard behavior for most order books (which would immediately match same-tick orders), it is intentionally permitted to support flip orders that flip to the same tick (see below).
 
-## Same-tick flip orders
+### Same-tick flip orders
 
 The `placeFlip` validation is relaxed to allow `flipTick == tick`:
 
@@ -57,26 +57,26 @@ The `placeFlip` validation is relaxed to allow `flipTick == tick`:
 
 This enables use cases like instant token convertibility, where an issuer places flip orders on both sides at the same tick to create a stable two-sided market that automatically replenishes when orders are filled.
 
-## Interaction with TIP-1001
+### Interaction with TIP-1001
 
 If TIP-1001 is accepted, the crossing check only applies when the pair is **active**—that is, when the pair's quote token equals the base token's current `quoteToken()`.
 
 For pairs created via `createNextPair` (where the quote token is the base token's `nextQuoteToken()`), the crossing check is skipped. This allows orders to accumulate freely during "place-only mode" before the quote token update is finalized. Such orders would likely be arbitraged nearly instantly once the pair launches, but this prevents someone from causing a denial-of-service to one side of the book by placing an extremely aggressive order on the other side.
 
-## New error
+### New error
 
 ```solidity
 /// @notice The order would cross existing orders on the opposite side
 error ORDER_WOULD_CROSS();
 ```
 
-## Events
+### Events
 
 No new events.
 
 ---
 
-# Invariants
+## Invariants
 
 - On active pairs, `best_bid_tick <= best_ask_tick` after any successful `place` or `placeFlip` call
 - On inactive pairs (per TIP-1001), no crossing check is enforced

--- a/src/pages/docs/protocol/tips/tip-1003.mdx
+++ b/src/pages/docs/protocol/tips/tip-1003.mdx
@@ -22,9 +22,9 @@ Traditional exchanges allow users to specify a client order ID (called `ClOrdID`
 
 ---
 
-# Specification
+## Specification
 
-## New storage
+### New storage
 
 A new mapping tracks active client order IDs per user:
 
@@ -32,7 +32,7 @@ A new mapping tracks active client order IDs per user:
 mapping(address user => mapping(uint128 clientOrderId => uint128 orderId)) public clientOrderIds;
 ```
 
-## Modified functions
+### Modified functions
 
 All order placement functions gain an optional `clientOrderId` parameter:
 
@@ -88,7 +88,7 @@ function placeFlip(
 ) external returns (uint128 orderId);
 ```
 
-## New functions
+### New functions
 
 ```solidity
 /// @notice Cancels an order by its client order ID
@@ -102,9 +102,9 @@ function cancelByClientOrderId(uint128 clientOrderId) external;
 function getOrderByClientOrderId(address user, uint128 clientOrderId) external view returns (uint128 orderId);
 ```
 
-## Behavior
+### Behavior
 
-### Placing orders with clientOrderId
+#### Placing orders with clientOrderId
 
 When `clientOrderId` is non-zero:
 
@@ -114,13 +114,13 @@ When `clientOrderId` is non-zero:
 
 When `clientOrderId` is zero, no client order ID tracking occurs.
 
-### Uniqueness and reuse
+#### Uniqueness and reuse
 
 A `clientOrderId` must be unique among a user's **active orders**. Once an order is filled or cancelled, its `clientOrderId` can be reused. This matches the standard FIX protocol behavior where `ClOrdID` uniqueness is required only for working orders.
 
 When an order reaches a terminal state (filled or cancelled), the `clientOrderIds` mapping entry is cleared.
 
-### Flip orders
+#### Flip orders
 
 When a flip order is filled and creates a new order on the opposite side:
 
@@ -130,11 +130,11 @@ When a flip order is filled and creates a new order on the opposite side:
 
 If the original order had no `clientOrderId` (was zero), the flipped order also has no `clientOrderId`.
 
-### Cancellation
+#### Cancellation
 
 `cancelByClientOrderId(clientOrderId)` looks up `clientOrderIds[msg.sender][clientOrderId]` and cancels that order. It reverts if no active order exists for that `clientOrderId`.
 
-## New event
+### New event
 
 ```solidity
 /// @notice Emitted when an order is placed (V2 with clientOrderId)
@@ -154,7 +154,7 @@ event OrderPlacedV2(
 
 `OrderPlacedV2` is identical to `OrderPlaced` but adds the `clientOrderId` field. When an order is placed, only `OrderPlacedV2` is emitted (not both events).
 
-## New errors
+### New errors
 
 ```solidity
 /// @notice The client order ID is already in use by an active order
@@ -166,7 +166,7 @@ error CLIENT_ORDER_ID_NOT_FOUND();
 
 ---
 
-# Invariants
+## Invariants
 
 - A non-zero `clientOrderId` maps to at most one active order per user
 - `clientOrderIds[user][clientOrderId]` is cleared when the order is filled or cancelled

--- a/src/pages/docs/protocol/tips/tip-1004.mdx
+++ b/src/pages/docs/protocol/tips/tip-1004.mdx
@@ -36,9 +36,9 @@ Adding a function for `transferWithAuthorization`, which we are also considering
 
 ---
 
-# Specification
+## Specification
 
-## New functions
+### New functions
 
 The following functions are added to the TIP-20 interface:
 
@@ -89,11 +89,11 @@ interface ITIP20Permit {
 }
 ```
 
-## EIP-712 Typed Data
+### EIP-712 Typed Data
 
 The permit signature must conform to EIP-712 typed structured data signing. The domain and message types are defined as follows:
 
-### Domain Separator
+#### Domain Separator
 
 The domain separator is computed using the following parameters:
 
@@ -114,7 +114,7 @@ bytes32 DOMAIN_SEPARATOR = keccak256(abi.encode(
 ));
 ```
 
-### Permit Typehash
+#### Permit Typehash
 
 The permit message type is:
 
@@ -124,7 +124,7 @@ bytes32 constant PERMIT_TYPEHASH = keccak256(
 );
 ```
 
-### Signature Construction
+#### Signature Construction
 
 To create a valid permit signature, the signer must sign the following EIP-712 digest:
 
@@ -147,28 +147,28 @@ bytes32 digest = keccak256(abi.encodePacked(
 
 The signature `(v, r, s)` must be produced by signing `digest` with the private key of `owner`.
 
-## Behavior
+### Behavior
 
-### Nonces
+#### Nonces
 
 Each address has an associated nonce that:
 - Starts at `0` for all addresses
 - Increments by `1` each time a permit is successfully executed for that address
 - Must be included in the permit signature to prevent replay attacks
 
-### Deadline
+#### Deadline
 
 The `deadline` parameter is a Unix timestamp. The permit is only valid if `block.timestamp <= deadline`. This allows signers to limit the validity window of their permits.
 
-### Pause State
+#### Pause State
 
 The `permit()` function follows the same pause behavior as `approve()`. Since setting an allowance does not move tokens, `permit()` is allowed to execute even when the token is paused.
 
-### TIP-403 Transfer Policy
+#### TIP-403 Transfer Policy
 
 The `permit()` function does not perform TIP-403 authorization checks, consistent with the behavior of `approve()`. Transfer policy checks are only enforced when tokens are actually transferred.
 
-### Signature Validation
+#### Signature Validation
 
 The implementation must:
 1. Verify that `block.timestamp <= deadline`, otherwise revert with `PermitExpired`
@@ -184,7 +184,7 @@ The implementation must:
 
 &gt; **Note**: The nonce is included in the signed digest, so nonce verification is implicit in signature validation — if the wrong nonce was signed, `ecrecover` will return a different address.
 
-## New errors
+### New errors
 
 ```solidity
 /// @notice The permit signature has expired (block.timestamp > deadline)
@@ -194,13 +194,13 @@ error PermitExpired();
 error InvalidSignature();
 ```
 
-## New events
+### New events
 
 None. Successful permit execution emits the existing `Approval` event from TIP-20.
 
 ---
 
-# Invariants
+## Invariants
 
 - `nonces(owner)` must only ever increase, never decrease
 - `nonces(owner)` must increment by exactly 1 on each successful `permit()` call for that owner
@@ -210,7 +210,7 @@ None. Successful permit execution emits the existing `Approval` event from TIP-2
 - After a successful `permit(owner, spender, value, ...)`, `allowance(owner, spender)` must equal `value`
 - `DOMAIN_SEPARATOR()` must be computed dynamically and reflect the current `block.chainid`
 
-## Test Cases
+### Test Cases
 
 The test suite must cover:
 

--- a/src/pages/docs/protocol/tips/tip-1005.mdx
+++ b/src/pages/docs/protocol/tips/tip-1005.mdx
@@ -30,9 +30,9 @@ This violates the zero-sum invariant: the taker pays more than the maker receive
 
 ---
 
-# Specification
+## Specification
 
-## Bug location
+### Bug location
 
 The bug is in `_fillOrdersExactIn` when processing ask orders (the `baseForQuote = false` path). Specifically, when a partial fill occurs:
 
@@ -42,7 +42,7 @@ The bug is in `_fillOrdersExactIn` when processing ask orders (the `baseForQuote
 
 The re-derivation in step 3 loses the original `remainingIn` information.
 
-## Fix
+### Fix
 
 For partial fills in the ask path, pass the actual `remainingIn` (quote) to `_fillOrder` and use it directly for the maker's credit, rather than re-deriving it from `fillAmount`.
 
@@ -52,11 +52,11 @@ The fix requires:
 2. In `_fillOrdersExactIn`, when partially filling an ask, pass `remainingIn` as the quote override
 3. When `quoteOverride` is provided, use it directly for the maker's balance increment instead of computing `ceil(fillAmount * price)`
 
-## Reference implementation changes
+### Reference implementation changes
 
 The fix requires changes to two functions in [`docs/specs/src/StablecoinDEX.sol`](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol):
 
-### 1. `_fillOrder` ([line 551-556](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol#L551-L556))
+#### 1. `_fillOrder` ([line 551-556](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol#L551-L556))
 
 Add an optional `quoteOverride` parameter. When non-zero and the order is an ask, use `quoteOverride` directly for the maker's balance increment instead of computing `ceil(fillAmount * price)`.
 
@@ -73,7 +73,7 @@ uint128 quoteAmount = quoteOverride > 0
 balances[order.maker][book.quote] += quoteAmount;
 ```
 
-### 2. `_fillOrdersExactIn` ([line 923-926](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol#L923-L926))
+#### 2. `_fillOrdersExactIn` ([line 923-926](https://github.com/tempoxyz/tempo/blob/main/docs/specs/src/StablecoinDEX.sol#L923-L926))
 
 In the partial fill branch for asks, pass `remainingIn` as the quote override:
 
@@ -85,13 +85,13 @@ orderId = _fillOrder(orderId, fillAmount);
 orderId = _fillOrder(orderId, fillAmount, remainingIn);
 ```
 
-## Affected code paths
+### Affected code paths
 
 - `_fillOrdersExactIn` with `baseForQuote = false` (ask path), partial fill case only
 - Full fills are not affected because the quote amount is derived from `order.remaining`, not `remainingIn`
 - Bid swaps are not affected because the taker pays base tokens directly
 
-## Example: Before and after
+### Example: Before and after
 
 **Before (buggy):**
 ```
@@ -111,7 +111,7 @@ Lost: 0 tokens
 
 ---
 
-# Invariants
+## Invariants
 
 - Zero-sum: for any swap, `takerPaid == makerReceived` (within the same token)
 - Taker receives `floor(amountIn / price)` base tokens (rounds in favor of protocol)

--- a/src/pages/docs/protocol/tips/tip-1006.mdx
+++ b/src/pages/docs/protocol/tips/tip-1006.mdx
@@ -27,9 +27,9 @@ The `burnAt` function provides this capability with appropriate access controls 
 
 ---
 
-# Specification
+## Specification
 
-## New Role
+### New Role
 
 A new role constant is added to TIP-20:
 
@@ -39,7 +39,7 @@ bytes32 public constant BURN_AT_ROLE = keccak256("BURN_AT_ROLE");
 
 This role is administered by the `DEFAULT_ADMIN_ROLE` (same as other TIP-20 roles).
 
-## New Event
+### New Event
 
 ```solidity
 /// @notice Emitted when tokens are burned from any account.
@@ -48,7 +48,7 @@ This role is administered by the `DEFAULT_ADMIN_ROLE` (same as other TIP-20 role
 event BurnAt(address indexed from, uint256 amount);
 ```
 
-## New Function
+### New Function
 
 ```solidity
 /// @notice Burns tokens from any account.
@@ -58,7 +58,7 @@ event BurnAt(address indexed from, uint256 amount);
 function burnAt(address from, uint256 amount) external;
 ```
 
-### Behavior
+#### Behavior
 
 1. **Access Control**: Reverts with `Unauthorized` if caller does not have `BURN_AT_ROLE`
 2. **Protected Addresses**: Reverts with `ProtectedAddress` if `from` is:
@@ -72,7 +72,7 @@ function burnAt(address from, uint256 amount) external;
    - Updates reward accounting if `from` is opted into rewards
 6. **Events**: Emits `Transfer(from, address(0), amount)` and `BurnAt(from, amount)`
 
-### Interface Addition
+#### Interface Addition
 
 The `ITIP20` interface is extended with:
 
@@ -87,7 +87,7 @@ function BURN_AT_ROLE() external view returns (bytes32);
 function burnAt(address from, uint256 amount) external;
 ```
 
-# Invariants
+## Invariants
 
 1. **Role Required**: `burnAt` must always revert if caller lacks `BURN_AT_ROLE`
 2. **Protected Addresses**: `burnAt` must never succeed when `from` is a protected precompile address
@@ -102,7 +102,7 @@ function burnAt(address from, uint256 amount) external;
    - Any previously accrued `rewardBalance` remains claimable
 6. **Policy Independence**: `burnAt` must succeed regardless of transfer policy status of `from`
 
-## Test Cases
+### Test Cases
 
 The test suite must verify:
 

--- a/src/pages/docs/protocol/tips/tip-1007.mdx
+++ b/src/pages/docs/protocol/tips/tip-1007.mdx
@@ -27,9 +27,9 @@ This capability was requested by a partner. It could be useful for contracts tha
 
 ---
 
-# Specification
+## Specification
 
-## New Function
+### New Function
 
 The following function is added to the `IFeeManager` interface:
 
@@ -46,13 +46,13 @@ interface IFeeManager {
 }
 ```
 
-## Behavior
+### Behavior
 
-### Fee Token Resolution
+#### Fee Token Resolution
 
 The fee token returned by `getFeeToken()` is the same token that was resolved by the protocol during transaction validation, following the [fee token preference rules](/docs/protocol/fees/spec-fee#fee-token-resolution).
 
-### Storage
+#### Storage
 
 The fee token is stored in **transient storage** (EIP-1153) within the FeeManager precompile. This means:
 
@@ -60,15 +60,15 @@ The fee token is stored in **transient storage** (EIP-1153) within the FeeManage
 - No persistent storage writes occur, minimizing gas costs
 - The value is consistent across all calls within a transaction (including internal calls and subcalls)
 
-### Timing
+#### Timing
 
 The fee token is set by the protocol in the `validate_against_state_and_deduct_caller` handler phase, before any user code executes. This ensures the value is available throughout the entire transaction execution.
 
-### Gas Cost
+#### Gas Cost
 
 Reading the fee token costs the standard warm transient storage read cost (100 gas for TLOAD). This is the cost of calling `getFeeToken()` itself; callers should account for additional gas used by the CALL opcode to invoke the precompile.
 
-### Edge Cases
+#### Edge Cases
 
 | Scenario | Return Value |
 |----------|--------------|
@@ -78,7 +78,7 @@ Reading the fee token costs the standard warm transient storage read cost (100 g
 
 The only case where `address(0)` is returned is in simulation contexts (e.g., `eth_call`) where the protocol handler does not execute.
 
-## Example Usage
+### Example Usage
 
 ```solidity
 import { IFeeManager } from "./interfaces/IFeeManager.sol";
@@ -101,7 +101,7 @@ contract FeeTokenAware {
 }
 ```
 
-## Interface Addition
+### Interface Addition
 
 The following function is added to `IFeeManager`:
 
@@ -113,7 +113,7 @@ function getFeeToken() external view returns (address);
 
 ---
 
-# Invariants
+## Invariants
 
 - `getFeeToken()` must return a consistent value across all calls within the same transaction
 - `getFeeToken()` must return `address(0)` in simulation contexts (e.g., `eth_call`) where no transaction handler runs
@@ -121,7 +121,7 @@ function getFeeToken() external view returns (address);
 - The fee token returned must match the token used for actual fee deduction in `collectFeePreTx` and `collectFeePostTx`
 - Reading the fee token must not modify any state (view function)
 
-## Test Cases
+### Test Cases
 
 The test suite must cover:
 

--- a/src/pages/docs/protocol/tips/tip-1009.mdx
+++ b/src/pages/docs/protocol/tips/tip-1009.mdx
@@ -26,9 +26,9 @@ Expiring nonces solve these problems by using time-based validity instead of seq
 
 ---
 
-# Specification
+## Specification
 
-## Nonce Key
+### Nonce Key
 
 Expiring nonce transactions use a reserved nonce key:
 
@@ -38,7 +38,7 @@ TEMPO_EXPIRING_NONCE_KEY = uint256.max (2^256 - 1)
 
 When a Tempo transaction specifies `nonceKey = uint256.max`, the protocol treats it as an expiring nonce transaction.
 
-## Transaction Fields
+### Transaction Fields
 
 Expiring nonce transactions require:
 
@@ -48,7 +48,7 @@ Expiring nonce transactions require:
 | `nonce` | `uint64` | Must be `0` (unused, validated for consistency) |
 | `validBefore` | `uint64` | Unix timestamp (seconds) after which the transaction is invalid |
 
-## Validity Window
+### Validity Window
 
 The `validBefore` timestamp must satisfy:
 
@@ -62,11 +62,11 @@ Where:
 
 Transactions with `validBefore` in the past or more than 30 seconds in the future are rejected.
 
-## Replay Protection
+### Replay Protection
 
 Replay protection uses a **circular buffer** data structure in the Nonce precompile:
 
-### Storage Layout
+#### Storage Layout
 
 ```solidity
 contract Nonce {
@@ -80,7 +80,7 @@ contract Nonce {
 }
 ```
 
-### Circular Buffer Design
+#### Circular Buffer Design
 
 The circular buffer has a fixed capacity:
 
@@ -90,7 +90,7 @@ EXPIRING_NONCE_SET_CAPACITY = 300,000
 
 This capacity is sized for 10,000 TPS × 30 seconds = 300,000 transactions, ensuring entries expire before being overwritten.
 
-### Algorithm
+#### Algorithm
 
 When processing an expiring nonce transaction:
 
@@ -114,7 +114,7 @@ When processing an expiring nonce transaction:
 
 7. **Advance pointer**: Write `expiringNonceRingPtr = ptr + 1`
 
-### Pseudocode
+#### Pseudocode
 
 ```solidity
 function checkAndMarkExpiringNonce(
@@ -150,7 +150,7 @@ function checkAndMarkExpiringNonce(
 }
 ```
 
-## Gas Costs
+### Gas Costs
 
 The intrinsic gas cost for expiring nonce transactions includes:
 
@@ -173,7 +173,7 @@ EXPIRING_NONCE_GAS = 2 * COLD_SLOAD_COST + WARM_SLOAD_COST + 3 * WARM_SSTORE_RES
 - Expiring nonce data is ephemeral: evicted within 30 seconds, fixed-size buffer (300k entries)
 - No permanent state growth, so the 20k penalty doesn't apply
 
-## Transaction Pool Validation
+### Transaction Pool Validation
 
 The transaction pool performs preliminary validation:
 
@@ -186,28 +186,28 @@ The transaction pool performs preliminary validation:
 
 Transactions failing these checks are rejected before entering the pool.
 
-## Interaction with Other Features
+### Interaction with Other Features
 
-### 2D Nonces
+#### 2D Nonces
 
 Expiring nonces and 2D nonces are mutually exclusive:
 - `nonceKey = 0`: Protocol nonce (standard sequential)
 - `nonceKey = 1..uint256.max-1`: 2D nonce keys
 - `nonceKey = uint256.max`: Expiring nonce mode
 
-### Access Keys (Keychain)
+#### Access Keys (Keychain)
 
 Expiring nonces work with access key signatures. The `validBefore` provides an additional security boundary—even if an access key is compromised, transactions signed with it become invalid after the expiry window.
 
-### Fee Tokens
+#### Fee Tokens
 
 Expiring nonce transactions pay fees in TIP-20 fee tokens like any other Tempo transaction.
 
 ---
 
-# Invariants
+## Invariants
 
-## Must Hold
+### Must Hold
 
 | ID | Invariant | Description |
 |----|-----------|-------------|
@@ -219,7 +219,7 @@ Expiring nonce transactions pay fees in TIP-20 fee tokens like any other Tempo t
 | **E6** | No nonce mutation | Expiring nonce txs do not increment protocol nonce or any 2D nonce |
 | **E7** | Concurrent independence | Multiple expiring nonce txs from same sender can execute in same block |
 
-## Invariant Tests
+### Invariant Tests
 
 These invariants are tested in the Foundry invariant test suite (`TempoTransactionInvariant.t.sol`):
 
@@ -234,7 +234,7 @@ These invariants are tested in the Foundry invariant test suite (`TempoTransacti
 | `handler_expiringNonceNoNonceMutation` | E6 | Protocol and 2D nonces unchanged after execution |
 | `handler_expiringNonceConcurrent` | E7 | Multiple concurrent txs from same sender succeed |
 
-## Test Cases
+### Test Cases
 
 1. **Basic flow**: Submit transaction, verify execution, attempt replay (should fail)
 
@@ -260,11 +260,11 @@ These invariants are tested in the Foundry invariant test suite (`TempoTransacti
 
 ---
 
-# Benchmark Results
+## Benchmark Results
 
 Benchmarks were run to measure state savings from expiring nonces compared to 2D nonces.
 
-## Key Findings
+### Key Findings
 
 | Metric | Value |
 |--------|-------|
@@ -272,7 +272,7 @@ Benchmarks were run to measure state savings from expiring nonces compared to 2D
 | Circular buffer capacity | 300,000 entries |
 | Buffer fills at 5k TPS | ~60 seconds |
 
-## Controlled Benchmark (100k transactions at 5k TPS)
+### Controlled Benchmark (100k transactions at 5k TPS)
 
 | Nonce Type | Final DB Size | Transactions |
 |------------|---------------|--------------|
@@ -282,7 +282,7 @@ Benchmarks were run to measure state savings from expiring nonces compared to 2D
 
 The ~107 bytes per transaction overhead includes MPT node overhead, MDBX metadata, and RLP encoding.
 
-## Scaling Projections
+### Scaling Projections
 
 | TPS | Daily Transactions | Daily State Savings |
 |-----|-------------------|---------------------|
@@ -293,9 +293,9 @@ After the circular buffer fills, expiring nonces maintain constant storage while
 
 ---
 
-# Open Questions
+## Open Questions
 
-## Safety Check for Buffer Eviction
+### Safety Check for Buffer Eviction
 
 The current implementation includes a safety check that reads `expiringNonceSeen[oldHash]` before evicting an entry from the ring buffer. This check verifies the entry is actually expired before overwriting.
 
@@ -316,7 +316,7 @@ The current implementation includes a safety check that reads `expiringNonceSeen
 2. Removed entirely, trusting the capacity sizing?
 3. Kept and fully charged (add 2,100 gas to `EXPIRING_NONCE_GAS`)?
 
-## Buffer Capacity Sizing
+### Buffer Capacity Sizing
 
 The current capacity of 300,000 assumes:
 - Maximum 10,000 TPS sustained
@@ -324,7 +324,7 @@ The current capacity of 300,000 assumes:
 
 **Question**: Should the capacity be configurable per-chain or hardcoded? What happens if TPS requirements increase significantly?
 
-## Transaction Hash Computation
+### Transaction Hash Computation
 
 The transaction hash used for replay protection must be computed before signature recovery.
 

--- a/src/pages/docs/protocol/tips/tip-1010.mdx
+++ b/src/pages/docs/protocol/tips/tip-1010.mdx
@@ -27,9 +27,9 @@ The parameters defined in this TIP represent the initial mainnet configuration a
 
 ---
 
-# Specification
+## Specification
 
-## Base Fee
+### Base Fee
 
 **Value**: `2 × 10^10` attodollars (20 billion attodollars per gas)
 
@@ -42,7 +42,7 @@ The parameters defined in this TIP represent the initial mainnet configuration a
 
 **Note**: The base fee is fixed per protocol version and does not adjust dynamically based on block utilization. Unlike EIP-1559, there is no in-protocol mechanism that raises or lowers the base fee in response to congestion. Changes to the base fee require a hardfork upgrade.
 
-## Block Gas Limit
+### Block Gas Limit
 
 **Value**: 500,000,000 gas per block (total block gas limit)
 
@@ -65,7 +65,7 @@ The parameters defined in this TIP represent the initial mainnet configuration a
 - Only transactions qualifying for the payment lane (simple TIP-20 transfers, memos, etc.) may exceed the `general_gas_limit`
 - Complex contract interactions use the general gas limit instead
 
-## Main Transaction Gas Limit
+### Main Transaction Gas Limit
 
 **Value**: 30,000,000 gas per block (`general_gas_limit`)
 
@@ -82,7 +82,7 @@ The parameters defined in this TIP represent the initial mainnet configuration a
 **Transactions exceeding 16,000,000 gas are not recommended.** The elevated gas limits (30M) exist solely to accommodate maximum-sized contract deployments under TIP-1000 state creation costs. Applications should not rely on transactions consuming more than 16M gas for normal operations. When storage pricing is moved to a separate mechanism (e.g., storage rent or state expiry), the transaction gas cap is expected to return to 16,000,000 gas.
 :::
 
-## Transaction Gas Cap
+### Transaction Gas Cap
 
 **Value**: 30,000,000 gas per transaction
 
@@ -96,7 +96,7 @@ The parameters defined in this TIP represent the initial mainnet configuration a
   - Contract code storage (TIP-1000): `24,576 bytes × 1,000 gas/byte = 24,576,000 gas`
   - **Total**: ~25,600,000-25,900,000 gas (fits within 30M limit)
 
-## Gas Schedule Summary
+### Gas Schedule Summary
 
 | Parameter | Value | Purpose |
 |-----------|-------|---------|
@@ -107,16 +107,16 @@ The parameters defined in this TIP represent the initial mainnet configuration a
 | General gas limit | 30,000,000 gas/block | Cap for non-payment transactions |
 | Transaction gas cap | 30,000,000 gas | Allow max-size contract deployment |
 
-## Economic Analysis
+### Economic Analysis
 
-### Fee Revenue Projections
+#### Fee Revenue Projections
 
 At full payment lane utilization:
 - 10,000 transfers per block × 1,000 microdollars = 10,000,000 microdollars ($10) per block
 - At 2 blocks/second: $20/second
 - Daily: ~$1,728,000 in base fees from payment lane alone
 
-### Cost Per Operation
+#### Cost Per Operation
 
 | Operation | Gas Cost | USD Cost (at target base fee) |
 |-----------|----------|-------------------------------|
@@ -128,7 +128,7 @@ At full payment lane utilization:
 
 ---
 
-# Invariants
+## Invariants
 
 1. **Base Fee Invariant**: The base fee is fixed at `2 × 10^10` attodollars per protocol version and can only be changed via a hardfork upgrade. At the current base fee, a TIP-20 transfer (50,000 gas) MUST cost approximately 0.1 cent (1,000 microdollars).
 
@@ -143,7 +143,7 @@ At full payment lane utilization:
    - Total gas used by non-payment (general) transactions exceeds the general gas limit (30M)
    - Total gas used by validator subblock transactions exceeds the shared gas limit (50M)
 
-## Implementation Notes
+### Implementation Notes
 
 These parameters are configured at the chainspec level and applied during block validation. Future adjustments may be made through:
 
@@ -151,7 +151,7 @@ These parameters are configured at the chainspec level and applied during block 
 2. Governance proposals (if on-chain governance is implemented)
 3. Emergency response procedures (for critical security issues)
 
-## Test Cases
+### Test Cases
 
 1. **Base fee targeting**: Verify that at equilibrium, TIP-20 transfers cost approximately 0.1 cent (1,000 microdollars)
 2. **Payment lane capacity**: Verify that 10,000 TIP-20 transfers can be included in a single block

--- a/src/pages/docs/protocol/tips/tip-1011.mdx
+++ b/src/pages/docs/protocol/tips/tip-1011.mdx
@@ -54,16 +54,16 @@ This TIP intentionally adds a narrow calldata rule (first ABI `address` argument
 
 ---
 
-# Specification
+## Specification
 
-## Extended Data Structures
+### Extended Data Structures
 
 Conventions used in this section:
 
 1. Protocol/RLP structs are written with Rust-like `Option<...>` notation.
 2. Solidity ABI structs are listed separately where ABI cannot directly represent protocol `Option` semantics.
 
-### TokenLimit
+#### TokenLimit
 
 **Current:**
 
@@ -102,7 +102,7 @@ Initialization and persistence:
 3. `period > 0` initializes `remainingInPeriod = limit` and `periodEnd = authorize_time + period`.
 4. For a given `(account,key,token)`, there is exactly one active `TokenLimit`; duplicate token entries in a single authorization MUST be rejected.
 
-### CallScope
+#### CallScope
 
 Call scoping uses explicit vectors in the protocol model:
 
@@ -135,7 +135,7 @@ Solidity ABI and protocol semantics match directly:
 
 In the Solidity precompile API, omitting a target scope blocks that target; `selectorRules = []` does not.
 
-### SelectorRule
+#### SelectorRule
 
 ```text
 SelectorRule {
@@ -195,7 +195,7 @@ Examples:
 6. `{ target: tokenX, selector_rules: [{selector: 0xa9059cbb, recipients: [0xA, 0xB]}] }`: allow `transfer` only when `to` is in `{0xA, 0xB}`.
 7. Distinct target scopes are independent: allowing selector `s` on target `A` never allows selector `s` on target `B`.
 
-### KeyAuthorization
+#### KeyAuthorization
 
 Existing fields remain, with a trailing optional call-scope field:
 
@@ -210,9 +210,9 @@ KeyAuthorization {
 }
 ```
 
-## Interface Changes
+### Interface Changes
 
-### Events
+#### Events
 
 ```solidity
 /// @notice Emitted when an access key spends tokens against a spending limit
@@ -232,7 +232,7 @@ event AccessKeySpend(
 
 This event MUST be emitted whenever an access-key transaction deducts from a spending limit (one-time or periodic).
 
-### IAccountKeychain.sol
+#### IAccountKeychain.sol
 
 ```solidity
 /// @notice Authorizes a key with enhanced permissions
@@ -289,9 +289,9 @@ function getRemainingLimit(
 3. `isScoped = true, calls = [c1, ...]`: scoped key with the listed allowlist.
 4. Missing, revoked, or expired access keys return `isScoped = true, calls = []`.
 
-## Semantic Behavior
+### Semantic Behavior
 
-### Periodic Limit Reset Logic
+#### Periodic Limit Reset Logic
 
 On each spend attempt for `(account, key, token)`:
 
@@ -309,7 +309,7 @@ On each spend attempt for `(account, key, token)`:
 4. MUST NOT change `periodEnd`.
 5. Therefore changing `period` requires re-authorizing the key (or removing and recreating that token limit entry).
 
-### Call Validation Logic
+#### Call Validation Logic
 
 Call-scope checks use map lookups keyed by `(account_key, target, selector)` plus optional selector-level recipient allowlists.
 
@@ -318,7 +318,7 @@ Scoped-call validation is performed in a metered pre-execution phase after trans
 If any call fails scoped-call validation, the transaction execution MUST fail atomically before any user call in the batch begins.
 
 
-#### Access-Key Contract Creation Ban
+##### Access-Key Contract Creation Ban
 
 If a transaction is signed with an access key (`key != Address::ZERO`), contract creation MUST be rejected as an invalid transaction in all configurations.
 
@@ -330,7 +330,7 @@ This ban applies regardless of:
 
 Only the root key (`key == Address::ZERO`) may submit contract-creation calls; this is not a global create ban.
 
-#### Single Call Validation
+##### Single Call Validation
 
 For each call:
 
@@ -346,7 +346,7 @@ For each call:
 10. For a selector rule with a non-empty `recipients` list, if calldata is shorter than `4 + 32` bytes, implementations MUST fail execution before the first user call begins.
 11. For a selector rule with a non-empty `recipients` list, implementations MUST enforce canonical ABI `address` encoding for argument `0` (upper 12 bytes zero) before membership check; otherwise implementations MUST fail execution before the first user call begins.
 
-#### Batch Validation
+##### Batch Validation
 
 For AA transactions with multiple calls, each call MUST be validated independently in the metered pre-execution phase before execution of the first user call begins.
 
@@ -356,7 +356,7 @@ If any call fails scope validation:
 2. No user call in the batch may execute.
 3. The failure MUST be reported as an execution failure rather than as an invalid transaction.
 
-### Root-Controlled Scope Updates
+#### Root-Controlled Scope Updates
 
 `setAllowedCalls` MUST be root-key-only and MUST apply create-or-replace semantics per target.
 
@@ -379,7 +379,7 @@ Rationale for rule 2 (`removeAllowedCalls` disables a target scope):
 1. This avoids unbounded gas from deletion-time slot iteration.
 2. Prior selector rows may remain in state, but the removed target scope no longer participates in matching.
 
-### Interaction Rules
+#### Interaction Rules
 
 1. Keys may mix one-time and periodic token limits.
 2. Spending limits and call scopes are independent checks; both must pass.
@@ -395,7 +395,7 @@ Wallet UX recommendation (non-consensus):
 
 1. Wallets SHOULD default to scoped keys (non-empty `selectorRules`) and require explicit user opt-in for unrestricted target scopes (`selectorRules = []`).
 
-## Gas And Complexity Bounds
+### Gas And Complexity Bounds
 
 This TIP only specifies the additional intrinsic gas delta for call scopes in handler-side `key_authorization` charging.
 
@@ -429,7 +429,7 @@ scope_slots = 0                    if allowed_calls is None
 
 Justification for `1 + 3*S + 3*K + C + 2*W`: `1` stores restricted mode, each target scope materializes as three set writes, each selector rule materializes as three set writes, each constrained selector writes one recipient-set length slot, and each recipient writes two set-membership slots.
 
-### Rounded Helper Overhead
+#### Rounded Helper Overhead
 
 Implementations may also charge a small rounded helper overhead for scoped-key authorization bookkeeping that is not captured by raw storage-row counts alone.
 
@@ -452,9 +452,9 @@ Bounds:
 
 No additional flat gas is specified here for precompile methods (`setAllowedCalls`, `getAllowedCalls`, etc.); those are charged by normal EVM metering at execution time.
 
-## Encoding
+### Encoding
 
-### Signing Format
+#### Signing Format
 
 Authorization digest format:
 
@@ -477,7 +477,7 @@ RLP safety note:
 1. Implementations MUST use canonical RLP encoding for all fields.
 2. The signed payload is a typed RLP list; distinct field tuples produce distinct canonical encodings (no cross-field preimage ambiguity under canonical RLP).
 
-### Transaction Authorization RLP
+#### Transaction Authorization RLP
 
 ```text
 KeyAuthorization := RLP([
@@ -525,7 +525,7 @@ Optional encoding rules:
 
 ---
 
-## Precompile Storage Changes
+### Precompile Storage Changes
 
 Current layout:
 
@@ -554,7 +554,7 @@ Absent target or selector entries represent disabled inner scopes; implementatio
 
 Implementations MAY maintain additional internal indexes or equivalent layouts so long as semantics remain unchanged.
 
-## Hardfork-Gated Features
+### Hardfork-Gated Features
 
 The following MUST be fork-gated:
 
@@ -577,7 +577,7 @@ Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 
 ---
 
-# Invariants
+## Invariants
 
 1. `periodEnd` is monotonic and never set to the past.
 2. `remainingInPeriod <= limit` after any operation.
@@ -590,7 +590,7 @@ Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 9. Selector rules with recipient allowlists are valid only for TIP-20 targets and only for the fixed constrained selector set.
 10. For recipient-allowlisted rules, calldata argument `0` must be a canonically encoded ABI address and must be in the configured recipient set.
 11. In the Solidity ABI, `selectorRules[i].recipients = []` means that selector has no recipient restriction.
-## Test Cases
+### Test Cases
 
 1. Periodic reset after elapsed period.
 2. No rollover of unused periodic allowance.
@@ -619,7 +619,7 @@ Pre-fork blocks MUST replay with pre-fork semantics to preserve state roots.
 27. Reject duplicate recipients within a selector rule.
 28. Reject key authorization when selector rules with recipient allowlists are used on a non-TIP-20 target.
 
-## References
+### References
 
 - [AccountKeychain docs](https://tempo.xyz/developers/docs/protocol/transactions/AccountKeychain)
 - [Tempo Transactions](https://tempo.xyz/developers/docs/guide/tempo-transaction)

--- a/src/pages/docs/protocol/tips/tip-1015.mdx
+++ b/src/pages/docs/protocol/tips/tip-1015.mdx
@@ -27,9 +27,9 @@ Compound policies enable these use cases while maintaining backward compatibilit
 
 ---
 
-# Specification
+## Specification
 
-## Policy Types
+### Policy Types
 
 TIP-403 currently supports two policy types: `WHITELIST` and `BLACKLIST`. This TIP adds a third type:
 
@@ -41,7 +41,7 @@ enum PolicyType {
 }
 ```
 
-## Compound Policy Structure
+### Compound Policy Structure
 
 A compound policy references three existing simple policies by their policy IDs:
 
@@ -55,7 +55,7 @@ struct CompoundPolicyData {
 
 All three referenced policies MUST be simple policies (WHITELIST or BLACKLIST), not compound policies. This prevents circular references and unbounded recursion.
 
-## Storage Layout
+### Storage Layout
 
 Policy data is stored in a unified `PolicyRecord` struct that contains both base policy data and compound policy data:
 
@@ -87,7 +87,7 @@ For a given policy ID, storage locations are:
 
 This unified layout requires only **1 keccak computation + 2 SLOADs** for compound policy authorization, compared to 2 keccak computations with separate mappings.
 
-## Interface Additions
+### Interface Additions
 
 The TIP403Registry interface is extended with the following:
 
@@ -188,9 +188,9 @@ interface ITIP403Registry {
 }
 ```
 
-## Authorization Logic
+### Authorization Logic
 
-### isAuthorizedSender
+#### isAuthorizedSender
 
 ```solidity
 function isAuthorizedSender(uint64 policyId, address user) external view returns (bool) {
@@ -205,7 +205,7 @@ function isAuthorizedSender(uint64 policyId, address user) external view returns
 }
 ```
 
-### isAuthorizedRecipient
+#### isAuthorizedRecipient
 
 ```solidity
 function isAuthorizedRecipient(uint64 policyId, address user) external view returns (bool) {
@@ -220,7 +220,7 @@ function isAuthorizedRecipient(uint64 policyId, address user) external view retu
 }
 ```
 
-### isAuthorizedMintRecipient
+#### isAuthorizedMintRecipient
 
 ```solidity
 function isAuthorizedMintRecipient(uint64 policyId, address user) external view returns (bool) {
@@ -235,7 +235,7 @@ function isAuthorizedMintRecipient(uint64 policyId, address user) external view 
 }
 ```
 
-### isAuthorized (updated)
+#### isAuthorized (updated)
 
 The existing `isAuthorized` function is updated to check both sender and recipient authorization:
 
@@ -247,11 +247,11 @@ function isAuthorized(uint64 policyId, address user) external view returns (bool
 
 This maintains backward compatibility: for simple policies both functions return the same result, so `isAuthorized` behaves identically to before. For compound policies, `isAuthorized` returns true only if the user is authorized as both sender and recipient.
 
-## Required Code Changes
+### Required Code Changes
 
 This TIP requires exactly 6 replacements of `isAuthorized` calls:
 
-### Direct Replacements
+#### Direct Replacements
 
 | Location | Current | Replace With |
 |----------|---------|--------------|
@@ -260,7 +260,7 @@ This TIP requires exactly 6 replacements of `isAuthorized` calls:
 | DEX `cancelStaleOrder` | `isAuthorized(maker)` | `isAuthorizedSender(maker)` |
 | Fee payer `can_fee_payer_transfer` | `isAuthorized(fee_payer)` | `isAuthorizedSender(fee_payer)` |
 
-### Core Authorization Logic
+#### Core Authorization Logic
 
 | Location | Current | Replace With |
 |----------|---------|--------------|
@@ -273,11 +273,11 @@ All other call sites use `ensureTransferAuthorized(from, to)` which delegates to
 - **TIP-20 Rewards**: `distributeReward`, `setRewardRecipient`, `claimRewards`
 - **Stablecoin DEX**: `decrementBalanceOrTransferFrom`, `placeLimitOrder`, `swapExactAmountIn`
 
-## TIP-20 Integration
+### TIP-20 Integration
 
 TIP-20 tokens MUST be updated to use the new sender/recipient authorization functions:
 
-### Transfer Authorization (isTransferAuthorized)
+#### Transfer Authorization (isTransferAuthorized)
 
 ```solidity
 function isTransferAuthorized(address from, address to) internal view returns (bool) {
@@ -290,7 +290,7 @@ function isTransferAuthorized(address from, address to) internal view returns (b
 }
 ```
 
-### Mint Operations
+#### Mint Operations
 
 Mint operations check the mint recipient policy:
 
@@ -303,7 +303,7 @@ function _mint(address to, uint256 amount) internal {
 }
 ```
 
-### Burn Blocked Operations
+#### Burn Blocked Operations
 
 The `burnBlocked` function checks sender authorization to verify the address is blocked:
 
@@ -319,9 +319,9 @@ function burnBlocked(address from, uint256 amount) external {
 }
 ```
 
-## Stablecoin DEX Integration
+### Stablecoin DEX Integration
 
-### Cancel Stale Order
+#### Cancel Stale Order
 
 The `cancelStaleOrder` function checks sender authorization on the token escrowed by the maker, since if the order is filled, the maker will have to send that token:
 
@@ -340,7 +340,7 @@ function cancelStaleOrder(uint128 orderId) external {
 }
 ```
 
-## Mutability
+### Mutability
 
 Compound policies are **structurally immutable** once created — their constituent policy ID references cannot be changed, and they have no admin. However, the referenced simple policies remain independently mutable by their respective admins. Modifications to a referenced simple policy's whitelist or blacklist will immediately affect the authorization behavior of any compound policy that references it.
 
@@ -351,7 +351,7 @@ To change which simple policies a compound policy references, token issuers must
 
 To modify authorization behavior without changing the compound policy itself, the admin of a referenced simple policy can modify that simple policy's whitelist or blacklist directly.
 
-## Backward Compatibility
+### Backward Compatibility
 
 This TIP is fully backward compatible:
 
@@ -361,7 +361,7 @@ This TIP is fully backward compatible:
 
 ---
 
-# Invariants
+## Invariants
 
 1. **Simple Policy Constraint**: All three policy IDs in a compound policy MUST reference simple policies (WHITELIST or BLACKLIST). Compound policies cannot reference other compound policies.
 
@@ -377,7 +377,7 @@ This TIP is fully backward compatible:
 
 7. **Non-existent Policy Revert**: All authorization functions (`isAuthorized`, `isAuthorizedSender`, `isAuthorizedRecipient`, `isAuthorizedMintRecipient`) MUST revert with `PolicyNotFound()` when called with a policy ID that does not exist. Built-in policies (0 and 1) always exist and are exempt from this check.
 
-## Test Cases
+### Test Cases
 
 1. **Simple policy equivalence**: Verify that for simple policies, all four authorization functions return the same result.
 

--- a/src/pages/docs/protocol/tips/tip-1016.mdx
+++ b/src/pages/docs/protocol/tips/tip-1016.mdx
@@ -46,9 +46,9 @@ The reservoir model (from [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) s
 
 ---
 
-# Specification
+## Specification
 
-## Gas Dimensions
+### Gas Dimensions
 
 All operations consume gas in two dimensions:
 
@@ -58,7 +58,7 @@ All operations consume gas in two dimensions:
 
 At the transaction level, the user pays for both. At the block level, only regular gas counts toward block and EIP-7825 max transaction gas limits; state gas is exempt.
 
-## Storage Gas Operations
+### Storage Gas Operations
 
 Storage creation operations split their cost between regular gas (computational overhead) and state gas (permanent storage burden):
 
@@ -76,7 +76,7 @@ For zero-to-non-zero `SSTORE`, Tempo keeps revm's decomposed Berlin accounting: 
 When the slot is cold, the existing Berlin cold-slot access charge (`GAS_COLD_SLOAD = 2,100`) is
 retained on top of that write component, for a total of 22,200 regular gas before state gas.
 
-### EIP-7702 Delegation Pricing
+#### EIP-7702 Delegation Pricing
 
 Each EIP-7702 authorization writes a 23-byte delegation designator (`0xef0100 || address`) to the authority account's code field. This is permanent state: redelegation overwrites the account's code pointer but the old code entry persists in the code database.
 
@@ -84,7 +84,7 @@ The base cost per authorization is **25,000 regular gas + 225,000 state gas = 25
 
 For authorizations where `auth.nonce == 0` (new account), the account creation cost (25,000 regular + 225,000 state) applies in addition to the delegation cost, for a total of 500,000 gas.
 
-### Keychain Authorization Pricing
+#### Keychain Authorization Pricing
 
 Keychain `authorize_key` is charged as intrinsic gas (T1B+). The SSTORE components use the same regular/state split as standard EVM SSTOREs:
 
@@ -101,7 +101,7 @@ Keychain `authorize_key` is charged as intrinsic gas (T1B+). The SSTORE componen
 The table above isolates the write component itself. Any first access to a cold storage slot still
 incurs the standard Berlin cold-access charge separately.
 
-### Precompile and Intrinsic Storage Operations
+#### Precompile and Intrinsic Storage Operations
 
 The regular/state gas split applies uniformly to all SSTORE and code deposit operations regardless of call site. Precompile storage operations route through the same path as standard EVM SSTOREs and inherit the split automatically. Intrinsic gas charges that include SSTORE costs (e.g. keychain authorization) use the same split.
 
@@ -114,7 +114,7 @@ The regular/state gas split applies uniformly to all SSTORE and code deposit ope
 - All other operations (non-state-creating) are charged entirely as regular gas
 - Regular gas is set to at least the pre-TIP-1000 (standard EVM) cost for each operation, ensuring that exempting state gas from limits never makes an operation cheaper against protocol limits than it was before TIP-1000
 
-## Transaction Validation
+### Transaction Validation
 
 Before transaction execution, `calculate_intrinsic_cost` returns three values:
 
@@ -138,7 +138,7 @@ The `max` ensures that calldata-heavy transactions cannot pass validation when t
 
 `validate_transaction` also returns `intrinsic_regular_gas`, `intrinsic_state_gas`, and `calldata_floor_gas_cost`.
 
-## Transaction-Level Gas Accounting (Reservoir Model)
+### Transaction-Level Gas Accounting (Reservoir Model)
 
 Since transactions have a single gas limit parameter (`tx.gas`), gas accounting is enforced through a **reservoir model**, in which `gas_left` and `state_gas_reservoir` are initialized as follows:
 
@@ -164,7 +164,7 @@ The `state_gas_reservoir` holds gas that exceeds the per-transaction regular gas
 
 The two counters are returned by the transaction output. Besides the two counters, the EVM also keeps track of `execution_state_gas_used` and `execution_regular_gas_used` during block execution. `state_gas` costs are added to `execution_state_gas_used` while `regular_gas` costs are added to `execution_regular_gas_used`. These two counters are also returned by the transaction output.
 
-## Transaction Gas Used
+### Transaction Gas Used
 
 At the end of transaction execution, the gas used before and after refunds is defined as:
 
@@ -181,7 +181,7 @@ The refund cap remains at 20% of gas used. The `max` with `calldata_floor_gas_co
 
 **Note**: EIP-8037 uses `tx_gas_used` in the refund and post-refund formulas, but that variable is not defined in the same code block. TIP-1016 uses `tx_gas_used_before_refund` consistently to avoid ambiguity.
 
-## Block-Level Gas Accounting
+### Block-Level Gas Accounting
 
 At block level, only **regular gas** counts toward block gas limits. State gas is exempt — it is not tracked at the block level and does not constrain block capacity.
 
@@ -217,7 +217,7 @@ gas_used_delta = parent.gas_used - parent.gas_target
 
 **Divergence from EIP-8037**: EIP-8037 uses a bottleneck model where `gas_used = max(block_regular_gas, block_state_gas)`, effectively capping state gas at the block gas limit. TIP-1016 instead exempts state gas entirely from block limits, relying on fixed high prices (250,000 gas per state element) as the economic deterrent for state growth.
 
-## SSTORE Refund for Slot Restoration
+### SSTORE Refund for Slot Restoration
 
 When a storage slot is set to a non-zero value and then restored to zero within the same transaction (0→X→0 pattern), the following are refunded via `refund_counter`:
 
@@ -226,21 +226,21 @@ When a storage slot is set to a non-zero value and then restored to zero within 
 
 The refund mechanism is identical to EIP-8037. The numeric values differ because Tempo uses fixed pricing (see Storage Gas Operations table) rather than EIP-8037's dynamic `cost_per_state_byte`. The net cost after refund is `GAS_WARM_ACCESS` (100), consistent with pre-EIP-8037 `SSTORE` restoration behavior. Refunds use `refund_counter` rather than direct gas accounting decrements, so that reverted frames do not benefit from the refund.
 
-## Revert Behavior for State Gas
+### Revert Behavior for State Gas
 
 State gas charged for account creation (`CREATE`, `CALL` to new account, and EOA delegation) is consumed even if the frame reverts — state changes are rolled back but gas is not refunded. This is consistent with pre-EIP-8037 behavior where `GAS_NEW_ACCOUNT` was consumed on revert.
 
 This is achieved structurally: `GAS_NEW_ACCOUNT` state gas is charged in the **parent frame** before creating the child frame. On child revert, `handle_reservoir_remaining_gas` restores only the child's `state_gas_spent` to the parent's reservoir — the parent's prior charge is preserved. Similarly, `GAS_CREATE` state gas for contract deployment is charged in the parent before the child initcode runs.
 
-## Receipt Semantics
+### Receipt Semantics
 
 Receipt `cumulative_gas_used` tracks the cumulative sum of `tx_gas_used_after_refund` (post-refund, post-floor) across transactions. This means `receipt[i].cumulative_gas_used - receipt[i-1].cumulative_gas_used` equals the gas paid by transaction `i`.
 
-## Contract Creation Pricing
+### Contract Creation Pricing
 
 Contract code storage cost increases from 1,000 to **2,500 gas/byte** (200 regular + 2,300 state).
 
-### Contract Deployment Cost Calculation
+#### Contract Deployment Cost Calculation
 
 When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed, gas is charged differently based on whether the deployment succeeds or fails. Given bytecode `B` (length `L`) returned by initcode and `H = keccak256(B)`:
 
@@ -258,7 +258,7 @@ When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed,
 
 This is aligned with EIP-8037's deployment flow, where `GAS_CODE_DEPOSIT` is charged only on the success path.
 
-### Example: 24KB Contract Deployment
+#### Example: 24KB Contract Deployment
 
 Operation | Regular | State gas
 ----------|---------|----------
@@ -272,9 +272,9 @@ Total gas: ~64M (user must authorize with `gas_limit >= 64M`)
 
 **Can deploy with protocol max_transaction_gas_limit = 16M** (only ~7M regular gas counts)
 
-## Examples
+### Examples
 
-### TIP-20 Transfer to New Address
+#### TIP-20 Transfer to New Address
 - Transfer logic: ~50,000 regular gas
 - New balance slot: 20,000 regular gas + 230,000 state gas
 - **Total**: ~70,000 regular gas + 230,000 state gas = ~300,000 gas
@@ -291,7 +291,7 @@ Total gas: ~64M (user must authorize with `gas_limit >= 64M`)
 - Block accounting: adds ~70,000 to `block_regular_gas_used` (state gas is exempt from block limits)
 - Total cost: ~300,000 gas
 
-### TIP-20 Transfer to Existing Address
+#### TIP-20 Transfer to Existing Address
 - Transfer logic: ~50,000 regular gas
 - Update existing slot: included in transfer logic
 - **Total**: ~50,000 regular gas
@@ -299,7 +299,7 @@ Total gas: ~64M (user must authorize with `gas_limit >= 64M`)
 - Counts toward block limit: ~50,000 regular gas
 - Total cost: ~50,000 gas
 
-### Block Throughput
+#### Block Throughput
 At 500M payment lane gas limit (only regular gas counts toward block limits):
 
 - **New account transfers**: ~70k regular gas each → ~7,150 transfers/block ≈ 14,300 TPS
@@ -309,7 +309,7 @@ At 500M payment lane gas limit (only regular gas counts toward block limits):
 
 ---
 
-# Invariants
+## Invariants
 
 1. **User Authorization**: Total gas used (regular + state) MUST NOT exceed `transaction.gas_limit` (prevents surprise costs)
 2. **Protocol Transaction Limit**: Regular gas (via `gas_left`) MUST NOT exceed `max_transaction_gas_limit` (EIP-7825 limit, e.g. 16M)
@@ -335,7 +335,7 @@ At 500M payment lane gas limit (only regular gas counts toward block limits):
 
 ---
 
-# Alignment with EIP-8037
+## Alignment with EIP-8037
 
 This TIP adopts the **reservoir model** from [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) for transaction-level gas accounting, with the following Tempo-specific differences:
 

--- a/src/pages/docs/protocol/tips/tip-1017.mdx
+++ b/src/pages/docs/protocol/tips/tip-1017.mdx
@@ -66,14 +66,14 @@ Thus, only the contract owner could change or deactivate entries.
 - Public keys remain reserved forever (even after deactivation)
 - Addresses are unique among current validators but can be reassigned via `transferValidatorOwnership`
 
-# Specification
+## Specification
 
-## Precompile Address
+### Precompile Address
 ```solidity
 address constant VALIDATOR_CONFIG_V2_ADDRESS = 0xCCCCCCCC00000000000000000000000000000001;
 ```
 
-## Interface
+### Interface
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -274,7 +274,7 @@ interface IValidatorConfigV2 {
 }
 ```
 
-## Overview
+### Overview
 
 - Migration incrementally reads and copies validator entries from V1 into V2.
 - During migration, the consensus layer continues reading V1 until `initializeIfMigrated()` completes.
@@ -283,7 +283,7 @@ interface IValidatorConfigV2 {
 - Validator `index` is stable for the lifetime of an entry.
 - Writes for post-migration operations are gated by `isInitialized()`.
 
-## State Model
+### State Model
 
 V2 stores validators in one append-only array, with lookup indexes by address and public key.
 
@@ -292,31 +292,31 @@ V2 stores validators in one append-only array, with lookup indexes by address an
 - `index`: immutable array position assigned at creation.
 - `initialized`: one-way migration flag toggled by `initializeIfMigrated()`.
 
-### Fee Recipient Separation
+#### Fee Recipient Separation
 
 Each validator entry includes a `feeRecipient` that can differ from the validator's control address. This enables operators to route protocol fees to a dedicated treasury wallet, while retaining a separate validator or treasury-ops multisig for operational calls. This separation reduces blast radius during key compromise: operational key exposure does not cause historically collected fees held by the custody wallet to be lost.
 
-## Operation Semantics
+### Operation Semantics
 
-### Lifecycle Operations
+#### Lifecycle Operations
 
 - `addValidator`: appends a new active entry after validation and signature verification.
 - `deactivateValidator`: marks an existing active entry as deactivated at current block height.
 - `rotateValidator`: to keep `index` stable, this updates the active entry in place and appends the entry to be deactivated. Active validator count is unchanged.
 
-### Network And Ownership Operations
+#### Network And Ownership Operations
 
 - `setIpAddresses`: updates ingress and egress for an active validator, enforcing address format and ingress uniqueness among active entries.
 - `setFeeRecipient`: updates the destination address that receives network fees from block proposing.
 - `transferValidatorOwnership`: rebinds a validator entry to a new address provided the address is not used by another active entry.
 
-### Migration And Phase-Gating Operations
+#### Migration And Phase-Gating Operations
 
 - `migrateValidator`: copies one V1 entry into V2 in descending index order.
 - `initializeIfMigrated`: switches V2 to initialized state after all V1 indices have been processed.
 - Mutators are phase-gated: migration mutators are blocked after init, and post-init mutators are blocked before init.
 
-### Input Validation And Safety Checks
+#### Input Validation And Safety Checks
 
 ValidatorConfig V2 enforces the following checks:
 
@@ -326,7 +326,7 @@ ValidatorConfig V2 enforces the following checks:
 4. `egress` must be a valid IP.
 5. `addValidator` and `rotateValidator` require a signature from the Ed25519 key being installed.
 
-### Ed25519 Signature Verification
+#### Ed25519 Signature Verification
 
 When adding or rotating a validator, the caller must provide an Ed25519 signature proving ownership of the public key.
 
@@ -359,15 +359,15 @@ rotateValidatorMessage = keccak256(
 
 The Ed25519 signature is computed over the operation-specific message with the namespace parameter (see commonware's [signing scheme](https://github.com/commonwarexyz/monorepo/blob/abb883b4a8b42b362d4003b510bd644361eb3953/cryptography/src/ed25519/scheme.rs#L38-L40) and [union format](https://github.com/commonwarexyz/monorepo/blob/abb883b4a8b42b362d4003b510bd644361eb3953/utils/src/lib.rs#L166-L174)).
 
-## Compatibility And Upgrade Behavior
+### Compatibility And Upgrade Behavior
 
-### Changes From V1
+#### Changes From V1
 
 1. V2 preserves append-only history with irreversible deactivation instead of mutable active/inactive toggling.
 2. V2 enforces stronger input checks in the precompile, including signature-backed key ownership.
 3. V2 keeps validator index stable across lifecycle operations.
 
-### Consensus Layer Read Behavior
+#### Consensus Layer Read Behavior
 
 The Consensus Layer checks `v2.isInitialized()` to determine which contract to read:
 
@@ -376,7 +376,7 @@ The Consensus Layer checks `v2.isInitialized()` to determine which contract to r
 
 This read switch is implemented in CL logic. V2 does not proxy reads to V1.
 
-## Consensus Layer Integration
+### Consensus Layer Integration
 
 **IP address changes**: `setIpAddresses` is expected to take effect in CL peer configuration on the next finalized block.
 
@@ -385,7 +385,7 @@ This read switch is implemented in CL logic. V2 does not proxy reads to V1.
 
 **Fee recipients**: Fee recipients are included now to be used in the future in a not yet determined hardfork.
 
-### DKG Player Selection
+#### DKG Player Selection
 
 The consensus layer determines DKG players for epoch `E+1` by reading state at `boundary(E) - 1` and filtering:
 
@@ -398,27 +398,27 @@ players(E+1) = validators.filter(v =>
 
 This enables node recovery and late joining without historical account state. 
 
-## Migration from V1
+### Migration from V1
 
 On networks that start directly with V2 (no V1 state), `initializeIfMigrated` can be called immediately when the V1 validator count is zero.
 
 Because `SSTORE` cost is high under TIP-1000, migration is done one validator at a time to reduce out-of-gas risk on large sets.
 
-### Full Migration Steps
+#### Full Migration Steps
 
 1. At fork activation, the V2 precompile goes live. However, CL continues reading from the V1 precompile.
 2. The owner calls `migrateValidator(n-1)` with `n` being the validator count in the V1 precompile.
 3. On the first migration call, V2 copies owner from V1 if unset and snapshots the V1 validator count, then continues in descending index order. The snapshotted count is used for all subsequent index validation to prevent V1 mutations from breaking migration ordering.
 4. After all indices are processed, owner calls `initializeIfMigrated()`, which flips `initialized` and activates CL reads from V2.
 
-### Migration Edge Cases
+#### Migration Edge Cases
 
 1. **Validator goes offline during migration**: admin deactivates the validator in V1. If that index has already been migrated the admin will also deactivates it in V2.
 2. **Invalid V1 entry encountered**: the index is still marked as processed (migrated, overwritten, or skipped by implementation rules) so global completion is not blocked.
 3. **Zero validators in V1**: The migration flow requires at least 1 validator to be in the V1 precompile.
 4. **Validator count overflow**: We use uint8s to cache the number of V1 validators and the number of skipped V1 validators. V1 currently has 14 validators, so a limit of 255 is sufficient.
 
-### Permitted Calls During Migration
+#### Permitted Calls During Migration
 
 | Contract | Caller | Allowed calls |
 | --- | --- | --- |
@@ -427,34 +427,34 @@ Because `SSTORE` cost is high under TIP-1000, migration is done one validator at
 | V2 (post-init) | any | `migrateValidator` and `initializeIfMigrated` are blocked |
 | V1 (during migration window) | owner and validators | all V1 calls remain available (subject to V1 authorization and key ownership assumptions) |
 
-# Security
+## Security
 
-## Considerations
+### Considerations
 
 - **Migration timing**: migration and `initializeIfMigrated()` should complete before an epoch boundary to avoid DKG disruption.
 - **Pre-migration validation**: admins should run a validation script against V1 state to detect entries that would fail V2 checks.
 - **State parity before init**: admins should verify V1/V2 state consistency before finalizing with `initializeIfMigrated()`.
 - **Signature domain separation**: signatures for `addValidator` and `rotateValidator` are bound to chain ID, precompile address, namespace, validator address, and endpoint payload.
 
-## Race And Griefing Risks
+### Race And Griefing Risks
 
 - Stable `index` values prevent races between concurrent state-changing calls.
 - Append-only history and permissionless rotation require query paths that remain safe as history grows.
 
-## Testing Requirements
+### Testing Requirements
 
 Unit tests should cover all control-flow branches in added functions, including initialization gating, migration completion checks, and index-based query behavior under large validator sets.
 
-## Invariants
+### Invariants
 
-### Identity and Uniqueness
+#### Identity and Uniqueness
 
 1. **Unique active addresses**: No two active validators share the same `validatorAddress`. Deactivated addresses may be reused.
 2. **Unique public keys**: No two validators (including deactivated) share the same `publicKey`.
 3. **Ingress uniqueness across active validators**: In `getActiveValidators()`, no two validators share the same ingress `<IP>:<port>`.
 4. **Valid public keys**: All validators must have valid ed25519 `publicKey`s.
 
-### Lifecycle and Storage Behavior
+#### Lifecycle and Storage Behavior
 
 1. **Append-only validator array**: `validatorsArray` length can only increase.
 2. **Entry index immutability**: Once a validator entry is created at index `i`, that entry can never move to another index. A previously deactivated operator may later be re-added as a new entry at a different index.
@@ -463,7 +463,7 @@ Unit tests should cover all control-flow branches in added functions, including 
 5. **Rotation preserves active cardinality**: A successful `rotateValidator` call does not change `getActiveValidators().length`.
 6. **Deactivation decrements active cardinality by one**: A successful `deactivateValidator` call decreases `getActiveValidators().length` by exactly one.
 
-### Query Correctness
+#### Query Correctness
 
 1. **Full-set reconstruction by index**: Reading `validatorByIndex(i)` for all `i` in `0..validatorCount()-1` must reconstruct exactly the ordered validator set.
 2. **Validator activity consistency**: Filtering the reconstructed validator set by `deactivatedAtHeight == 0` must produce exactly `getActiveValidators()` (same members, order not important).
@@ -471,7 +471,7 @@ Unit tests should cover all control-flow branches in added functions, including 
 4. **Public-key round-trip for all entries**: For any `i < validatorCount()`, `validatorByPublicKey(validatorByIndex(i).publicKey).index == i`.
 5. **Index round-trip for all entries**: For any `i < validatorCount()`, `validatorByIndex(i).index == i`.
 
-### Migration and Initialization
+#### Migration and Initialization
 
 1. **Initialization phase gating**: Before initialization, post-init mutators are blocked; after initialization, migration mutators are blocked.
 2. **Initialized once**: The `initialized` flag can only transition from `false` to `true`, never back.

--- a/src/pages/docs/protocol/tips/tip-1022.mdx
+++ b/src/pages/docs/protocol/tips/tip-1022.mdx
@@ -24,9 +24,9 @@ This TIP introduces **virtual addresses**: a reserved 20-byte address format tha
 
 ---
 
-# Specification
+## Specification
 
-## Address Layout
+### Address Layout
 
 Virtual addresses are standard 20-byte EVM addresses with the following reserved format:
 
@@ -41,13 +41,13 @@ Virtual addresses are standard 20-byte EVM addresses with the following reserved
 | **VIRTUAL_MAGIC** | 10 | Fixed magic value `0xFDFDFDFDFDFDFDFDFDFD`. Identifies the address as virtual. |
 | **userTag** | 6 | Opaque per-user identifier derived offchain by the operator. 48 bits support ~2.8×10^14 unique deposit addresses per master. |
 
-### Why This Layout?
+#### Why This Layout?
 
 TIP-1022 intentionally places the 10-byte magic sequence in the **middle** of the address instead of at the beginning. This preserves more visually useful bytes at the front and back of the address for operators and users comparing deposit addresses in wallets, explorers, etc.
 
 The 4-byte `masterId` is kept short to preserve room for a large `userTag`, while the 10-byte magic keeps the format highly unlikely to appear accidentally. The security implications of this tradeoff are discussed in **Security Considerations**.
 
-## Conformance and Scope
+### Conformance and Scope
 
 TIP-1022 applies only to TIP-20 precompile recipient resolution for the entrypoints listed in **Transfer Path Modification**.
 
@@ -57,7 +57,7 @@ Non-TIP-20 token transfers (e.g. ERC-20 contracts deployed on Tempo) to virtual 
 
 `setRewardRecipient` is **not** a TIP-20 transfer-path operation and is therefore not subject to TIP-1022 recipient resolution. Implementations MUST reject virtual addresses when setting reward recipients so that rewards remain tied to canonical accounts rather than aliases.
 
-## Reserved Virtual Address Format
+### Reserved Virtual Address Format
 
 Any address whose bytes `[4:14]` equal `VIRTUAL_MAGIC` is treated as a virtual address by the TIP-20 precompile.
 
@@ -69,13 +69,13 @@ If a TIP-20 transfer targets such an address:
 
 The literal virtual address never accumulates TIP-20 balance through standard TIP-20 transfer paths.
 
-### Reserved Address Space
+#### Reserved Address Space
 
 Addresses matching the virtual-address format occupy a reserved TIP-20 recipient namespace. A user who happens to control an EOA or contract whose address matches this format can still exist on Tempo and can still originate ordinary EVM transactions. However, TIP-20 transfers to such an address will follow TIP-1022 recipient resolution semantics rather than crediting the literal address.
 
 Users who control such an address SHOULD NOT use it as a normal account on Tempo.
 
-## Master ID Derivation
+### Master ID Derivation
 
 The `masterId` is deterministic and derived from the registration hash computed during `registerVirtualMaster()`:
 
@@ -88,13 +88,13 @@ The first 4 bytes of `registrationHash` are consumed by the proof-of-work check 
 
 The salt is a `bytes32` value chosen by the caller. Callers MUST grind the salt to satisfy the 32-bit proof-of-work requirement. The resulting `masterId` is permanently bound to the registration address.
 
-### Why `masterId` Registrations Are Immutable
+#### Why `masterId` Registrations Are Immutable
 
 TIP-1022 intentionally does not provide a mechanism to rotate or update the master address bound to a `masterId`. Allowing rotation would interact poorly with TIP-403 policies: a blacklisted master could rotate to a fresh address and resume receiving deposits, requiring policy enforcement to track `masterId`s in addition to addresses. Operators who need to change their underlying key material can register their `masterId` to an upgradeable proxy contract or multisig, allowing the controlling keys to be rotated at the contract layer without any protocol-level change. Finally, any rotation mechanism would require a timelock or similar delay to prevent an attacker who compromises a master key from silently redirecting deposits before the legitimate owner can respond — complexity that is better handled by the operator's own key management infrastructure.
 
 In the event of a `masterId` collision (two `(address, salt)` pairs mapping to the same 4-byte `masterId`), the second registration reverts with `MasterIdCollision`. The caller can retry with a different valid salt. The probability of such a collision (and the resulting need to regrind another salt) is less than 0.1% even if 4 million masterId's have already been registered. 
 
-## Registration Proof of Work
+### Registration Proof of Work
 
 Registration requires a 32-bit proof of work to make **targeted collisions against a chosen `masterId`** computationally expensive.
 
@@ -115,13 +115,13 @@ This requires the caller to grind ~2^32 salt values to find a valid registration
 
 This proof of work is intended to make it expensive for an attacker who sees a pending registration transaction to compute a different `(attackerAddress, salt)` pair that lands on the same `masterId` and gets mined first. With a 4-byte `masterId` and a 32-bit proof-of-work requirement, that targeted attack costs ~2^64 work.
 
-## User Tag Derivation (Offchain)
+### User Tag Derivation (Offchain)
 
 The `userTag` is an opaque 6-byte value generated offchain by the operator. The protocol does not interpret or validate it — all values including `0x000000000000` are valid. It exists solely so the operator can attribute deposits to specific users via the two-hop `Transfer` events described below.
 
 Operators maintain their own internal mapping `{internalUserId -> virtualAddress}`. No onchain transaction is needed to create a new deposit address.
 
-## Worked Example
+### Worked Example
 
 An exchange with master address `0xABCD...1234` registers with a salt that satisfies the 32-bit PoW:
 
@@ -136,7 +136,7 @@ Virtual address = 0x07A3B1C2  FDFDFDFDFDFDFDFDFDFD  D4E5A7C3F19E
                   masterId     magic (10)           userTag (6)
 ```
 
-## Registry Precompile
+### Registry Precompile
 
 Virtual address resolution requires a registry that maps `masterId -> masterAddress`. This is managed through a new precompile deployed at `0xFDC0000000000000000000000000000000000000`.
 
@@ -153,7 +153,7 @@ A **valid master address** MUST satisfy TIP-20 recipient safety constraints:
 - MUST NOT itself match the virtual-address format (`VIRTUAL_MAGIC` at bytes `[4:14]`)
 - MUST NOT be a TIP-20 token address (`0x20c000....` at bytes `[0:12]`)
 
-### Registry Storage Layout
+#### Registry Storage Layout
 
 Each `masterId` maps to a single 32-byte storage slot:
 
@@ -174,7 +174,7 @@ Here `REGISTRY_SLOT` means the storage slot of the `mapping(bytes4 => bytes32)` 
 
 This layout packs all metadata for a `masterId` into a single storage slot, enabling one SLOAD during transfer-path resolution.
 
-### Interface
+#### Interface
 
 ```solidity
 interface IAddressRegistry {
@@ -243,14 +243,14 @@ interface IAddressRegistry {
 }
 ```
 
-### Constants
+#### Constants
 
 | Name | Value | Description |
 |------|-------|-------------|
 | `VIRTUAL_MAGIC` | `0xFDFDFDFDFDFDFDFDFDFD` | 10-byte magic value identifying virtual addresses |
 | `REGISTRY_ADDRESS` | `0xFDC0000000000000000000000000000000000000` | Precompile address for the virtual-address registry |
 
-## Transfer Path Modification
+### Transfer Path Modification
 
 The following existing TIP-20 entrypoints are modified to resolve the `to` (recipient) address before crediting:
 
@@ -264,7 +264,7 @@ The following existing TIP-20 entrypoints are modified to resolve the `to` (reci
 
 The `from` address on `transferFrom`, `transferFromWithMemo`, and `systemTransferFrom` is **not** affected by TIP-1022 resolution.
 
-### Resolution Logic
+#### Resolution Logic
 
 ```text
 function resolveRecipient(to: address) -> address:
@@ -281,7 +281,7 @@ function resolveRecipient(to: address) -> address:
     return master
 ```
 
-### Standard Transfer Entrypoints
+#### Standard Transfer Entrypoints
 
 For `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, and `systemTransferFrom`:
 
@@ -293,7 +293,7 @@ For `transfer`, `transferFrom`, `transferWithMemo`, `transferFromWithMemo`, and 
 
 If any step reverts, the enclosing TIP-20 operation MUST revert atomically with no balance changes and no events.
 
-### Mint Entrypoints
+#### Mint Entrypoints
 
 For `mint` and `mintWithMemo`:
 
@@ -304,7 +304,7 @@ For `mint` and `mintWithMemo`:
 
 If any step reverts, the enclosing TIP-20 operation MUST revert atomically with no balance changes and no events.
 
-### Authorization Semantics
+#### Authorization Semantics
 
 TIP-1022 does not introduce new authorization logic in TIP-403 itself. Instead, TIP-20 transfer and mint logic MUST resolve virtual recipient addresses before invoking the existing TIP-403 / TIP-1015 checks.
 
@@ -319,13 +319,13 @@ This preserves view/execution symmetry with the TIP-20 authorization path define
 
 Contracts or integrators that need explicit resolution behavior outside the TIP-20 transfer path MAY call `resolveRecipient` on the registry.
 
-## Event Emission
+### Event Emission
 
 TIP-1022 does **not** introduce new transfer-path events. The registry precompile emits `MasterRegistered`, but forwarding itself is represented using **two-hop standard `Transfer` events**: one hop showing funds arriving at the virtual address, and a second hop showing funds moving from the virtual address to the resolved master. Using standard `Transfer` events (rather than a new event type) preserves compatibility with existing indexers, block explorers, and wallets that already understand TIP-20 / ERC-20 `Transfer` events — no custom integration is required to track virtual address deposits.
 
 For transfers where the recipient is **not** a virtual address, event emission is unchanged from standard TIP-20 behavior — a single `Transfer(sender, to, amount)`.
 
-### Deposit Forwarding (Inbound)
+#### Deposit Forwarding (Inbound)
 
 When a transfer targets a virtual address (`to` is virtual), the precompile MUST emit two `Transfer` events in sequence:
 
@@ -336,7 +336,7 @@ The actual balance change is applied only to `masterAddress`. The virtual addres
 
 Indexers that need deposit attribution SHOULD watch for pairs of `Transfer` events within the same transaction where the intermediate address matches the virtual-address format. The `userTag` can then be extracted from the virtual address to identify the depositor.
 
-### Entrypoint-Specific Event Ordering
+#### Entrypoint-Specific Event Ordering
 
 - `transfer`, `transferFrom`, `systemTransferFrom`:
   1. `Transfer(sender, virtualAddress, amount)`
@@ -358,11 +358,11 @@ Indexers that need deposit attribution SHOULD watch for pairs of `Transfer` even
   3. `Mint(virtualAddress, amount)`
   4. `Transfer(virtualAddress, masterAddress, amount)`
 
-## Self-Forwarding
+### Self-Forwarding
 
 If the registered master sends tokens to one of its own virtual addresses, the transfer resolves back to the master, effectively a transfer to self. The standard TIP-20 self-transfer semantics apply (no net balance change). The two-hop `Transfer` events are still emitted: `Transfer(master, virtualAddress, amount)` followed by `Transfer(virtualAddress, master, amount)`. Indexers SHOULD NOT interpret this as net inflow when `from == masterAddress` in the first hop.
 
-## Interaction with TIP-403
+### Interaction with TIP-403
 
 Virtual address resolution happens **before** TIP-403 / TIP-1015 authorization checks. Policy evaluation uses the resolved `masterAddress`, not the literal virtual address.
 
@@ -370,7 +370,7 @@ Virtual address resolution happens **before** TIP-403 / TIP-1015 authorization c
 - If the **sender** is not authorized to send the token, the transfer reverts.
 - Policies configured on individual virtual addresses are ignored by the TIP-20 transfer path because virtual addresses have no independent canonical TIP-20 balance.
 
-### Rejection of Virtual Addresses in Policy Operations
+#### Rejection of Virtual Addresses in Policy Operations
 
 TIP-403 operations that accept addresses as policy members MUST reject virtual addresses rather than accepting them silently.
 
@@ -378,14 +378,14 @@ Implementations SHOULD use a clear, informative error indicating that virtual ad
 
 Rejecting these operations avoids the footgun where an operator configures policy on the virtual alias they see in logs or explorers instead of on the resolved master address that actually holds the funds.
 
-## Interaction with Account-Level Features
+### Interaction with Account-Level Features
 
 - **`balanceOf(virtualAddress)`**: Always returns 0. Virtual addresses do not hold balances.
 - **Nonce / transaction origination**: A contract or EOA whose address matches the virtual-address format can still exist and can still originate ordinary EVM transactions. TIP-1022 resolution applies only to the `to` field in TIP-20 precompile calls, not to transaction senders.
 
-## Security Considerations
+### Security Considerations
 
-### 4-Byte `masterId` and 32-Bit Registration PoW
+#### 4-Byte `masterId` and 32-Bit Registration PoW
 
 A 4-byte `masterId` would be too small if its security relied only on raw namespace size. TIP-1022 does **not** rely on that. Instead, security comes from the combination of:
 
@@ -405,7 +405,7 @@ That targeted attack costs roughly 2^64 work. Further, because registration requ
 
 This does not eliminate the residual collision-risk entirely, but it substantially reduces the practical chance that an operator incorrectly believes they control a master ID that was actually registered first by an attacker.
 
-### Why the Magic Bytes Are in the Middle
+#### Why the Magic Bytes Are in the Middle
 
 The middle `VIRTUAL_MAGIC` layout is a deliberate usability tradeoff:
 
@@ -415,13 +415,13 @@ The middle `VIRTUAL_MAGIC` layout is a deliberate usability tradeoff:
 
 This improves address comparison in UIs while still keeping a large reserved pattern that is highly unlikely to appear accidentally. We believe this layout is superior to the other permutations in terms of the prospect of address poisoning attacks (see below).
 
-### Contracts and EOAs Matching the Virtual Format
+#### Contracts and EOAs Matching the Virtual Format
 
 A sufficiently resourced adversary could, in principle, grind a CREATE2 deployment or private key so that a contract or EOA lands at an address matching the virtual-address format in a `masterID` controlled by the adversary. We view this as unlikely in practice because the address must match a 10-byte fixed magic value in the middle of the address, while targeted theft of a specific registered namespace also requires colliding the 4-byte `masterId` under the registration proof-of-work design (i.e., 14 bytes totally). 
 
 A stronger global reservation mechanism for problematic address ranges may still be desirable in the future. 
 
-### Policy Configuration on Virtual Addresses
+#### Policy Configuration on Virtual Addresses
 
 Virtual addresses are forwarding aliases, not canonical TIP-20 holders. Using them directly in policy configuration is misleading and dangerous because the TIP-20 transfer path evaluates policies against the resolved master address.
 
@@ -429,41 +429,41 @@ Accordingly, TIP-403 configuration operations SHOULD reject virtual addresses wi
 
 ---
 
-## Risks and Limitations
+### Risks and Limitations
 
-### Address Poisoning and UI Confusion
+#### Address Poisoning and UI Confusion
 
 TIP-1022 still introduces a recognizable structured address format. Wallets, block explorers, and operational tooling that truncate addresses SHOULD display enough of the address to distinguish both the `masterId` and the `userTag`; ideally they SHOULD show the full address.
 
 
-### Non-TIP-20 Token Loss
+#### Non-TIP-20 Token Loss
 
 TIP-1022 forwarding applies exclusively to TIP-20 precompile operations. Non-TIP-20 tokens (e.g. ERC-20 contracts deployed on Tempo) transferred to a virtual address are credited to the literal virtual address by the ERC-20 contract and are irrecoverable: no recovery mechanism is defined here.
 
 This risk is mitigated by the strong incentives for token issuers to use TIP-20 on Tempo (gas-payment eligibility, access to the payment lane, and policy support), but it remains a limitation of this design.
 
-### Non-TIP-20 Protocol Positions Minted to Virtual Addresses
+#### Non-TIP-20 Protocol Positions Minted to Virtual Addresses
 TIP-1022 changes only the TIP-20 transfer and mint entrypoints listed in this document. It does not change other protocol logic that accepts an address parameter and records ownership against that literal address.
 
 This creates an edge case for protocols that mint LP shares, receipt tokens, or other redeemable positions to a user-supplied to address. If such a protocol later requires the recorded holder address to burn, redeem, or withdraw, a position minted to a virtual address can become stranded even though the corresponding master account controls that virtual namespace. The Fee AMM is one example of this pattern: LP shares minted can be mited to a virtual address, but are then permanently unburnable since `burn` checks that `msg_sender==lp_address`.
 
 In short, virtual-address forwarding is only defined for the TIP-20 paths enumerated by TIP-1022; other protocols remain literal-address systems unless they explicitly say otherwise.
 
-### Externally-Triggerable Revert on Unregistered Virtual Addresses
+#### Externally-Triggerable Revert on Unregistered Virtual Addresses
 
 TIP-1022 introduces a recipient-dependent revert: if the `to` address matches the virtual-address format but its `masterId` is not registered, the transfer reverts with `VirtualAddressUnregistered`. This is the first TIP-20 revert condition that an untrusted recipient address can induce — prior to TIP-1022, transfers could only revert due to sender-side conditions (insufficient balance, authorization failure).
 
 Contracts that perform batch transfers in a single transaction (e.g. payroll, airdrop, or distribution contracts) SHOULD validate recipient addresses before execution or wrap individual transfers in try/catch to prevent a single unregistered virtual address from reverting the entire batch.
 
-### Contracts and EOAs at virtual addresses 
+#### Contracts and EOAs at virtual addresses
 
 It is theoretically possible to deploy a contract or control an EOA whose address matches `VIRTUAL_MAGIC`, including by grinding CREATE2 salts or private keys. Such addresses can still exist and originate ordinary EVM transactions, but we consider this unlikely in practice because targeting the 10-byte `VIRTUAL_MAGIC` requires roughly 2^80 work, with additional cost for targeted collisions against registered virtual namespaces.
 
 ---
 
-# Invariants
+## Invariants
 
-## Core Invariants
+### Core Invariants
 
 1. **No fund loss**: A TIP-20 transfer to a virtual address MUST either credit the registered master's balance by exactly the transfer amount, or revert. Funds MUST NOT be credited to the virtual address itself or lost.
 

--- a/src/pages/docs/protocol/tips/tip-1030.mdx
+++ b/src/pages/docs/protocol/tips/tip-1030.mdx
@@ -21,29 +21,29 @@ Currently, `placeFlip` requires `flipTick` to be strictly on the opposite side o
 
 ---
 
-# Specification
+## Specification
 
-## Modified behavior
+### Modified behavior
 
 The `placeFlip` validation is relaxed to allow `flipTick == tick`:
 
 - **Current behavior**: For bids, `flipTick > tick` required; for asks, `flipTick < tick` required
 - **New behavior**: For bids, `flipTick >= tick` required; for asks, `flipTick <= tick` required
 
-## Events
+### Events
 
 No new events.
 
-## New errors
+### New errors
 
 No new errors.
 
-# Implications
+## Implications
 
 - **Locked books**: Same-tick flip orders can result in `best_bid_tick == best_ask_tick`. This forecloses any future upgrade that would forbid bids and asks from resting at the same tick, since same-tick flip orders legitimately create that state.
 - **MEV**: Tighter flip orders (where `flipTick` is closer to or equal to `tick`) increase the likelihood of certain kinds of MEV, such as backrunning, since the new opposite-side order appears at a better price for the backrunner.
 
-# Invariants
+## Invariants
 
 - Flip orders with `flipTick == tick` are accepted and behave like any other flip order
 - Flip orders with `flipTick` strictly on the wrong side of `tick` are still rejected

--- a/src/pages/docs/protocol/tips/tip-1031.mdx
+++ b/src/pages/docs/protocol/tips/tip-1031.mdx
@@ -23,7 +23,7 @@ By embedding the context into the header, Tempo blocks can implement the require
 
 ---
 
-# Specification
+## Specification
 
 When activated, a new field, `Option<Context>` is added as the **last** field of `TempoHeader`, which must be set on every subsequent block containing consensus metadata. The field follows the trailing‑optional pattern used by Ethereum's fork‑activated header fields (e.g. `base_fee_per_gas`, `blob_gas_used`): when `None`, it is omitted entirely from the RLP stream, preserving existing block hashes for pre‑activation headers.
 
@@ -45,7 +45,7 @@ The `Context` adds 3 fields: 3 `u64` values and 1 `B256` value, totaling 56 byte
 
 **Compact (DB)**: The `reth_codecs::Compact` representation is comparable, using bitflag‑compressed integer widths.
 
-## Block Production
+### Block Production
 
 When activated the proposals must:
 
@@ -54,7 +54,7 @@ When activated the proposals must:
 
 If not activated, the context field **MUST** be `None`.
 
-## Block Verification
+### Block Verification
 
 During `Automaton::verify()` step:
 
@@ -64,13 +64,13 @@ During `Automaton::verify()` step:
 
 Important to note the immediate switch to `Deferred` is __not strictly required__. For example a validator can choose an implementation that preserves synchronous verification. This validator simply does not contribute to the reduced latency in forming the notarization certificate.
 
-## Genesis Block
+### Genesis Block
 
 The Genesis block MUST have the consensus context set to `None`.
 
 ---
 
-# Invariants
+## Invariants
 
 1. **Context presence**: Every block beyond genesis when activated has a set `Context`.
 

--- a/src/pages/docs/protocol/tips/tip-1036.mdx
+++ b/src/pages/docs/protocol/tips/tip-1036.mdx
@@ -20,81 +20,81 @@ Internal and external review uncovered several T2-relevant correctness and secur
 
 ---
 
-# Changes
+## Changes
 
-## 1. Require `tx.origin` for AccountKeychain admin ops
+### 1. Require `tx.origin` for AccountKeychain admin ops
 
 **PRs**: [#3202](https://github.com/tempoxyz/tempo/pull/3202) · **Author**: @legion2002, [#3250](https://github.com/tempoxyz/tempo/pull/3250) · **Author**: @0xrusowsky
 
 With T2, `authorizeKey`, `revokeKey`, and `updateSpendingLimit` require direct owner calls by enforcing both `transaction_key == Address::ZERO` and `msg_sender == tx_origin`. This blocks indirect contract-call paths from being used to perform key-admin actions with owner-level authority. If `tx_origin` is not seeded, admin ops are rejected (failed-closed).
 
-## 2. Reject self-sponsored fee payer signatures
+### 2. Reject self-sponsored fee payer signatures
 
 **PR**: [#3200](https://github.com/tempoxyz/tempo/pull/3200) *(merged)* · **Author**: @legion2002
 
 Rejects AA transactions where the `fee_payer_signature` resolves back to the sender, preventing self-sponsored signatures from bypassing fee-payer assumptions. Enforced in both txpool validation and EVM fee-payer resolution.
 
-## 3. Check token paused in internal DEX balance swaps
+### 3. Check token paused in internal DEX balance swaps
 
 **PR**: [#3204](https://github.com/tempoxyz/tempo/pull/3204) · **Author**: @0xrusowsky
 
 Adds a `check_not_paused()` call in `StablecoinDEX` internal balance transfers gated behind `is_t2()`. Previously, swaps using internal DEX balances could bypass the token pause state.
 
-## 4. Correct built-in policy type data for TIP403Registry
+### 4. Correct built-in policy type data for TIP403Registry
 
 **PR**: [#3203](https://github.com/tempoxyz/tempo/pull/3203) *(merged)* · **Author**: @0xrusowsky
 
 Built-in policies (`REJECT_ALL` / `ALLOW_ALL`) are virtual and not stored on-chain. On T2, `policyData()` now returns the correct `PolicyType` (`WHITELIST` / `BLACKLIST` respectively) and `Address::ZERO` admin for these built-in IDs instead of falling through to storage reads.
 
-## 5. Reject legacy invalid policy types in compound sub-policies
+### 5. Reject legacy invalid policy types in compound sub-policies
 
 **PR**: [#3188](https://github.com/tempoxyz/tempo/pull/3188) *(merged)* · **Author**: @howydev
 
 Uses `is_simple()` instead of `!is_compound()` to validate compound policy sub-policies, rejecting legacy type-255 policies that previously passed the negated check.
 
-## 6. Handle T2 policy errors in DEX
+### 6. Handle T2 policy errors in DEX
 
 **PR**: [#3015](https://github.com/tempoxyz/tempo/pull/3015) *(merged)* · **Author**: @0xrusowsky
 
 Updates DEX precompiles to handle the new `TIP403RegistryError::InvalidPolicyType` error returned by `policy_type()` post-T2, replacing the old `Panic(UnderOverflow)` sentinel.
 
-## 7. Return zero remaining limit for revoked keys
+### 7. Return zero remaining limit for revoked keys
 
 **PR**: [#2553](https://github.com/tempoxyz/tempo/pull/2553) *(merged)* · **Author**: @0xrusowsky
 
 `getRemainingLimit()` now returns zero for revoked or non-existent access keys instead of a stale positive value.
 
-## 8. Nonce key gas repricing
+### 8. Nonce key gas repricing
 
 **PR**: [#2533](https://github.com/tempoxyz/tempo/pull/2533) *(merged)* · **Author**: @0xrusowsky
 
 Increases intrinsic gas costs for 2D nonce keys on T2 by adding `2 × WARM_SLOAD` to both existing-key and new-key gas to account for extended storage lookups. Base costs differ (`COLD_SLOAD + WARM_SSTORE_RESET` for existing, `COLD_SLOAD + SSTORE_SET` for new), but the T2 delta is the same.
 
-## 9. Error with `PolicyNotFound` for non-existent policy IDs
+### 9. Error with `PolicyNotFound` for non-existent policy IDs
 
 **PR**: [#2618](https://github.com/tempoxyz/tempo/pull/2618) *(merged)* · **Author**: @0xrusowsky
 
 `get_policy_data()` now reverts with `PolicyNotFound` for non-existent policy IDs instead of silently returning default values.
 
-## 10. Refund spending limit for unused gas fees
+### 10. Refund spending limit for unused gas fees
 
 **PR**: [#2528](https://github.com/tempoxyz/tempo/pull/2528) *(merged)* · **Author**: @legion2002
 
 Restores access key spending limits by the refunded gas amount in `transfer_fee_post_tx()`. Previously the full max fee was permanently deducted from the spending limit regardless of actual gas used.
 
-## 11. Tick spacing checks on DEX price conversion functions
+### 11. Tick spacing checks on DEX price conversion functions
 
 **PR**: [#2513](https://github.com/tempoxyz/tempo/pull/2513) *(merged)* · **Author**: @0xKitsune
 
 Adds tick spacing validation to `tick_to_price` and `price_to_tick`, rejecting ticks that don't align with the pool's configured spacing.
 
-## 12. Reserved liquidity transient storage check
+### 12. Reserved liquidity transient storage check
 
 **PR**: [#2496](https://github.com/tempoxyz/tempo/pull/2496) *(merged)* · **Author**: @0xKitsune
 
 Adds a transient storage (`TSTORE`/`TLOAD`) guard to prevent reserved liquidity from being double-spent within the same transaction.
 
-## 13. Reject zero-address ecrecover in permit
+### 13. Reject zero-address ecrecover in permit
 
 **PR**: [#2786](https://github.com/tempoxyz/tempo/pull/2786) *(merged)* · **Author**: @howydev
 

--- a/src/pages/docs/protocol/tips/tip-1038.mdx
+++ b/src/pages/docs/protocol/tips/tip-1038.mdx
@@ -19,15 +19,15 @@ Ongoing internal review and audit follow-ups uncovered several correctness and p
 
 ---
 
-# Changes
+## Changes
 
-## 1. Skip redundant `setUserToken` write and event when token unchanged
+### 1. Skip redundant `setUserToken` write and event when token unchanged
 
 **PR**: [#3272](https://github.com/tempoxyz/tempo/pull/3272) · **Author**: @fgimenez
 
 `setUserToken()` unconditionally writes to storage and emits `UserTokenSet` even when the token hasn't changed. Since the event triggers a full O(pool_size) txpool scan via `evict_invalidated_transactions`, any account can force network-wide CPU work each block by repeatedly calling `setUserToken` with the same value. T3+ adds a read-before-write guard that returns early when the stored token already matches, eliminating the redundant write, event, and pool scan.
 
-## 2. TIP-20: verify paused state before mint and burn
+### 2. TIP-20: verify paused state before mint and burn
 
 **PR**: [#3411](https://github.com/tempoxyz/tempo/pull/3411) · **Author**: @0xrusowsky
 
@@ -35,7 +35,7 @@ The TIP-20 pause mechanism was missing from `mint`, `mintWithMemo`, `burn`, `bur
 
 T3+ adds `check_not_paused()` to all five functions. A new `validate_mint` helper consolidates the pause check, recipient validation, and TIP-403 policy check into a single call. Administrative functions (role management, unpausing) and `transferFeePostTx` remain intentionally exempt.
 
-## 3. Disambiguate optional AA expiry and validity timestamps
+### 3. Disambiguate optional AA expiry and validity timestamps
 
 **PRs**: [#3500](https://github.com/tempoxyz/tempo/pull/3500), [#3501](https://github.com/tempoxyz/tempo/pull/3501) · **Author**: @legion2002
 
@@ -43,13 +43,13 @@ Several AA timestamp fields were encoded as `Option<u64>` in RLP, but `None` and
 
 T3+ changes `key_authorization.expiry`, `valid_before`, and `valid_after` to `Option<NonZeroU64>` at the primitives layer so zero-valued bounds are unrepresentable. Serde-backed JSON/request deserialization rejects `0x0` explicitly for these fields, while downstream execution and pool components convert back to plain `u64` only where comparisons or storage require it.
 
-## 4. StablecoinDEX: check token paused in internal balance swaps
+### 4. StablecoinDEX: check token paused in internal balance swaps
 
 **PR**: [#3204](https://github.com/tempoxyz/tempo/pull/3204) · **Author**: @0xrusowsky
 
 The StablecoinDEX `swap_exact_amount_in` and `swap_exact_amount_out` paths operate on internal DEX balances and bypass TIP-20 `transfer`, so the pause check in the token contract is never hit. A paused token could still be swapped through the DEX — including as an intermediate hop in a multi-leg route. T3+ adds `check_not_paused()` to `validate_and_build_route` for every token in the swap path, ensuring paused tokens block DEX swaps the same way they block direct transfers.
 
-## 5. Account-keychain: clamp refunded spending limits to the configured max
+### 5. Account-keychain: clamp refunded spending limits to the configured max
 
 **PR**: [#3483](https://github.com/tempoxyz/tempo/pull/3483) · **Author**: @rakita
 

--- a/src/pages/docs/protocol/tips/tip-1047.mdx
+++ b/src/pages/docs/protocol/tips/tip-1047.mdx
@@ -22,9 +22,9 @@ CREATE and CREATE2 addresses are downstream of keccak; EIP-7702 authority addres
 
 ---
 
-# Specification
+## Specification
 
-## CREATE and CREATE2
+### CREATE and CREATE2
 
 Before setting up a create frame, compute the would-be contract address:
 
@@ -33,13 +33,13 @@ Before setting up a create frame, compute the would-be contract address:
 
 If `is_tip20_prefix(address)` is true, revert the opcode. The caller's nonce is not bumped, no value is transferred, and no init-code is executed. Base opcode gas is consumed; init-code gas is not.
 
-## EIP-7702 Authorizations
+### EIP-7702 Authorizations
 
 When processing EIP-7702 authorization lists, if `is_tip20_prefix(authority)` is true for a recovered authority address, skip the entry. The delegation is not applied.
 
 ---
 
-# Invariants
+## Invariants
 
 1. **No new code at TIP-20 addresses**: No CREATE/CREATE2 produces a contract where `is_tip20_prefix` returns true. Applies to all depths (top-level and nested creates).
 
@@ -53,4 +53,3 @@ When processing EIP-7702 authorization lists, if `is_tip20_prefix(authority)` is
 - CREATE where the computed address has a TIP-20 prefix reverts with nonce unchanged.
 - EIP-7702 authorization with a TIP-20-prefixed authority is skipped.
 - Normal CREATE/CREATE2 producing non-TIP-20 addresses is unaffected.
-

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -3,6 +3,7 @@ import { resolveBaseUrl } from './src/lib/base-url'
 import { docsRouteDestination, proxiedLegacyDocsRoutes } from './src/lib/docs-routing'
 import { docsStructuredDataHead } from './src/lib/docs-structured-data'
 import { createFeedbackAdapter } from './src/lib/feedback-adapter'
+import { demoteMarkdownHeadings } from './src/lib/markdown-headings'
 import { plainMarkdownComponents } from './src/lib/markdown-output'
 
 // Only set baseUrl in production — Vocs injects a <base> tag from this value,
@@ -17,15 +18,21 @@ const changelog = Changelog.from({
   ...tempoChangelog,
   async fetch(options) {
     const releases = await tempoChangelog.fetch(options)
-    return releases.map((release) => ({
-      ...release,
+    return releases.map((release) => {
       // GitHub-generated release notes use HTML disclosures. Markdown output cannot retain
       // them, so preserve their content as a heading instead.
-      body: release.body
+      const body = release.body
         .replace(/<details\b[^>]*>/gi, '')
         .replace(/<\/details>/gi, '')
-        .replace(/<summary\b[^>]*>([\s\S]*?)<\/summary>/gi, '\n\n#### $1\n\n'),
-    }))
+        .replace(/<summary\b[^>]*>([\s\S]*?)<\/summary>/gi, '\n\n#### $1\n\n')
+
+      return {
+        ...release,
+        // The changelog page owns the only H1. Release titles render as H2, so shift body
+        // headings down one level while preserving the release note's relative hierarchy.
+        body: demoteMarkdownHeadings(Changelog.stripDuplicateTitle({ body, title: release.title })),
+      }
+    })
   },
 })
 


### PR DESCRIPTION
## What

- Gives each Vocs route one document-title owner while preserving `seoTitle` frontmatter, canonical links, social metadata, and structured data.
- Removes the 16 literal API `<title>` workarounds added in #777 and pins the patched Vocs version until the behavior is available upstream.
- Normalizes authored TIP headings and generated changelog headings to one H1 with a logical H2/H3 hierarchy.
- Adds source and browser regressions for every built public route and expands the sitemap audit to all docs routes.

## Why

The SEO titles from #777 were correct in prerendered HTML, but React hydration retained title output from the Vocs root, route layout, OpenAPI layout, and literal MDX workarounds. That produced two to four `<head><title>` elements on every docs route. The existing raw-response tests only checked that the recommended title was present, so they did not catch the hydrated duplicates.

## Verification

- 316 unit tests passed.
- 244 Playwright tests passed, covering raw and hydrated semantics across all 231 built public routes, client-side navigation, and the 404 page.
- Vocs production-mode build and type checks passed.
- Frozen-lockfile install, Markdown output audit, Biome check, and `git diff --check` passed.
- Generated changelog release titles remain H2 and release-body headings begin at H3.
- SVG `<title>` elements remain intact for accessibility; document-title assertions are scoped to `head > title`.