### PR TITLE
Add Mt Pelerin and Bridge Wallet to docs ecosystem

### DIFF
--- a/src/pages/docs/ecosystem/orchestration.mdx
+++ b/src/pages/docs/ecosystem/orchestration.mdx
@@ -50,6 +50,12 @@ For EUR and GBP, Hercle also supports pay-ins, payouts, and stablecoin on-ramps 
 
 Explore the [MoonPay developer docs](https://dev.moonpay.com/) to get started.
 
+## Mt Pelerin
+
+[Mt Pelerin](https://www.mtpelerin.com/) provides non-custodial on-ramp and off-ramp services for supported assets on Tempo. Users can buy by bank transfer, card, Apple Pay, or Google Pay and cash out to bank accounts in 18 fiat currencies.
+
+Explore [Mt Pelerin's buy and cash-out services](https://www.mtpelerin.com/) or use its [Bridge Wallet mobile app](https://www.mtpelerin.com/bridge-wallet).
+
 ## Rio
 
 [Rio](https://www.rio.trade/stablecoin-fx) provides stablecoin FX infrastructure for converting between fiat currencies and stablecoins. Its real-time execution engine and integration APIs help platforms embed FX conversion and settle transactions onchain.

--- a/src/pages/docs/ecosystem/wallets.mdx
+++ b/src/pages/docs/ecosystem/wallets.mdx
@@ -99,6 +99,12 @@ Access Tempo through the [Fireblocks console](https://console.fireblocks.io/) an
 
 Get started at [Bitget Wallet](https://web3.bitget.com).
 
+### Bridge Wallet
+
+[Bridge Wallet](https://www.mtpelerin.com/bridge-wallet) is Mt Pelerin's self-custodial mobile wallet with Tempo support. Users hold their own secret phrase and can send, receive, manage, buy, swap, or cash out supported assets through the app.
+
+Download Bridge Wallet from the [Mt Pelerin website](https://www.mtpelerin.com/bridge-wallet).
+
 ### OKX Wallet
 
 [OKX Wallet](https://www.okx.com/web3) is a self-custodial multi-chain wallet with native Tempo support. Users can store, swap, and manage Tempo-based assets, with built-in DEX aggregation and DApp connectivity.


### PR DESCRIPTION
## What changed

- Added Mt Pelerin to the Issuance & orchestration ecosystem page.
- Added Bridge Wallet to the Self-Custodial section of the wallets ecosystem page.
- Kept both partner sections alphabetized.
- Linked to Mt Pelerin's official ramp services and Bridge Wallet product page.

## Why

Mt Pelerin provides on-ramp and off-ramp access for supported assets on Tempo, and Bridge Wallet is its self-custodial mobile wallet with Tempo support. Documenting both products keeps the Docs ecosystem section aligned with the website ecosystem guide.

## Validation

- `pnpm check:types`
- `pnpm build`
- `pnpm check:markdown`
- Generic-heading scan for the changed MDX pages
- Confirmed both entries appear in rendered HTML, generated Markdown, search index, and `llms-full.txt`