### PR TITLE
Update T9 release and mainnet activation dates

### DIFF
--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.12.0 | Target: Aug 3, 2026 | Testnet + Mainnet | Required for T9. Adds TIP-403 storage for TIP-20 token policy bindings used by zones/provable contract flows, plus a targeted migration path for existing tokens that need one. Testnet activation is scheduled for Aug 5, 2026; mainnet activation is scheduled for Aug 10, 2026. | <Badge variant="red">Required</Badge> |
+| [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) | Aug 3, 2026 | Testnet + Mainnet | Required for T9. Adds TIP-403 storage for TIP-20 token policy bindings used by zones/provable contract flows, plus a targeted migration path for existing tokens that need one. Testnet activation is scheduled for Aug 5, 2026; mainnet activation is scheduled for Aug 6, 2026. | <Badge variant="red">Required</Badge> |
 | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8; active on testnet and scheduled for mainnet activation on July 30. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
@@ -44,12 +44,12 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | **Scope** | TIP-20 policy IDs in TIP-403 for zones/provable contract flows, plus targeted migration for existing TIP-20 tokens that need a TIP-403 binding |
 | **TIPs** | [TIP-20 Policy IDs in TIP-403](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md) |
 | **Details** | [T9 network upgrade](/docs/protocol/upgrades/t9) |
-| **Release** | v1.12.0 (target: August 3, 2026) |
+| **Release** | [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) |
 | **Testnet** | Scheduled: August 5, 2026 |
-| **Mainnet** | Scheduled: August 10, 2026 |
+| **Mainnet** | Scheduled: August 6, 2026 |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
-T9 is scheduled for testnet on August 5, 2026 and mainnet on August 10, 2026. v1.12.0 is targeted for August 3, 2026. Node operators should plan to upgrade before activation once the release is available.
+T9 is scheduled for testnet on August 5, 2026 and mainnet on August 6, 2026. It is supported by [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0), published on August 3, 2026. Node operators should plan to upgrade before activation.
 
 ---
 

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -12,18 +12,18 @@ In simpler terms, T9 moves the answer to "which transfer rules apply to this tok
 For most partners, T9 is only relevant if you issue TIP-20 tokens, run tooling that reads token policy state, or build zone/provable contract flows that depend on TIP-403 policy checks.
 
 :::info[T9 status]
-v1.12.0 is targeted for August 3, 2026. Testnet activation is scheduled for August 5, 2026, and mainnet activation is scheduled for August 10, 2026.
+Release [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) is published and required for T9. Testnet activation is scheduled for August 5, 2026, and mainnet activation is scheduled for August 6, 2026.
 :::
 
 ## Timeline
 
 | Milestone | Date |
 |-----------|------|
-| Target release | August 3, 2026 |
+| Release published | August 3, 2026 |
 | Testnet activation | August 5, 2026 |
-| Mainnet activation | August 10, 2026 |
+| Mainnet activation | August 6, 2026 |
 
-Node operators should plan to upgrade to v1.12.0 before the activation time for each network.
+Node operators should plan to upgrade to [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) before the activation time for each network.
 
 ## Overview
 
@@ -55,7 +55,7 @@ For zone enablement, ZonePortal checks whether the token already has a TIP-403 b
 
 ## Compatible release
 
-v1.12.0 is targeted for August 3, 2026. Release notes and binaries will be linked here when they are available.
+Release notes and binaries are available in the [v1.12.0 release](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0).
 
 ## Integration impact
 


### PR DESCRIPTION
## Summary

- Links the published [v1.12.0 release](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) from the T9 page and Network Upgrades table.
- Updates T9 mainnet activation from August 10, 2026 to August 6, 2026.
- Replaces target-release wording with published-release wording now that v1.12.0 is available.

## Checks

- `git diff --check`