### PR TITLE
Update T8 sidebar label

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -894,12 +894,11 @@ export default defineConfig({
               },
               {
                 text: 'T8',
-                badge: { text: 'Testnet', variant: 'info' as const },
+                badge: { text: 'Latest', variant: 'info' as const },
                 link: '/docs/protocol/upgrades/t8',
               },
               {
                 text: 'T7',
-                badge: { text: 'Latest', variant: 'info' as const },
                 link: '/docs/protocol/upgrades/t7',
               },
               {


### PR DESCRIPTION
## Summary

- Updates the Network Upgrades sidebar so T8 is labeled `Latest`.
- Removes the `Latest` badge from T7.

## Checks

- `git diff --check`