### PR TITLE
docs: document API key IP allowlists

### DIFF
--- a/src/pages/docs/api/authentication.mdx
+++ b/src/pages/docs/api/authentication.mdx
@@ -68,6 +68,12 @@ curl 'https://api.tempo.xyz/v1/blocks?chainId=testnet' \
 - **The plaintext token is shown only once**, at provision time. Store it securely; it cannot be revealed again. If you lose it, revoke the key and provision a new one.
 - At rest, only a hash of the token is stored. Tokens are redacted from logs and error output.
 
+### IP-restricted API keys
+
+An API key can carry an allowlist of exact IPv4 or IPv6 addresses and CIDR ranges. When the list is non-empty, Tempo accepts the key only when the trusted client IP matches at least one entry. A missing or nonmatching client IP returns `403` with `api_key_ip_forbidden`.
+
+An omitted or empty allowlist leaves the key unrestricted. Updates are eventually consistent and may take a minute or more to propagate globally. See [Restrict an API key by IP address](/docs/api/console/api-keys#restrict-an-api-key-by-ip-address) for management examples and safe rollout guidance.
+
 ## MPP (Paying per Request)
 
 Endpoints that permit anonymous access also accept [MPP](https://mpp.dev), a pay-per-request payment protocol, as an alternative to an API key. Use it to call those endpoints without a key, or to keep going once you exceed a rate limit.

--- a/src/pages/docs/api/console/api-keys.mdx
+++ b/src/pages/docs/api/console/api-keys.mdx
@@ -59,6 +59,40 @@ const client = Client.create({
 
 Keep the key in a server-side environment variable or secret manager. Do not expose it in frontend code, logs, support messages, or source control.
 
+## Restrict an API key by IP address
+
+Use an IP allowlist for server-side integrations with stable egress addresses. Tempo accepts exact IPv4 and IPv6 addresses or CIDR ranges.
+
+Set `allowedIps` when creating a key through the management API:
+
+```http
+POST /v1/orgs/{orgId}/projects/{projectId}/api-keys
+Content-Type: application/json
+
+{
+  "name": "production-worker",
+  "scopes": ["data:read"],
+  "allowedIps": ["203.0.113.7", "2001:db8::/32"]
+}
+```
+
+Replace an existing key's complete allowlist with `PATCH`:
+
+```http
+PATCH /v1/orgs/{orgId}/projects/{projectId}/api-keys/{keyId}
+Content-Type: application/json
+
+{
+  "allowedIps": ["198.51.100.0/24"]
+}
+```
+
+An omitted or empty `allowedIps` list means unrestricted access. Send `{ "allowedIps": [] }` to remove an existing restriction. Each list supports up to 100 entries.
+
+Requests from an address outside the allowlist, or without a trusted client IP, fail with `403 api_key_ip_forbidden`. Allowlist changes are eventually consistent and may take a minute or more to propagate globally. During an egress migration, add both the old and new ranges, wait for propagation, then remove the old range.
+
+See the [Tempo API reference](/docs/api/reference) for complete request and response schemas.
+
 ## Rotate an API key
 
 Tempo API Console does not reveal an existing token again. Rotate a credential by overlapping the old and new keys:

--- a/src/pages/docs/api/errors.mdx
+++ b/src/pages/docs/api/errors.mdx
@@ -83,6 +83,7 @@ The credential is valid but not permitted to perform the request.
 | Code | Meaning |
 | --- | --- |
 | `api_key_forbidden` | The API key is missing a [scope](/docs/api/authentication) required by this endpoint. |
+| `api_key_ip_forbidden` | The API key has an IP allowlist, but the trusted client IP is missing or does not match it. |
 | `limit_exceeded` | A resource limit was reached (for example, the maximum number of webhooks). |
 
 ## 404: Not Found


### PR DESCRIPTION
## Motivation

Document client IP allowlists for API keys so operators can restrict credentials to stable egress networks and roll out changes safely. Companion documentation for tempoxyz/api#621.

## Summary

- explain exact IPv4, IPv6, and CIDR allowlist rules
- show create, replace, and clear request bodies
- add `api_key_ip_forbidden` to the error catalog

## Key design considerations

- describe eventual consistency and a safe egress-migration sequence
- direct readers to the management API because the Console UI does not expose allowlists yet