### PR TITLE
docs: fix funding api links

### DIFF
--- a/src/pages/docs/api.mdx
+++ b/src/pages/docs/api.mdx
@@ -73,7 +73,7 @@ Create production and sandbox API keys in [Tempo API Console](https://console.te
 
 - **Track and reconcile a stablecoin payment.** Look up the [transaction and receipt](/docs/api/transactions), then inspect its [transaction activities](/docs/api/activities#list-transaction-activities) to confirm the token movement. Use [webhooks](/docs/api/webhooks) when your backend needs signed event callbacks.
 - **Monitor an account.** Read [balances](/docs/api/balances) and [activity](/docs/api/activities) to build payment history, treasury, or account views.
-- **Fund and exchange stablecoins.** Compare [funding quotes](/docs/api/funding) across supported chains and providers; the Funding API does not execute the transfer. Use [exchange quotes](/docs/api/exchange) to prepare unsigned approval and swap calls for you to sign and submit.
+- **Fund and exchange stablecoins.** Compare [funding quotes](/docs/api/quotes) across supported chains and providers, then [create a transfer](/docs/api/transfers) or [create a reusable deposit address](/docs/api/deposit-addresses). Use [exchange quotes](/docs/api/exchange) to prepare unsigned approval and swap calls for you to sign and submit.
 - **Sponsor transaction fees.** Use the [Fee Payer API](/docs/api/fee-payer) to apply sponsorship policy and fill, sponsor, and broadcast user transactions.
 - **Query custom payment data.** Use the [Indexer API](/docs/api/indexer-api) for read-only SQL across indexed blocks, transactions, receipts, logs, transfers, and exchange data.
 - **Prepare a production integration.** Create projects and keys in [Tempo API Console](/docs/api/console), then review [authentication](/docs/api/authentication), [rate limits](/docs/api/rate-limits), and [errors](/docs/api/errors).

--- a/src/pages/docs/api/faq.mdx
+++ b/src/pages/docs/api/faq.mdx
@@ -25,7 +25,7 @@ Read the [transaction and receipt](/docs/api/transactions) to follow execution, 
 
 ## Does the Tempo Funding API execute a transfer?
 
-No. The [Funding API](/docs/api/funding) compares live quotes across supported chains and providers, but it does not execute a transfer. Execute the chosen transfer separately.
+No. The [Funding API](/docs/api/quotes) compares live quotes across supported chains and providers, but it does not execute a transfer. Execute the chosen transfer separately.
 
 ## Does the Tempo Exchange API submit a transaction?
 


### PR DESCRIPTION
Replaces links to the removed `Funding` reference with the generated `Quotes`, `Transfers`, and `Deposit Addresses` pages after the Funding & Bridge API split.