### PR TITLE
docs: expand api sidebar

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -217,7 +217,7 @@ export default defineConfig({
       spec: 'https://api.tempo.xyz/openapi.json',
       sidebar: {
         backLink: false,
-        collapsed: true,
+        collapsed: false,
         intro: [
           {
             text: 'API Console',


### PR DESCRIPTION
Expands generated API reference categories and resources by default while preserving the collapsed API Console group, making the full API surface visible without additional clicks.