### PR TITLE
docs: update Exa service URL

### DIFF
--- a/src/pages/docs/guide/machine-payments/use-cases/web-search-and-research.mdx
+++ b/src/pages/docs/guide/machine-payments/use-cases/web-search-and-research.mdx
@@ -24,7 +24,7 @@ With MPP, your agent pays per search query or page extraction in a single HTTP r
 | Provider | Capabilities | Service URL |
 |---|---|---|
 | [Parallel](https://parallelmpp.dev) | Web search, page extraction, multi-hop research | `parallelmpp.dev` |
-| Exa | AI-powered search, content retrieval, answers | `exa.mpp.tempo.xyz` |
+| Exa | AI-powered search, content retrieval, answers | `api.exa.ai` |
 | [Brave](https://brave.mpp.paywithlocus.com) | Web, news, images, videos, AI answers | `brave.mpp.paywithlocus.com` |
 | Firecrawl | Web scraping, crawling, structured extraction | `firecrawl.mpp.tempo.xyz` |
 | [Diffbot](https://diffbot.mpp.paywithlocus.com) | Article, product, and discussion extraction | `diffbot.mpp.paywithlocus.com` |


### PR DESCRIPTION
## Summary

- Update the web-search guide to use Exa's current MPP service URL, `api.exa.ai`.
- Confirm the live service catalog reports `https://api.exa.ai` for Exa.

## Validation

- `pnpm check:types`
- Repository scan confirms no stale `exa.mpp.tempo.xyz` references remain.
- `pnpm build` reached the Vocs build but was blocked by an external OpenAPI fetch timeout.

Prompted by: @brendanjryan