### PR TITLE
Mark T9 live on mainnet

### DIFF
--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,8 +15,8 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) | Aug 3, 2026 | Testnet + Mainnet | Required for T9. Adds TIP-403 storage for TIP-20 token policy bindings used by zones/provable contract flows, plus a targeted migration path for existing tokens that need one. Testnet activation is scheduled for Aug 5, 2026; mainnet activation is scheduled for Aug 6, 2026. | <Badge variant="red">Required</Badge> |
-| [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8; active on testnet and scheduled for mainnet activation on July 30. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
+| [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) | Aug 3, 2026 | Testnet + Mainnet | Required for T9. Adds TIP-403 storage for TIP-20 token policy bindings used by zones/provable contract flows, plus a targeted migration path for existing tokens that need one. T9 is active on testnet and mainnet. | <Badge variant="red">Required</Badge> |
+| [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. T8 is active on testnet and mainnet. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
 | [v1.9.1](https://github.com/tempoxyz/tempo/releases/tag/v1.9.1) | Jun 19, 2026 | Testnet + Mainnet | Patch release with follow-mode stability fixes, payload-builder latency fixes, Reth/Rust dependency updates, and transaction-pool/RPC improvements. | <Badge variant="yellow">Recommended</Badge> |
 | [v1.9.0](https://github.com/tempoxyz/tempo/releases/tag/v1.9.0) | Jun 15, 2026 | Testnet + Mainnet | Required for T6; adds account-level receive policies for safer TIP-20 deposits and admin access keys for smoother passkey, device, and delegated-key management. Operators were required to run this release before the T6 activation timestamp on each network. | <Badge variant="red">Required</Badge> |
@@ -45,11 +45,11 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | **TIPs** | [TIP-20 Policy IDs in TIP-403](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1092.md) |
 | **Details** | [T9 network upgrade](/docs/protocol/upgrades/t9) |
 | **Release** | [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) |
-| **Testnet** | Scheduled: August 5, 2026 |
-| **Mainnet** | Scheduled: August 6, 2026 |
+| **Testnet** | Live: August 5, 2026 |
+| **Mainnet** | Live: August 6, 2026 |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
-T9 is scheduled for testnet on August 5, 2026 and mainnet on August 6, 2026. It is supported by [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0), published on August 3, 2026. Node operators should plan to upgrade before activation.
+T9 is active on testnet and mainnet and supported by [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0), published on August 3, 2026. Node operators were required to run the T9-compatible release before activation to stay synced.
 
 ---
 
@@ -62,10 +62,10 @@ T9 is scheduled for testnet on August 5, 2026 and mainnet on August 6, 2026. It 
 | **Details** | [T8 network upgrade](/docs/protocol/upgrades/t8) |
 | **Release** | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) |
 | **Testnet** | Live: July 27, 2026 |
-| **Mainnet** | Scheduled: July 30, 2026 |
+| **Mainnet** | Live: July 30, 2026 |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
-T8 is active on testnet and scheduled for mainnet on July 30, 2026. It is supported by [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0), published on July 22, 2026. Testnet node operators were required to run the T8-compatible release before activation; mainnet node operators should run it before mainnet activation to stay synced.
+T8 is active on testnet and mainnet and supported by [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0), published on July 22, 2026. Node operators were required to run the T8-compatible release before activation to stay synced.
 
 ---
 

--- a/src/pages/docs/protocol/upgrades/t8.mdx
+++ b/src/pages/docs/protocol/upgrades/t8.mdx
@@ -8,7 +8,7 @@ description: T8 network upgrade overview covering current committee state, FeeAM
 T8 focuses on clearer validator committee reads, FeeAMM policy behavior, DEX order storage, and the final TIP-20 rewards shutdown.
 
 :::info[T8 status]
-T8 is active on testnet. Mainnet activation is scheduled for July 30, 2026. Release [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) is required for T8; see the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
+T8 is active on testnet and mainnet. Release [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) is required for T8; see the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
 :::
 
 ## Timeline
@@ -16,9 +16,9 @@ T8 is active on testnet. Mainnet activation is scheduled for July 30, 2026. Rele
 | Network | Date |
 |---------|------|
 | Testnet | Live: July 27, 2026 |
-| Mainnet | Scheduled: July 30, 2026 |
+| Mainnet | Live: July 30, 2026 |
 
-Testnet node operators were required to run [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) before testnet activation. Mainnet node operators should run [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) before mainnet activation to stay synced.
+Node operators were required to run [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) before activation to stay synced.
 
 ## Overview
 

--- a/src/pages/docs/protocol/upgrades/t9.mdx
+++ b/src/pages/docs/protocol/upgrades/t9.mdx
@@ -12,7 +12,7 @@ In simpler terms, T9 moves the answer to "which transfer rules apply to this tok
 For most partners, T9 is only relevant if you issue TIP-20 tokens, run tooling that reads token policy state, or build zone/provable contract flows that depend on TIP-403 policy checks.
 
 :::info[T9 status]
-Release [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) is published and required for T9. Testnet activation is scheduled for August 5, 2026, and mainnet activation is scheduled for August 6, 2026.
+T9 is active on testnet and mainnet. Release [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) is required for T9; see the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
 :::
 
 ## Timeline
@@ -20,10 +20,10 @@ Release [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) is pub
 | Milestone | Date |
 |-----------|------|
 | Release published | August 3, 2026 |
-| Testnet activation | August 5, 2026 |
-| Mainnet activation | August 6, 2026 |
+| Testnet rollout | Live: August 5, 2026 |
+| Mainnet rollout | Live: August 6, 2026 |
 
-Node operators should plan to upgrade to [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) before the activation time for each network.
+Node operators were required to run [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) before activation to stay synced.
 
 ## Overview
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -890,12 +890,11 @@ export default defineConfig({
             items: [
               {
                 text: 'T9',
-                badge: { text: 'Planned', variant: 'note' as const },
+                badge: { text: 'Latest', variant: 'info' as const },
                 link: '/docs/protocol/upgrades/t9',
               },
               {
                 text: 'T8',
-                badge: { text: 'Latest', variant: 'info' as const },
                 link: '/docs/protocol/upgrades/t8',
               },
               {


### PR DESCRIPTION
## Summary

- Marks T9 active on testnet and mainnet on the T9 upgrade page.
- Updates the Network Upgrades and Releases page so T9 is shown as live on both networks.
- Moves the Network Upgrades sidebar `Latest` badge from T8 to T9.
- Cleans up nearby T8 status copy that still described mainnet activation as scheduled.

## Checks

- `git diff --check`
- `pnpm run check:markdown` could not run locally because `node_modules` is not installed in this checkout.
- `pnpm run check:anchors` could not run locally because `node_modules` is not installed in this checkout.