### PR TITLE
docs: add transaction debugger guide

### DIFF
--- a/src/lib/docs-seo-metadata.test.ts
+++ b/src/lib/docs-seo-metadata.test.ts
@@ -89,7 +89,7 @@ describe('docs SEO metadata', () => {
           /^seoTitle:/m.test(source) && path.relative(docsRoot, file) !== 'api/reference.mdx',
       )
 
-    expect(auditedPages).toHaveLength(106)
+    expect(auditedPages).toHaveLength(107)
 
     for (const { file, source } of auditedPages) {
       const title = frontmatterString(source, 'title')

--- a/src/pages/docs/ecosystem/block-explorers.mdx
+++ b/src/pages/docs/ecosystem/block-explorers.mdx
@@ -12,6 +12,8 @@ View transactions, blocks, accounts, and token activity on Tempo.
 
 Tempo's official Mainnet block explorer is available at [explore.tempo.xyz](https://explore.tempo.xyz). View transactions, blocks, accounts, and token activity on the Tempo network. Testnet block explorer is available at [explore.testnet.tempo.xyz](https://explore.testnet.tempo.xyz). For more connection information, see [Connect to the Network](/docs/quickstart/connection-details).
 
+The explorer also includes a [transaction debugger](https://explore.tempo.xyz/simulate) that simulates a transaction without broadcasting it. Follow the [transaction debugging guide](/docs/guide/debug-transactions) to inspect execution traces, balance changes, events, gas use, and revert details.
+
 ## Tenderly
 
 [Tenderly](https://tenderly.co) delivers full-stack observability, debugging, and simulation tools for Tempo smart contract development and monitoring. With Tenderly you get real-time error tracking, EVM-level tracing, and off-chain transaction simulation — enabling you to catch bugs, analyze reverts, and inspect gas usage before transactions go live.

--- a/src/pages/docs/guide/debug-transactions.mdx
+++ b/src/pages/docs/guide/debug-transactions.mdx
@@ -8,6 +8,14 @@ description: Simulate a Tempo transaction before submitting it, then inspect exe
 
 Use the [Tempo transaction debugger](https://explore.tempo.xyz/simulate) to test a transaction against current Mainnet state without broadcasting it. Simulate a transaction to diagnose reverts or verify a contract interaction.
 
+:::info[What simulations show]
+- **Gas flame graphs** show which calls consume the most gas.
+- **State changes** show how balances and contract storage would change.
+- **Event logs** show the events the transaction would emit.
+- **Call traces** show the transaction's execution path across contracts.
+- **Revert errors** identify the call and error that caused a failure.
+:::
+
 ## Run a transaction simulation
 
 :::::steps

--- a/src/pages/docs/guide/debug-transactions.mdx
+++ b/src/pages/docs/guide/debug-transactions.mdx
@@ -6,36 +6,26 @@ description: Simulate a Tempo transaction before submitting it, then inspect exe
 
 # Simulate and debug Tempo transactions
 
-Use the [Tempo transaction debugger](https://explore.tempo.xyz/simulate) to test a transaction against current Mainnet state without broadcasting it. The simulation shows what the transaction would do, which helps you diagnose reverts and verify contract interactions before signing.
+Use the [Tempo transaction debugger](https://explore.tempo.xyz/simulate) to test a transaction against current Mainnet state without broadcasting it. Simulate a transaction to diagnose reverts or verify a contract interaction.
 
 ## Run a transaction simulation
 
 :::::steps
 
-### Open the transaction debugger
+### Enter the transaction
 
-Go to [explore.tempo.xyz/simulate](https://explore.tempo.xyz/simulate).
-
-### Enter the transaction request
-
-Provide the sender, recipient, value, and calldata your application would submit. Use `0` for value when the call does not transfer value.
+Open [explore.tempo.xyz/simulate](https://explore.tempo.xyz/simulate), then provide the sender, recipient, value, and calldata.
 
 ### Simulate the transaction
 
-Run the simulation. The debugger executes the request against current chain state without submitting it to Tempo.
+Run the simulation against current chain state.
 
 ### Inspect the execution
 
-Review the decoded calls, balance changes, events, execution trace, gas use, and any revert details. Confirm that the addresses, token amounts, and contract calls match the intended result before you broadcast the transaction.
+Review the decoded calls, balance changes, events, execution trace, gas use, and any revert details.
 
 :::::
 
 ## Diagnose a failed transaction
 
-Start with the first reverted call in the execution trace. Its decoded error or return data usually identifies the contract and condition that rejected the transaction. Then check balance changes and events to verify which operations ran before the revert.
-
-If you need a local or command-line workflow, use [`cast run`](/docs/sdk/foundry#interact-and-debug-tempo-contracts-with-cast) to replay a transaction by hash against a Tempo RPC endpoint.
-
-## Protect sensitive transaction data
-
-Simulations do not broadcast transactions, but the request is sent to the debugger service. Do not enter private keys, signatures, secrets, or confidential calldata. A transaction simulation only reflects chain state at the time it runs, so state-dependent results can change before submission.
+Start with the first reverted call in the execution trace. Its decoded error or return data usually identifies the contract and condition that rejected the transaction.

--- a/src/pages/docs/guide/debug-transactions.mdx
+++ b/src/pages/docs/guide/debug-transactions.mdx
@@ -1,0 +1,41 @@
+---
+title: "Simulate and debug Tempo transactions"
+seoTitle: "Tempo Transaction Debugger and Simulator | Tempo Docs"
+description: Simulate a Tempo transaction before submitting it, then inspect execution traces, balance changes, events, gas use, and revert details.
+---
+
+# Simulate and debug Tempo transactions
+
+Use the [Tempo transaction debugger](https://explore.tempo.xyz/simulate) to test a transaction against current Mainnet state without broadcasting it. The simulation shows what the transaction would do, which helps you diagnose reverts and verify contract interactions before signing.
+
+## Run a transaction simulation
+
+:::::steps
+
+### Open the transaction debugger
+
+Go to [explore.tempo.xyz/simulate](https://explore.tempo.xyz/simulate).
+
+### Enter the transaction request
+
+Provide the sender, recipient, value, and calldata your application would submit. Use `0` for value when the call does not transfer value.
+
+### Simulate the transaction
+
+Run the simulation. The debugger executes the request against current chain state without submitting it to Tempo.
+
+### Inspect the execution
+
+Review the decoded calls, balance changes, events, execution trace, gas use, and any revert details. Confirm that the addresses, token amounts, and contract calls match the intended result before you broadcast the transaction.
+
+:::::
+
+## Diagnose a failed transaction
+
+Start with the first reverted call in the execution trace. Its decoded error or return data usually identifies the contract and condition that rejected the transaction. Then check balance changes and events to verify which operations ran before the revert.
+
+If you need a local or command-line workflow, use [`cast run`](/docs/sdk/foundry#interact-and-debug-tempo-contracts-with-cast) to replay a transaction by hash against a Tempo RPC endpoint.
+
+## Protect sensitive transaction data
+
+Simulations do not broadcast transactions, but the request is sent to the debugger service. Do not enter private keys, signatures, secrets, or confidential calldata. A transaction simulation only reflects chain state at the time it runs, so state-dependent results can change before submission.

--- a/src/pages/docs/guide/tempo-transaction/index.mdx
+++ b/src/pages/docs/guide/tempo-transaction/index.mdx
@@ -17,7 +17,9 @@ Transaction [SDKs](#integration-guides) are available for TypeScript, Rust, Go, 
 
 If you're integrating with Tempo, we **strongly recommend** using Tempo Transactions, and not regular Ethereum transactions. Learn more about the benefits below, or follow the guide on issuance [here](/docs/guide/issuance).
 
-Before broadcasting a transaction, use the [Tempo transaction debugger](/docs/guide/debug-transactions) to simulate it and inspect its execution trace, balance changes, events, gas use, and revert details.
+:::tip[Debug failed transactions]
+If a transaction fails, use the [Tempo transaction debugger](/docs/guide/debug-transactions) to reproduce the failure and inspect its execution trace, balance changes, events, gas use, and revert details.
+:::
 
 <Cards>
   <Card

--- a/src/pages/docs/guide/tempo-transaction/index.mdx
+++ b/src/pages/docs/guide/tempo-transaction/index.mdx
@@ -17,6 +17,8 @@ Transaction [SDKs](#integration-guides) are available for TypeScript, Rust, Go, 
 
 If you're integrating with Tempo, we **strongly recommend** using Tempo Transactions, and not regular Ethereum transactions. Learn more about the benefits below, or follow the guide on issuance [here](/docs/guide/issuance).
 
+Before broadcasting a transaction, use the [Tempo transaction debugger](/docs/guide/debug-transactions) to simulate it and inspect its execution trace, balance changes, events, gas use, and revert details.
+
 <Cards>
   <Card
     description="Pay transaction fees with any USD-denominated TIP-20 token via automatic Fee AMM conversion."

--- a/src/pages/docs/sdk/foundry/index.mdx
+++ b/src/pages/docs/sdk/foundry/index.mdx
@@ -206,8 +206,6 @@ For more verification options including verifying existing contracts and API ver
 
 ### Interact and debug Tempo contracts with `cast`
 
-For a browser-based workflow, use the [Tempo transaction debugger](/docs/guide/debug-transactions) to simulate a transaction and inspect decoded calls, balance changes, events, gas use, and reverts before broadcasting.
-
 ```bash
 # Check that your contract is deployed:
 cast code <CONTRACT_ADDRESS> \

--- a/src/pages/docs/sdk/foundry/index.mdx
+++ b/src/pages/docs/sdk/foundry/index.mdx
@@ -206,6 +206,8 @@ For more verification options including verifying existing contracts and API ver
 
 ### Interact and debug Tempo contracts with `cast`
 
+For a browser-based workflow, use the [Tempo transaction debugger](/docs/guide/debug-transactions) to simulate a transaction and inspect decoded calls, balance changes, events, gas use, and reverts before broadcasting.
+
 ```bash
 # Check that your contract is deployed:
 cast code <CONTRACT_ADDRESS> \

--- a/src/pages/docs/tools.mdx
+++ b/src/pages/docs/tools.mdx
@@ -45,6 +45,12 @@ If you are integrating a product, start with the TypeScript SDKs and Tempo API. 
 
 <Cards>
   <Card
+    title="Transaction Debugger"
+    description="Simulate a transaction and inspect calls, balance changes, events, gas use, and reverts before broadcasting."
+    to="/docs/guide/debug-transactions"
+    icon="lucide:bug"
+  />
+  <Card
     title="JSON-RPC API"
     description="Browse Tempo RPC methods, request shapes, and protocol-level API behavior."
     to="/docs/protocol/rpc"

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -600,6 +600,10 @@ export default defineConfig({
             link: '/docs/guide/tempo-transaction',
           },
           {
+            text: 'Debug Transactions',
+            link: '/docs/guide/debug-transactions',
+          },
+          {
             text: 'Get Testnet Faucet Funds',
             link: '/docs/quickstart/faucet',
           },
@@ -1216,6 +1220,7 @@ export default defineConfig({
       '/docs/guide/machine-payments': buildSidebar,
       '/docs/quickstart': integrateSidebar,
       '/docs/guide/tempo-transaction': integrateSidebar,
+      '/docs/guide/debug-transactions': integrateSidebar,
       '/docs/guide/bridge-layerzero': integrateSidebar,
       '/docs/guide/bridge-bungee': integrateSidebar,
       '/docs/guide/bridge-relay': integrateSidebar,


### PR DESCRIPTION
## Summary

- add an SEO-focused guide for the Tempo transaction debugger
- link it from Integrate Tempo navigation, Tools & SDKs, Tempo Transactions, Foundry, and Block Explorers

## Validation

- `pnpm check:types`
- `pnpm check` (passes with existing warnings)
- `pnpm build` (blocked when Vocs could not fetch an external OpenAPI source: connection timeout)

Prompted by: @deodad