### PR TITLE
docs: add Coins.ph to ecosystem

### DIFF
--- a/src/pages/docs/ecosystem/orchestration.mdx
+++ b/src/pages/docs/ecosystem/orchestration.mdx
@@ -36,6 +36,12 @@ Get started by creating an account [here](https://app.brale.xyz/buy/signup/).
 
 Get started with [Bridge's Tempo Integration Guide](https://apidocs.bridge.xyz/get-started/guides/move-money/tempo-integration-guide#tempo-integration-guide).
 
+## Coins.ph
+
+[Coins.ph](https://www.coins.ph/en-ph/business) provides regulated payment and stablecoin infrastructure for businesses operating in the Philippines. Its APIs support PHP collections and disbursements, cross-border payments, virtual accounts, institutional trading, and fiat-to-stablecoin on-ramps and off-ramps.
+
+Explore the [Coins.ph API documentation](https://docs.coins.ph/) or [contact the Coins.ph business team](https://www.coins.ph/en-ph/business) to get started.
+
 ## Hercle
 
 [Hercle](https://www.hercle.com/) provides institutional cross-border payment infrastructure connecting fiat, stablecoins, and digital assets. Teams on Tempo can access competitive FX rates in EUR, GBP, and 30+ local currencies.


### PR DESCRIPTION
## Summary
- add Coins.ph to the issuance and orchestration ecosystem docs
- link the Coins.ph business and API documentation pages

## Validation
- `pnpm check:types`
- `pnpm build` attempted twice; blocked by a timeout fetching an unrelated external OpenAPI schema in the Vocs LLMS plugin

Prompted by: @juandolealt