### PR TITLE
Center authored API documentation pages

### DIFF
--- a/e2e/openapi-layout.test.ts
+++ b/e2e/openapi-layout.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+
+test.use({ viewport: { height: 1000, width: 1960 } })
+
+test('centers authored API guides while preserving full-width endpoint references', async ({
+  page,
+}) => {
+  await page.goto('/docs/api/indexer-api')
+
+  const guideLayout = page.locator('[data-layout][data-v-sidebar]')
+  const guide = guideLayout.locator('[data-v-openapi-guide]')
+  const main = guideLayout.locator(':scope > [data-v-main]')
+
+  await expect(guideLayout).not.toHaveAttribute('data-v-content-width', 'full')
+  await expect(guide).toBeVisible()
+
+  const [guideBox, mainBox, mainPaddingRight] = await Promise.all([
+    guide.boundingBox(),
+    main.boundingBox(),
+    main.evaluate((element) => Number.parseFloat(getComputedStyle(element).paddingRight)),
+  ])
+
+  expect(guideBox).not.toBeNull()
+  expect(mainBox).not.toBeNull()
+  if (!guideBox || !mainBox) throw new Error('Expected the guide and main content to render')
+
+  const guideCenter = guideBox.x + guideBox.width / 2
+  const readableAreaCenter = mainBox.x + (mainBox.width - mainPaddingRight) / 2
+  expect(Math.abs(guideCenter - readableAreaCenter)).toBeLessThanOrEqual(1)
+
+  await page.goto('/docs/api/authentication')
+
+  const referenceLayout = page.locator('[data-layout][data-v-sidebar]')
+  const operation = referenceLayout.locator('[data-v-openapi-operation]').first()
+  const playground = operation.locator('[data-v-openapi-operation-aside]')
+
+  await expect(referenceLayout).toHaveAttribute('data-v-content-width', 'full')
+  await expect(playground).toBeVisible()
+
+  const [operationBox, playgroundBox] = await Promise.all([
+    operation.boundingBox(),
+    playground.boundingBox(),
+  ])
+
+  expect(operationBox).not.toBeNull()
+  expect(playgroundBox).not.toBeNull()
+  if (!operationBox || !playgroundBox) throw new Error('Expected the API operation to render')
+
+  expect(playgroundBox.x).toBeGreaterThan(operationBox.x + operationBox.width / 2)
+})

--- a/patches/vocs@2.8.5.patch
+++ b/patches/vocs@2.8.5.patch
@@ -111,7 +111,7 @@ index 06cc466393643245bf0dfcc0c946e013c717a75c..e5b39e12c9e2017238a9744412943e2e
      const title = props.title ?? props.frontmatter?.title;
      const description = props.description ?? props.frontmatter?.description;
 -    return (_jsxs(OpenApiLayout, { frontmatter: { ...props.frontmatter, description, title }, width: "full", children: [title ? _jsx("title", { children: title }) : null, _jsxs("div", { "data-v-openapi-guide": true, children: [props.header && title ? (_jsxs("header", { "data-v-openapi-header": true, children: [_jsxs("h1", { "data-v": true, "data-v-openapi-h1": true, id: props.id, children: [title, props.id ? _jsx(HeadingAnchor, { id: props.id }) : null] }), description ? _jsx(Prose, { markdown: description, attr: "description" }) : null] })) : null, props.children] })] }));
-+    return (_jsx(OpenApiLayout, { documentTitle: resolveDocumentTitle(props.frontmatter, title), frontmatter: { ...props.frontmatter, description, title }, width: "full", children: _jsxs("div", { "data-v-openapi-guide": true, children: [props.header && title ? (_jsxs("header", { "data-v-openapi-header": true, children: [_jsxs("h1", { "data-v": true, "data-v-openapi-h1": true, id: props.id, children: [title, props.id ? _jsx(HeadingAnchor, { id: props.id }) : null] }), description ? _jsx(Prose, { markdown: description, attr: "description" }) : null] })) : null, props.children] }) }));
++    return (_jsx(OpenApiLayout, { documentTitle: resolveDocumentTitle(props.frontmatter, title), frontmatter: { ...props.frontmatter, description, title }, width: "default", children: _jsxs("div", { "data-v-openapi-guide": true, children: [props.header && title ? (_jsxs("header", { "data-v-openapi-header": true, children: [_jsxs("h1", { "data-v": true, "data-v-openapi-h1": true, id: props.id, children: [title, props.id ? _jsx(HeadingAnchor, { id: props.id }) : null] }), description ? _jsx(Prose, { markdown: description, attr: "description" }) : null] })) : null, props.children] }) }));
  }
  /**
   * Renders an isolated, auto-generated OpenAPI reference section (Vite/RSC site
@@ -321,7 +321,7 @@ index 939c937581ec434975aee43e7284c6c2d48add93..4622655fa2c046435180c35f012b6a31
 +    <OpenApiLayout
 +      documentTitle={resolveDocumentTitle(props.frontmatter, title)}
 +      frontmatter={{ ...props.frontmatter, description, title }}
-+      width="full"
++      width="default"
 +    >
        <div data-v-openapi-guide>
          {props.header && title ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ patchedDependencies:
     hash: 47bfcf62e3c84ba85d881815422a02e23f372df46bddb9b022eb3705361fd165
     path: patches/dayjs@1.11.20.patch
   vocs@2.8.5:
-    hash: 0877ba0b3b9cc95e4fac0362c563038291536674597a4cfb1b121b05cb752893
+    hash: c2f1ad9028315f09c74b65c5bc8ab1f504c7a34c6bd7cedc5f2c69caa289ad23
     path: patches/vocs@2.8.5.patch
 
 importers:
@@ -143,7 +143,7 @@ importers:
         version: 2.54.6(typescript@6.0.3)(zod@4.4.3)
       vocs:
         specifier: 2.8.5
-        version: 2.8.5(patch_hash=0877ba0b3b9cc95e4fac0362c563038291536674597a4cfb1b121b05cb752893)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
+        version: 2.8.5(patch_hash=c2f1ad9028315f09c74b65c5bc8ab1f504c7a34c6bd7cedc5f2c69caa289ad23)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
       wagmi:
         specifier: 3.6.20
         version: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
@@ -9958,7 +9958,7 @@ snapshots:
       stripe: 19.3.0(@types/node@26.0.1)
       tidx.ts: 0.1.1(typescript@6.0.3)
       viem: 2.54.6(typescript@6.0.3)(zod@4.4.3)
-      vocs: 2.8.5(patch_hash=0877ba0b3b9cc95e4fac0362c563038291536674597a4cfb1b121b05cb752893)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
+      vocs: 2.8.5(patch_hash=c2f1ad9028315f09c74b65c5bc8ab1f504c7a34c6bd7cedc5f2c69caa289ad23)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -10406,7 +10406,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@2.8.5(patch_hash=0877ba0b3b9cc95e4fac0362c563038291536674597a4cfb1b121b05cb752893)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1)):
+  vocs@2.8.5(patch_hash=c2f1ad9028315f09c74b65c5bc8ab1f504c7a34c6bd7cedc5f2c69caa289ad23)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1)):
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## What changed

- Center consumer-authored pages mounted beneath the OpenAPI section, matching the rest of the documentation.
- Keep generated API reference groups full width so their request/response playgrounds retain the two-column layout.
- Add a wide-viewport regression test covering both layouts.

## Root cause

Vocs rendered every authored page under an OpenAPI mount with `content.width = "full"`. That mode is needed by generated endpoint reference pages, but ordinary guide pages such as Indexer API do not have a right-hand playground. The full-width gutter therefore collapsed to the sidebar and left the prose pinned to the left.

## Impact

Authored API documentation now starts in the standard centered readable area with the table of contents in the normal right gutter. Generated endpoint references are unchanged.

## Screenshots


### Before

<img width="1960" height="1000" alt="Before: Indexer API prose left-aligned beside the sidebar" src="https://github.com/user-attachments/assets/b6f6f26b-d3d4-4749-8ba8-47dbeaa4a116" />

### After

<img width="1960" height="1000" alt="After: Indexer API prose centered with the table of contents in the right gutter" src="https://github.com/user-attachments/assets/01a3b92c-ac1a-41ae-866f-7a55963fb5ee" />

### Generated API reference (right-hand panel preserved)

<img width="2269" height="1203" alt="After: generated API endpoint remains full width with the right-hand request and response panel" src="https://github.com/user-attachments/assets/195ac84f-d5eb-4c2c-8bb0-cb4c33884bd1" />

## Validation

- `pnpm build`
- `pnpm check:types`
- `pnpm exec biome check e2e/openapi-layout.test.ts`
- `CI=true pnpm exec playwright test e2e/openapi-layout.test.ts --project=chromium`