### PR TITLE
Center the API overview page

### DIFF
--- a/e2e/openapi-layout.test.ts
+++ b/e2e/openapi-layout.test.ts
@@ -2,9 +2,33 @@ import { expect, test } from '@playwright/test'
 
 test.use({ viewport: { height: 1000, width: 1960 } })
 
-test('centers authored API guides while preserving full-width endpoint references', async ({
+test('centers the API overview and authored guides while preserving full-width endpoint references', async ({
   page,
 }) => {
+  await page.goto('/docs/api')
+
+  const overviewLayout = page.locator('[data-layout][data-v-sidebar]')
+  const overview = overviewLayout.locator('[data-v-openapi-landing]')
+  const overviewMain = overviewLayout.locator(':scope > [data-v-main]')
+
+  await expect(overviewLayout).not.toHaveAttribute('data-v-content-width', 'full')
+  await expect(overview).toBeVisible()
+
+  const [overviewBox, overviewMainBox, overviewMainPaddingRight] = await Promise.all([
+    overview.boundingBox(),
+    overviewMain.boundingBox(),
+    overviewMain.evaluate((element) => Number.parseFloat(getComputedStyle(element).paddingRight)),
+  ])
+
+  expect(overviewBox).not.toBeNull()
+  expect(overviewMainBox).not.toBeNull()
+  if (!overviewBox || !overviewMainBox) throw new Error('Expected the API overview to render')
+
+  const overviewCenter = overviewBox.x + overviewBox.width / 2
+  const overviewReadableAreaCenter =
+    overviewMainBox.x + (overviewMainBox.width - overviewMainPaddingRight) / 2
+  expect(Math.abs(overviewCenter - overviewReadableAreaCenter)).toBeLessThanOrEqual(1)
+
   await page.goto('/docs/api/indexer-api')
 
   const guideLayout = page.locator('[data-layout][data-v-sidebar]')

--- a/patches/vocs@2.8.5.patch
+++ b/patches/vocs@2.8.5.patch
@@ -125,7 +125,7 @@ index 06cc466393643245bf0dfcc0c946e013c717a75c..e5b39e12c9e2017238a9744412943e2e
      // Overview / landing page.
      const title = props.title ?? props.frontmatter?.title ?? ir.info.title;
 -    return (_jsxs(OpenApiLayout, { frontmatter: { ...props.frontmatter, title }, width: "full", children: [_jsx("title", { children: title }), _jsx(ReferenceOverview, { ir: ir, intro: props.intro, endpoints: props.endpoints ? _jsx(Endpoints, { path: ir.path || undefined }) : undefined })] }));
-+    return (_jsx(OpenApiLayout, { documentTitle: resolveDocumentTitle(props.frontmatter, title), frontmatter: { ...props.frontmatter, title }, width: "full", children: _jsx(ReferenceOverview, { ir: ir, intro: props.intro, endpoints: props.endpoints ? _jsx(Endpoints, { path: ir.path || undefined }) : undefined }) }));
++    return (_jsx(OpenApiLayout, { documentTitle: resolveDocumentTitle(props.frontmatter, title), frontmatter: { ...props.frontmatter, title }, width: "default", children: _jsx(ReferenceOverview, { ir: ir, intro: props.intro, endpoints: props.endpoints ? _jsx(Endpoints, { path: ir.path || undefined }) : undefined }) }));
 +}
 +function resolveDocumentTitle(frontmatter, fallback) {
 +    const seoTitle = typeof frontmatter?.seoTitle === 'string' ? frontmatter.seoTitle.trim() : '';
@@ -349,7 +349,7 @@ index 939c937581ec434975aee43e7284c6c2d48add93..4622655fa2c046435180c35f012b6a31
 +    <OpenApiLayout
 +      documentTitle={resolveDocumentTitle(props.frontmatter, title)}
 +      frontmatter={{ ...props.frontmatter, title }}
-+      width="full"
++      width="default"
 +    >
        <ReferenceOverview
          ir={ir}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ patchedDependencies:
     hash: 47bfcf62e3c84ba85d881815422a02e23f372df46bddb9b022eb3705361fd165
     path: patches/dayjs@1.11.20.patch
   vocs@2.8.5:
-    hash: c2f1ad9028315f09c74b65c5bc8ab1f504c7a34c6bd7cedc5f2c69caa289ad23
+    hash: 4f406d690d5b460539df91b69534bd9bd4ca6538d6954a74e17b75710726b327
     path: patches/vocs@2.8.5.patch
 
 importers:
@@ -143,7 +143,7 @@ importers:
         version: 2.54.6(typescript@6.0.3)(zod@4.4.3)
       vocs:
         specifier: 2.8.5
-        version: 2.8.5(patch_hash=c2f1ad9028315f09c74b65c5bc8ab1f504c7a34c6bd7cedc5f2c69caa289ad23)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
+        version: 2.8.5(patch_hash=4f406d690d5b460539df91b69534bd9bd4ca6538d6954a74e17b75710726b327)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
       wagmi:
         specifier: 3.6.20
         version: 3.6.20(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.6(typescript@6.0.3)(zod@4.4.3))
@@ -9958,7 +9958,7 @@ snapshots:
       stripe: 19.3.0(@types/node@26.0.1)
       tidx.ts: 0.1.1(typescript@6.0.3)
       viem: 2.54.6(typescript@6.0.3)(zod@4.4.3)
-      vocs: 2.8.5(patch_hash=c2f1ad9028315f09c74b65c5bc8ab1f504c7a34c6bd7cedc5f2c69caa289ad23)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
+      vocs: 2.8.5(patch_hash=4f406d690d5b460539df91b69534bd9bd4ca6538d6954a74e17b75710726b327)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -10406,7 +10406,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@2.8.5(patch_hash=c2f1ad9028315f09c74b65c5bc8ab1f504c7a34c6bd7cedc5f2c69caa289ad23)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1)):
+  vocs@2.8.5(patch_hash=4f406d690d5b460539df91b69534bd9bd4ca6538d6954a74e17b75710726b327)(@cfworker/json-schema@4.1.1)(@types/react@19.2.17)(@vue/compiler-sfc@3.5.38)(change-case@5.4.4)(esbuild@0.28.1)(idb-keyval@6.2.2)(mermaid@11.14.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.4)(rollup@4.60.1)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.28.1)):
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## What changed

- Center the OpenAPI overview/landing route, including the authored Tempo API overview at `/docs/api`.
- Keep generated endpoint group pages full width for their two-column request/response playgrounds.
- Extend the wide-viewport regression test to cover the overview, authored guide, and endpoint-reference layouts.

## Root cause

The earlier fix updated `OpenApiGuide`, which covers authored pages beneath the OpenAPI mount, but `/docs/api` is rendered through the separate `OpenApiPage` landing branch. That branch still explicitly requested `content.width = "full"`, collapsing the centering gutter even though the overview has no right-hand operation panel.

## Impact

The Tempo API overview now uses the same centered readable column as other single-column docs. Generated endpoint reference groups are unchanged.

## Screenshots

### Before

<img width="2496" height="1271" alt="Before: Tempo API overview left-aligned beside the sidebar" src="https://github.com/user-attachments/assets/8adf753c-507b-4eee-9389-25025dc4c7b4" />

### After

<img width="2269" height="1156" alt="After: Tempo API overview centered in the standard readable column" src="https://github.com/user-attachments/assets/e8d34bb6-2c80-47e1-946d-e6f44759d3b4" />

## Validation

- `pnpm build`
- `pnpm exec biome check e2e/openapi-layout.test.ts`
- `CI=true pnpm exec playwright test e2e/openapi-layout.test.ts --project=chromium`