### PR TITLE
Fix Developers page QA issues

### DIFF
--- a/e2e/developers-homepage.test.ts
+++ b/e2e/developers-homepage.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+
+test('renders the QA-approved homepage copy and footer targets', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page).toHaveTitle('Tempo Developers: Build on a Payments-First Blockchain')
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+    'content',
+    'Build payment applications on Tempo with stablecoin-native tokens, predictable fees, fast settlement, SDKs, APIs, and open-source developer tools.',
+  )
+  await expect(
+    page.getByRole('heading', {
+      level: 1,
+      name: 'Build on the blockchain engineered for payments',
+    }),
+  ).toBeVisible()
+
+  const footer = page.locator('footer')
+  await expect(footer.getByRole('link', { name: 'MPP' })).toHaveAttribute(
+    'href',
+    'https://mpp.dev/',
+  )
+  const openSourceLink = footer.getByRole('link', { name: 'Open source' })
+  await expect(openSourceLink).toHaveAttribute('href', '/#open-source')
+
+  await openSourceLink.click()
+  await expect(page).toHaveURL(/\/#open-source$/)
+  await expect
+    .poll(() =>
+      page.locator('#open-source').evaluate((element) => element.getBoundingClientRect().top),
+    )
+    .toBeLessThan(250)
+})
+
+test('scrolls to the lazy Open source section on direct fragment navigation', async ({ page }) => {
+  await page.goto('/#open-source')
+
+  const target = page.locator('#open-source')
+  await expect(target).toBeVisible()
+  await expect
+    .poll(() => target.evaluate((element) => Math.abs(element.getBoundingClientRect().top)))
+    .toBeLessThan(250)
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+})

--- a/e2e/html-response-size.test.ts
+++ b/e2e/html-response-size.test.ts
@@ -1,0 +1,36 @@
+import { Buffer } from 'node:buffer'
+import { expect, test } from '@playwright/test'
+
+test.skip(!process.env.CI, 'requires the production build output')
+
+const pages = [
+  { path: '/docs/protocol/transactions', maxBytes: 2_000_000, shiki: true },
+  { path: '/docs/guide/tempo-transaction', maxBytes: 2_000_000, shiki: true },
+  { path: '/docs/changelog', maxBytes: 1_000_000, shiki: false },
+] as const
+
+for (const page of pages) {
+  test(`${page.path} stays below its initial HTML budget`, async ({ request }) => {
+    const response = await request.get(page.path, {
+      headers: {
+        accept: 'text/html,application/xhtml+xml',
+        'user-agent': 'Mozilla/5.0 Chrome/140 Safari/537.36',
+      },
+    })
+    expect(response.status()).toBe(200)
+    expect(response.headers()['content-type']).toContain('text/html')
+
+    const html = await response.text()
+    expect(Buffer.byteLength(html)).toBeLessThan(page.maxBytes)
+
+    if (page.shiki) {
+      expect(html).toContain('data-shiki-styles')
+      expect((html.match(/--shiki-light/g) ?? []).length).toBeLessThan(100)
+      expect(html).toContain('light-dark(')
+      expect(html).toContain('twoslash-hover')
+    } else {
+      expect(html.match(/bodyHtml/g) ?? []).toHaveLength(20)
+      expect(html).toContain('https://github.com/tempoxyz/tempo/releases')
+    }
+  })
+}

--- a/e2e/seo-head.test.ts
+++ b/e2e/seo-head.test.ts
@@ -44,9 +44,9 @@ const cases: {
 }[] = [
   {
     path: '/',
-    title: 'Tempo developers',
-    ogTitle: 'Tempo developers',
-    descriptionIncludes: 'payments-first Layer 1 blockchain',
+    title: 'Tempo Developers: Build on a Payments-First Blockchain',
+    ogTitle: 'Tempo Developers: Build on a Payments-First Blockchain',
+    descriptionIncludes: 'stablecoin-native tokens',
     ogImageIncludes: '/og-docs.png',
   },
   {

--- a/src/lib/compact-shiki-styles.test.ts
+++ b/src/lib/compact-shiki-styles.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { rehypeCompactShikiStyles } from './compact-shiki-styles'
+
+describe('rehypeCompactShikiStyles', () => {
+  it('deduplicates inline styles inside Shiki markup', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        { type: 'mdxjsEsm', value: "import { Tabs } from 'vocs/components'" },
+        {
+          type: 'element',
+          tagName: 'pre',
+          properties: { class: 'shiki shiki-themes', style: 'background:#fff;color:#111' },
+          children: [
+            {
+              type: 'element',
+              tagName: 'code',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'span',
+                  properties: { style: 'color:light-dark(#111, #eee);--shiki-light:#111' },
+                  children: [{ type: 'text', value: 'const' }],
+                },
+                {
+                  type: 'element',
+                  tagName: 'span',
+                  properties: { style: 'color:light-dark(#111, #eee);--shiki-light:#111' },
+                  children: [{ type: 'text', value: ' value' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'element',
+          tagName: 'div',
+          properties: { style: 'color:red' },
+          children: [],
+        },
+      ],
+    }
+
+    rehypeCompactShikiStyles()(tree)
+
+    const styleRegistry = tree.children[1]
+    const pre = tree.children[2]
+    const spans = pre.children?.[0]?.children ?? []
+
+    expect(styleRegistry).toMatchObject({
+      type: 'element',
+      tagName: 'style',
+      properties: { 'data-shiki-styles': '' },
+    })
+    expect(styleRegistry.children?.[0]?.value?.match(/color:light-dark/g)).toHaveLength(1)
+    expect(pre.properties?.style).toBeUndefined()
+    expect(spans[0]?.properties?.style).toBeUndefined()
+    expect(spans[0]?.properties?.class).toEqual(spans[1]?.properties?.class)
+    expect(tree.children[3]?.properties?.style).toBe('color:red')
+  })
+
+  it('does not add a registry when the page has no Shiki markup', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          properties: { style: 'color:red' },
+          children: [{ type: 'text', value: 'Tempo' }],
+        },
+      ],
+    }
+
+    rehypeCompactShikiStyles()(tree)
+
+    expect(tree.children).toHaveLength(1)
+    expect(tree.children[0]?.properties?.style).toBe('color:red')
+  })
+})

--- a/src/lib/compact-shiki-styles.ts
+++ b/src/lib/compact-shiki-styles.ts
@@ -1,0 +1,90 @@
+type HastNode = {
+  type: string
+  tagName?: string
+  value?: string
+  properties?: Record<string, unknown>
+  children?: HastNode[]
+}
+
+type HastRoot = HastNode & { children: HastNode[] }
+
+function classNames(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((item): item is string => typeof item === 'string')
+  if (typeof value === 'string') return value.split(/\s+/).filter(Boolean)
+  return []
+}
+
+function styleClassName(style: string): string {
+  let high = 0xdeadbeef
+  let low = 0x41c6ce57
+
+  for (let index = 0; index < style.length; index += 1) {
+    const code = style.charCodeAt(index)
+    high = Math.imul(high ^ code, 2_654_435_761)
+    low = Math.imul(low ^ code, 1_597_334_677)
+  }
+
+  high =
+    Math.imul(high ^ (high >>> 16), 2_246_822_507) ^ Math.imul(low ^ (low >>> 13), 3_266_489_909)
+  low =
+    Math.imul(low ^ (low >>> 16), 2_246_822_507) ^ Math.imul(high ^ (high >>> 13), 3_266_489_909)
+
+  return `s-${(high >>> 0).toString(36)}${(low >>> 0).toString(36)}`
+}
+
+function compactNodeStyles(
+  node: HastNode,
+  inheritedShikiContext: boolean,
+  styles: Map<string, string>,
+) {
+  const properties = node.properties
+  const nodeClasses = [...classNames(properties?.class), ...classNames(properties?.className)]
+  const shikiContext = inheritedShikiContext || nodeClasses.includes('shiki')
+
+  if (shikiContext && properties && typeof properties.style === 'string') {
+    const style = properties.style.trim()
+    if (style) {
+      const className = styleClassName(style)
+      const registeredStyle = styles.get(className)
+
+      if (registeredStyle && registeredStyle !== style) {
+        throw new Error(`Shiki style hash collision for ${className}`)
+      }
+
+      styles.set(className, style)
+      if ('className' in properties) properties.className = [...nodeClasses, className]
+      else properties.class = [...nodeClasses, className].join(' ')
+      delete properties.style
+    }
+  }
+
+  for (const child of node.children ?? []) compactNodeStyles(child, shikiContext, styles)
+}
+
+/**
+ * Replaces repeated Shiki inline styles with deterministic classes and one
+ * page-level style registry. Vocs otherwise serializes the same light/dark
+ * token colors thousands of times into the initial React Flight response.
+ */
+export function rehypeCompactShikiStyles() {
+  return (tree: HastRoot) => {
+    const styles = new Map<string, string>()
+    compactNodeStyles(tree, false, styles)
+    if (styles.size === 0) return
+
+    const css = [...styles]
+      .map(([className, style]) => `.${className}{${style.endsWith(';') ? style : `${style};`}}`)
+      .join('')
+
+    const styleNode: HastNode = {
+      type: 'element',
+      tagName: 'style',
+      properties: { 'data-shiki-styles': '' },
+      children: [{ type: 'text', value: css }],
+    }
+
+    let insertionIndex = 0
+    while (tree.children[insertionIndex]?.type === 'mdxjsEsm') insertionIndex += 1
+    tree.children.splice(insertionIndex, 0, styleNode)
+  }
+}

--- a/src/marketing/app/_components/Footer.tsx
+++ b/src/marketing/app/_components/Footer.tsx
@@ -62,7 +62,7 @@ const columns: FooterColumn[] = [
   {
     header: 'Libraries',
     links: [
-      { label: 'MPP', href: 'https://github.com/tempoxyz/mpp' },
+      { label: 'MPP', href: 'https://mpp.dev/' },
       { label: 'SDKs', href: TEMPO_SDK_DOCS_URL },
       { label: 'GitHub', href: 'https://github.com/tempoxyz' },
     ],
@@ -86,7 +86,7 @@ const columns: FooterColumn[] = [
     links: [
       { label: 'Blog', href: developersPath('/blog') },
       { label: 'Performance', href: developersPath('/performance') },
-      { label: 'Open source', href: `${developersPath('/')}#open-source` },
+      { label: 'Open source', href: developersPath('/#open-source') },
       { label: 'Contact', href: CONTACT_URL },
     ],
   },

--- a/src/marketing/app/_components/Hero.tsx
+++ b/src/marketing/app/_components/Hero.tsx
@@ -57,7 +57,7 @@ export default function Hero() {
       />
       <Reveal className="mx-auto flex w-full max-w-[860px] flex-col items-center text-center">
         <h1 className="max-w-[820px] font-sans text-[42px] text-foreground leading-[1.05] tracking-[-0.03em] antialiased sm:text-[56px] lg:text-[68px]">
-          Engineered for payments from the ground up
+          Build on the blockchain engineered for payments
         </h1>
         <p className="mt-5 max-w-[640px] font-sans text-[16px] text-foreground-secondary leading-[1.5] tracking-[0] lg:text-[18px]">
           Accept payments, issue stablecoins, and build blockchain applications that scale globally

--- a/src/marketing/app/_components/HomeBelowFold.tsx
+++ b/src/marketing/app/_components/HomeBelowFold.tsx
@@ -14,6 +14,34 @@ export default function HomeBelowFold() {
   const perfSectionRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
+    let frameId: number | undefined
+
+    const scrollToHashTarget = () => {
+      const hash = window.location.hash
+      if (!hash) return
+
+      let id = hash.slice(1)
+      try {
+        id = decodeURIComponent(id)
+      } catch {
+        // Keep the literal fragment when it contains malformed percent encoding.
+      }
+
+      const target = document.getElementById(id)
+      if (!target) return
+      if (frameId !== undefined) window.cancelAnimationFrame(frameId)
+      frameId = window.requestAnimationFrame(() => target.scrollIntoView())
+    }
+
+    scrollToHashTarget()
+    window.addEventListener('hashchange', scrollToHashTarget)
+    return () => {
+      window.removeEventListener('hashchange', scrollToHashTarget)
+      if (frameId !== undefined) window.cancelAnimationFrame(frameId)
+    }
+  }, [])
+
+  useEffect(() => {
     const section = perfSectionRef.current
     if (!section || loadPerfData) return
     if (!('IntersectionObserver' in window)) {

--- a/src/marketing/app/_lib/developersPaths.test.ts
+++ b/src/marketing/app/_lib/developersPaths.test.ts
@@ -11,6 +11,7 @@ describe('developersPath', () => {
     const { developersPath } = await import('./developersPaths')
 
     expect(developersPath('/')).toBe('/')
+    expect(developersPath('/#open-source')).toBe('/#open-source')
     expect(developersPath('/docs')).toBe('/docs')
     expect(developersPath('/build/tempo-transactions')).toBe('/build/tempo-transactions')
   })
@@ -20,9 +21,8 @@ describe('developersPath', () => {
     const { developersPath } = await import('./developersPaths')
 
     expect(developersPath('/')).toBe('/developers')
+    expect(developersPath('/#open-source')).toBe('/developers/#open-source')
     expect(developersPath('/docs')).toBe('/developers/docs')
-    expect(developersPath('/build/tempo-transactions')).toBe(
-      '/developers/build/tempo-transactions',
-    )
+    expect(developersPath('/build/tempo-transactions')).toBe('/developers/build/tempo-transactions')
   })
 })

--- a/src/marketing/index.html
+++ b/src/marketing/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tempo developers</title>
-    <meta name="description" content="Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Explore APIs, SDKs, wallets, and protocol documentation." />
+    <title>Tempo Developers: Build on a Payments-First Blockchain</title>
+    <meta name="description" content="Build payment applications on Tempo with stablecoin-native tokens, predictable fees, fast settlement, SDKs, APIs, and open-source developer tools." />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Tempo developers" />
+    <meta property="og:title" content="Tempo Developers: Build on a Payments-First Blockchain" />
     <meta property="og:site_name" content="Tempo" />
-    <meta property="og:description" content="Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Explore APIs, SDKs, wallets, and protocol documentation." />
-    <meta property="og:image" content="/api/og?title=Tempo%20developers&section=BUILD&v=3" />
+    <meta property="og:description" content="Build payment applications on Tempo with stablecoin-native tokens, predictable fees, fast settlement, SDKs, APIs, and open-source developer tools." />
+    <meta property="og:image" content="/api/og?title=Tempo%20Developers%3A%20Build%20on%20a%20Payments-First%20Blockchain&section=BUILD&v=3" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Tempo developers" />
-    <meta name="twitter:description" content="Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Explore APIs, SDKs, wallets, and protocol documentation." />
-    <meta property="twitter:image" content="/api/og?title=Tempo%20developers&section=BUILD&v=3" />
+    <meta name="twitter:title" content="Tempo Developers: Build on a Payments-First Blockchain" />
+    <meta name="twitter:description" content="Build payment applications on Tempo with stablecoin-native tokens, predictable fees, fast settlement, SDKs, APIs, and open-source developer tools." />
+    <meta property="twitter:image" content="/api/og?title=Tempo%20Developers%3A%20Build%20on%20a%20Payments-First%20Blockchain&section=BUILD&v=3" />
     <link rel="icon" href="/favicon-dark.svg" media="(prefers-color-scheme: dark)" type="image/svg+xml" />
     <link rel="icon" href="/favicon-light.svg" media="(prefers-color-scheme: light)" type="image/svg+xml" />
     <link rel="preload" href="/fonts/pilat/Pilat-Book.woff2" as="font" type="font/woff2" crossorigin />

--- a/src/marketing/routeMetadata.ts
+++ b/src/marketing/routeMetadata.ts
@@ -6,9 +6,9 @@ export type RouteMetadata = { title: string; description: string }
 
 export const routeMetadata: Record<string, RouteMetadata> = {
   '/': {
-    title: 'Tempo developers',
+    title: 'Tempo Developers: Build on a Payments-First Blockchain',
     description:
-      'Tempo is a payments-first Layer 1 blockchain incubated by Stripe and Paradigm. Explore APIs, SDKs, wallets, and protocol documentation.',
+      'Build payment applications on Tempo with stablecoin-native tokens, predictable fees, fast settlement, SDKs, APIs, and open-source developer tools.',
   },
   '/build': {
     title: 'Build on Tempo',

--- a/src/pages/docs/changelog.md
+++ b/src/pages/docs/changelog.md
@@ -1,3 +1,7 @@
 # Changelog
 
-::changelog
+Tempo publishes the 20 most recent network releases here.
+
+::changelog{limit=20}
+
+[Browse the full release history on GitHub](https://github.com/tempoxyz/tempo/releases).

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,5 +1,6 @@
 import { Changelog, defineConfig, Embedding, Reranker, Retriever } from 'vocs/config'
 import { resolveBaseUrl } from './src/lib/base-url'
+import { rehypeCompactShikiStyles } from './src/lib/compact-shiki-styles'
 import { docsRouteDestination, proxiedLegacyDocsRoutes } from './src/lib/docs-routing'
 import { docsStructuredDataHead } from './src/lib/docs-structured-data'
 import { createFeedbackAdapter } from './src/lib/feedback-adapter'
@@ -17,23 +18,35 @@ const tempoChangelog = Changelog.github({ prereleases: true, repo: 'tempoxyz/tem
 
 const changelog = Changelog.from({
   ...tempoChangelog,
-  async fetch(options) {
-    const releases = await tempoChangelog.fetch(options)
-    return releases.map((release) => {
-      // GitHub-generated release notes use HTML disclosures. Markdown output cannot retain
-      // them, so preserve their content as a heading instead.
-      const body = release.body
-        .replace(/<details\b[^>]*>/gi, '')
-        .replace(/<\/details>/gi, '')
-        .replace(/<summary\b[^>]*>([\s\S]*?)<\/summary>/gi, '\n\n#### $1\n\n')
-
-      return {
-        ...release,
-        // The changelog page owns the only H1. Release titles render as H2, so shift body
-        // headings down one level while preserving the release note's relative hierarchy.
-        body: demoteMarkdownHeadings(Changelog.stripDuplicateTitle({ body, title: release.title })),
-      }
+  async fetch(options = {}) {
+    const limit = options.limit ?? 50
+    // The repository also publishes package-only tags. Over-fetch, then retain
+    // the requested number of network releases for the public changelog.
+    const releases = await tempoChangelog.fetch({
+      ...options,
+      limit: Math.min(limit * 5, 100),
     })
+
+    return releases
+      .filter((release) => /^v\d+\.\d+\.\d+(?:[-+].*)?$/.test(release.version))
+      .slice(0, limit)
+      .map((release) => {
+        // GitHub-generated release notes use HTML disclosures. Markdown output cannot retain
+        // them, so preserve their content as a heading instead.
+        const body = release.body
+          .replace(/<details\b[^>]*>/gi, '')
+          .replace(/<\/details>/gi, '')
+          .replace(/<summary\b[^>]*>([\s\S]*?)<\/summary>/gi, '\n\n#### $1\n\n')
+
+        return {
+          ...release,
+          // The changelog page owns the only H1. Release titles render as H2, so shift body
+          // headings down one level while preserving the release note's relative hierarchy.
+          body: demoteMarkdownHeadings(
+            Changelog.stripDuplicateTitle({ body, title: release.title }),
+          ),
+        }
+      })
   },
 })
 
@@ -137,6 +150,7 @@ export default defineConfig({
     lastmod: (_path, { filePath, lastmod }) => (/\.mdx?$/.test(filePath) ? lastmod : false),
   },
   markdown: {
+    rehypePlugins: [rehypeCompactShikiStyles],
     outputRemarkPlugins: [plainMarkdownComponents],
   },
   baseUrl: baseUrl || undefined,


### PR DESCRIPTION
## Summary

- apply the QA-approved Developers homepage title, meta description, and H1
- fix the footer MPP destination and make the Open source fragment reliable on click and fresh navigation
- replace repeated Shiki inline styles with shared classes and add browser-HTML size budgets
- limit the changelog to 20 network releases while preserving a link to the full GitHub archive

## Why

Actions every recommendation in the [Developers Page QA sheet](https://docs.google.com/spreadsheets/d/1cuYacQI3jg_hKqmFfqwodmVHeBS77KvpWMjjkvsSCII/edit?gid=1372261427#gid=1372261427).

## Impact

Built browser HTML is now:

- `/docs/protocol/transactions`: 1,792,928 bytes, down from 2,349,781
- `/docs/guide/tempo-transaction`: 1,734,486 bytes, down from 2,291,339
- `/docs/changelog`: 601,036 bytes, down from 3,093,088

Syntax colors, Twoslash interactions, tabs, copy controls, and mobile code scrolling are preserved.

## Validation

- `pnpm check:types`
- `CI=true pnpm test`: 353 tests passed
- `CI=true pnpm build`
- targeted Playwright suite: 16 tests passed
- Biome and `git diff --check`
- responsive browser QA at 1440×900 and 390×844, including light/dark syntax colors and direct fragment navigation