### PR TITLE
fix(docs): resolve broken API reference links and legacy startReward references

### DIFF
--- a/src/pages/docs/api.mdx
+++ b/src/pages/docs/api.mdx
@@ -71,9 +71,9 @@ Create production and sandbox API keys in [Tempo API Console](https://console.te
 
 ## Common Tempo API workflows
 
-- **Track and reconcile a stablecoin payment.** Look up the [transaction and receipt](/docs/api/transactions), then inspect its [transaction activities](/docs/api/activities#list-transaction-activities) to confirm the token movement. Use [webhooks](/docs/api/webhooks) when your backend needs signed event callbacks.
-- **Monitor an account.** Read [balances](/docs/api/balances) and [activity](/docs/api/activities) to build payment history, treasury, or account views.
-- **Fund and exchange stablecoins.** Compare [funding quotes](/docs/api/funding/quotes) across supported chains and providers, then [create a transfer](/docs/api/funding/transfers) or [create a reusable deposit address](/docs/api/funding/deposit-addresses). Use [exchange quotes](/docs/api/exchange) to prepare unsigned approval and swap calls for you to sign and submit.
+- **Track and reconcile a stablecoin payment.** Look up the [transaction and receipt](/docs/api/transactions), then inspect its [transaction activities](/docs/api/reference#tag/activities) to confirm the token movement. Use [webhooks](/docs/api/reference#tag/webhooks) when your backend needs signed event callbacks.
+- **Monitor an account.** Read [balances](/docs/api/reference#tag/balances) and [activity](/docs/api/reference#tag/activities) to build payment history, treasury, or account views.
+- **Fund and exchange stablecoins.** Compare [funding quotes](/docs/api/reference#tag/funding) across supported chains and providers, then [create a transfer](/docs/api/reference#tag/funding) or [create a reusable deposit address](/docs/api/reference#tag/deposit-addresses). Use [exchange quotes](/docs/api/reference#tag/exchange) to prepare unsigned approval and swap calls for you to sign and submit.
 - **Sponsor transaction fees.** Use the [Fee Payer API](/docs/api/fee-payer) to apply sponsorship policy and fill, sponsor, and broadcast user transactions.
 - **Query custom payment data.** Use the [Indexer API](/docs/api/indexer-api) for read-only SQL across indexed blocks, transactions, receipts, logs, transfers, and exchange data.
 - **Prepare a production integration.** Create projects and keys in [Tempo API Console](/docs/api/console), then review [authentication](/docs/api/authentication), [rate limits](/docs/api/rate-limits), and [errors](/docs/api/errors).

--- a/src/pages/docs/api/faq.mdx
+++ b/src/pages/docs/api/faq.mdx
@@ -21,15 +21,15 @@ Most read endpoints work without credentials at the public rate limit. Use [MPP 
 
 ## How do I monitor a stablecoin payment?
 
-Read the [transaction and receipt](/docs/api/transactions) to follow execution, then inspect its [transaction activities](/docs/api/activities#list-transaction-activities) to identify the stablecoin movement. Configure [webhooks](/docs/api/webhooks) for signed callbacks instead of polling, and review delivery history when you need to audit an attempt.
+Read the [transaction and receipt](/docs/api/transactions) to follow execution, then inspect its [transaction activities](/docs/api/reference#tag/activities) to identify the stablecoin movement. Configure [webhooks](/docs/api/reference#tag/webhooks) for signed callbacks instead of polling, and review delivery history when you need to audit an attempt.
 
 ## Does the Tempo Funding API execute a transfer?
 
-No. The [Funding API](/docs/api/funding/quotes) compares live quotes across supported chains and providers, but it does not execute a transfer. Execute the chosen transfer separately.
+No. The [Funding API](/docs/api/reference#tag/funding) compares live quotes across supported chains and providers, but it does not execute a transfer. Execute the chosen transfer separately.
 
 ## Does the Tempo Exchange API submit a transaction?
 
-No. The [Exchange API](/docs/api/exchange) creates a priced preview on Tempo's native stablecoin DEX and returns unsigned approval and swap calls. Sign and submit the returned calls to complete the exchange.
+No. The [Exchange API](/docs/api/reference#tag/exchange) creates a priced preview on Tempo's native stablecoin DEX and returns unsigned approval and swap calls. Sign and submit the returned calls to complete the exchange.
 
 ## Where do I manage Tempo API projects and keys?
 

--- a/src/pages/docs/api/indexer-api.mdx
+++ b/src/pages/docs/api/indexer-api.mdx
@@ -15,7 +15,7 @@ import { TidxQuery } from '../../../components/TidxQuery'
 
 Use the Indexer API to run read-only SQL against Tempo chain data without operating your own indexing pipeline.
 
-The Tempo API exposes [`GET /v1/indexer/query`](/docs/api/indexer), backed by [`tidx`](https://github.com/tempoxyz/tidx). The indexer continuously follows Tempo, stores blocks, transactions, logs, and receipts, and maintains analytics tables for common reads.
+The Tempo API exposes [`GET /v1/indexer/query`](/docs/api/reference#tag/indexer), backed by [`tidx`](https://github.com/tempoxyz/tidx). The indexer continuously follows Tempo, stores blocks, transactions, logs, and receipts, and maintains analytics tables for common reads.
 
 ## Querying the Indexer API
 
@@ -28,7 +28,7 @@ curl --get "https://api.tempo.xyz/v1/indexer/query" \
 
 Requests use the same [authentication](/docs/api/authentication), [rate limits](/docs/api/rate-limits), and `RateLimit-*` headers as the rest of the Tempo API. Use public access for low-volume queries, MPP for pay-per-request access, or an API key for a higher dedicated quota.
 
-See the [indexer query reference](/docs/api/indexer) for the complete request and response contract, live streaming, and error behavior.
+See the [indexer query reference](/docs/api/reference#tag/indexer) for the complete request and response contract, live streaming, and error behavior.
 
 <span id="how-tidx-indexes-tempo-data" />
 

--- a/src/pages/docs/protocol/fees/spec-fee.mdx
+++ b/src/pages/docs/protocol/fees/spec-fee.mdx
@@ -100,7 +100,7 @@ The protocol checks for token preferences in five ways, with this order of prece
 
 1. Transaction (set by the `fee_token` field of the transaction)
 2. Account (set on the FeeManager contract by the `fee_payer` of the transaction)
-3. TIP-20 contract (if the transaction is calling `transfer`, `transferWithMemo`, or `startReward` on a TIP-20 token contract, the transaction uses that token as its fee token)
+3. TIP-20 contract (if the transaction is calling `transfer` or `transferWithMemo` on a TIP-20 token contract, the transaction uses that token as its fee token)
 4. Stablecoin DEX (for certain swap calls, the transaction uses the `tokenIn` argument as its fee token)
 5. PathUSD (as a fallback)
 
@@ -136,7 +136,6 @@ If the top-level call of a transaction is to one of the following functions on a
 
 * `transfer(address to, uint256 amount)`
 * `transferWithMemo(address to, uint256 amount, bytes32 memo)`
-* `startReward(uint256 amount, uint32 seconds_)`
 
 then that TIP-20 token is used as the user's fee token for that transaction (unless there is a preference specified at the [transaction](#transaction-level) or [account](#account-level) level).
 

--- a/src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx
+++ b/src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx
@@ -695,7 +695,7 @@ When a limited Access Key attempts to call any mutable keychain function:
 
 The protocol tracks and enforces spending limits for TIP20 token transfers:
 
-**Scope:** Only TIP20 `transfer()`, `transferWithMemo()`, `approve()`, and `startReward()` calls are tracked
+**Scope:** Only TIP20 `transfer()`, `transferWithMemo()`, and `approve()` calls are tracked
 - Spending limits only apply when `msg.sender == tx.origin` (direct EOA calls)
 - When a contract makes transfers on behalf of the user, spending limits do NOT apply (e.g., `transferFrom()`)
 - Native value transfers are NOT limited
@@ -703,7 +703,7 @@ The protocol tracks and enforces spending limits for TIP20 token transfers:
 - Other asset types are NOT limited
 
 **Tracking:** During transaction execution, when an Access Key's transaction directly calls TIP20 methods:
-1. Protocol intercepts `transfer(to, amount)`, `transferWithMemo()`, `approve(spender, amount)`, and `startReward()` calls
+1. Protocol intercepts `transfer(to, amount)`, `transferWithMemo()`, and `approve(spender, amount)` calls
 2. For `transfer`/`transferWithMemo`, the full `amount` is checked against the remaining limit
 3. For `approve`, only **increases** in approval (new approval minus previous allowance) are checked and counted against the limit
 4. Queries: `getRemainingLimitWithPeriod(account, keyId, token)`, which returns `(remaining, periodEnd)` and reflects any periodic rollover

--- a/src/pages/docs/server/relay-handler.mdx
+++ b/src/pages/docs/server/relay-handler.mdx
@@ -21,7 +21,7 @@ const handler = Handler.relay({
 })
 ```
 
-By default, the relay configures Viem clients for Tempo mainnet and testnet and loads fee-token candidates from the [Tempo API verified-token list](/docs/api/verified-tokens#gettokenlist). Pass `apiKey` to authenticate the built-in RPC and verified-token requests. When you omit it, the clients use each chain's default Viem transport and the verified-token request is unauthenticated.
+By default, the relay configures Viem clients for Tempo mainnet and testnet and loads fee-token candidates from the [Tempo API verified-token list](/docs/api/reference#tag/tokens). Pass `apiKey` to authenticate the built-in RPC and verified-token requests. When you omit it, the clients use each chain's default Viem transport and the verified-token request is unauthenticated.
 
 :::info
 The built-in client defaults to mainnet when a request does not specify a chain. Use testnet chain ID `42431` with Sandbox API keys.
@@ -570,7 +570,7 @@ When you use [`Provider.relay`](https://accounts.tempo.xyz/docs/api/provider#rel
 - **Type:** `(chainId: number) => readonly Address[] | Promise<readonly Address[]>`
 - **Optional**
 
-Returns candidate token addresses for fee-token resolution. By default, the relay loads the [Tempo API verified-token list](/docs/api/verified-tokens#gettokenlist) for mainnet and testnet. Pass a resolver to replace these candidates. For additional chains, provide both `getClient` and `resolveTokens`.
+Returns candidate token addresses for fee-token resolution. By default, the relay loads the [Tempo API verified-token list](/docs/api/reference#tag/tokens) for mainnet and testnet. Pass a resolver to replace these candidates. For additional chains, provide both `getClient` and `resolveTokens`.
 
 ```ts
 const handler = Handler.relay({


### PR DESCRIPTION
### Summary

This PR addresses two areas of documentation integrity across the Tempo documentation site (\docs.tempo.xyz\):

1. **Resolves 16 Broken Internal API Links (\/docs/api/*\ 404 Routes)**:
   - Several pages (\src/pages/docs/api.mdx\, \src/pages/docs/api/faq.mdx\, \src/pages/docs/api/indexer-api.mdx\, \src/pages/docs/server/relay-handler.mdx\) previously referenced subroutes such as \/docs/api/activities\, \/docs/api/webhooks\, \/docs/api/balances\, \/docs/api/funding/quotes\, \/docs/api/funding/transfers\, \/docs/api/funding/deposit-addresses\, \/docs/api/exchange\, \/docs/api/indexer\, and \/docs/api/verified-tokens\.
   - These endpoints are hosted under the unified OpenAPI reference page (\/docs/api/reference\). All links are updated to their canonical OpenAPI tag anchors (\/docs/api/reference#tag/...\).

2. **Clarifies Legacy \startReward\ References in Protocol Specifications**:
   - \src/pages/docs/protocol/fees/spec-fee.mdx\: Removed deprecated \startReward\ from active TIP-20 fee-token inference method lists.
   - \src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx\: Removed \startReward\ from limited Access Key spending limit tracking scopes, matching current TIP-20 behavior post-T7/T8 upgrades.

Resolves #741

### Changes Made

- \src/pages/docs/api.mdx\: Updated 7 links in Common Workflows to canonical \/docs/api/reference#tag/*\ anchors.
- \src/pages/docs/api/faq.mdx\: Updated 4 links in FAQ answers to \/docs/api/reference#tag/*\.
- \src/pages/docs/api/indexer-api.mdx\: Updated \GET /v1/indexer/query\ and indexer reference links to \/docs/api/reference#tag/indexer\.
- \src/pages/docs/server/relay-handler.mdx\: Updated verified-token list links to \/docs/api/reference#tag/tokens\.
- \src/pages/docs/protocol/fees/spec-fee.mdx\: Omitted \startReward\ from TIP-20 fee preference detection.
- \src/pages/docs/protocol/transactions/spec-tempo-transaction.mdx\: Omitted \startReward\ from spending limit tracking.

### Verification

- Audited all internal markdown links across \src/pages/docs/\ to ensure zero broken routes.
- Verified that all OpenAPI tags match the operations declared in \eference.mdx\ and \ocs.config.ts\.
- Ensured formatting adheres to Conventional Commits and Vocs guidelines.