### PR TITLE
docs: categorize human authorization post as case study

### DIFF
--- a/blogs/human-authorization-in-agentic-workflows.md
+++ b/blogs/human-authorization-in-agentic-workflows.md
@@ -2,7 +2,7 @@
 title: "Human Authorization in Agentic Workflows"
 excerpt: "How Tempo enables AI-accelerated development securely"
 date: 2026-08-17
-category: technical
+category: case-studies
 ---
 
 At Tempo, we are building more workflows where software can move quickly on a person's behalf. That is useful, but it can also be risky.


### PR DESCRIPTION
## Summary

- Move the Human Authorization in Agentic Workflows post from Technical posts to Case studies.

## Testing

- `pnpm check:types`

Prompted by: tom