### PR TITLE
fix: preserve blog media paths under developers mount

### DIFF
--- a/src/marketing/blogPlugin.test.ts
+++ b/src/marketing/blogPlugin.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { makeBlogAssetUrlsMountSafe } from './blogPlugin'
+
+describe('makeBlogAssetUrlsMountSafe', () => {
+  it('keeps blog media under the current mount path', () => {
+    const html = [
+      '<img src="/blog/example.png">',
+      '<video><source src="/blog/example.mp4"></video>',
+      '<a href="/blog/example.mp4">Watch the video</a>',
+      '<a href="/docs">Read the docs</a>',
+    ].join('')
+
+    expect(makeBlogAssetUrlsMountSafe(html)).toBe(
+      [
+        '<img src="./example.png">',
+        '<video><source src="./example.mp4"></video>',
+        '<a href="./example.mp4">Watch the video</a>',
+        '<a href="/docs">Read the docs</a>',
+      ].join(''),
+    )
+  })
+})

--- a/src/marketing/blogPlugin.ts
+++ b/src/marketing/blogPlugin.ts
@@ -44,6 +44,12 @@ function inlineSvgImages(html: string): string {
   })
 }
 
+// Blog pages are mounted at /developers/blog in production and /blog in
+// previews. Relative media URLs preserve the active mount path in both places.
+export function makeBlogAssetUrlsMountSafe(html: string): string {
+  return html.replace(/(\b(?:src|href)=["'])\/blog\//g, '$1./')
+}
+
 const CATEGORY_SLUGS = ['network-upgrades', 'events', 'technical', 'case-studies']
 
 // ALL-CAPS markdown files (AGENTS.md, DIAGRAMS.md, …) are documentation for
@@ -148,7 +154,7 @@ async function renderPost(filename: string): Promise<SearchablePost> {
     )
   }
 
-  const html = inlineSvgImages(String(await processor.process(content)))
+  const html = makeBlogAssetUrlsMountSafe(inlineSvgImages(String(await processor.process(content))))
 
   return {
     slug,


### PR DESCRIPTION
## Summary

- Rewrite rendered `/blog/...` media URLs as mount-relative URLs.
- Preserve `/blog` paths in previews and `/developers/blog` paths on tempo.xyz.
- Add a regression test covering image, video source, and fallback link URLs.

## Production evidence

- Images currently request `/blog/...` and return `404 text/html`.
- Videos currently receive the same HTML 404 page as `206 text/html`.
- The corresponding `/developers/blog/...` assets return `200 image/png` and `200 video/mp4`.

## Testing

- `pnpm exec biome check src/marketing/blogPlugin.ts src/marketing/blogPlugin.test.ts`
- `pnpm check:types`
- Generated virtual blog data contains mount-safe paths for every Voight-Kampff image and video
- Vitest startup is locally blocked by the existing external OpenAPI fetch timeout; CI will run the committed regression test

Prompted by: tom