### PR TITLE
docs: list Chainlink CCIP as a bridge

### DIFF
--- a/src/pages/docs/ecosystem/bridges.mdx
+++ b/src/pages/docs/ecosystem/bridges.mdx
@@ -20,6 +20,12 @@ Bridge assets to Tempo through the [Across app](https://app.across.to/) and expl
 
 Get started with the [Tempo Bungee guide](/docs/guide/bridge-bungee), read the [Bungee docs](https://docs.bungee.exchange/), or try the [Bungee app](https://bungee.exchange).
 
+## Chainlink CCIP
+
+[Chainlink Cross-Chain Interoperability Protocol (CCIP)](https://chain.link/cross-chain) enables applications to transfer tokens and messages across blockchains. CCIP connects Tempo to supported networks through active cross-chain lanes.
+
+View supported tokens, lanes, fees, and contract configuration in the [Tempo Mainnet CCIP Directory](https://docs.chain.link/ccip/directory/mainnet/chain/tempo-mainnet).
+
 ## LayerZero
 
 [LayerZero](https://layerzero.network) is an omnichain interoperability protocol that enables secure, low-level message passing between blockchains. Stargate is the global interface for value movement onchain. Within Tempo, Stargate enables native, 1&#58;1 asset transfers into and out of the ecosystem.

--- a/src/pages/docs/guide/getting-funds.mdx
+++ b/src/pages/docs/guide/getting-funds.mdx
@@ -58,6 +58,7 @@ Use one of these supported bridges to move assets to Tempo:
 When you bridge USDC with LayerZero (Stargate), it appears on Tempo as USDC.e. Stargate does not charge its transfer fee on the direct route between Ethereum and Tempo, but other routes can vary, so check the quote before sending.
 
 - **[LayerZero (Stargate)](/docs/guide/bridge-layerzero)**: Bridge USDC to and from Tempo via Stargate. See the [full bridging guide](/docs/guide/bridge-layerzero) for contract addresses, code examples, and EndpointDollar details.
+- **[Chainlink CCIP](https://docs.chain.link/ccip/directory/mainnet/chain/tempo-mainnet)**: Transfer supported tokens to and from Tempo. Check the CCIP Directory for current tokens, lanes, fees, and contract configuration.
 - **[Squid](https://app.squidrouter.com/)**: Swap and bridge assets to Tempo in one flow.
 - **[Relay](https://relay.link/)**: Bridge assets to Tempo with low fees.
 - **[Across](https://app.across.to/)**: Bridge assets to Tempo quickly with competitive fees.

--- a/src/pages/docs/quickstart/developer-tools.mdx
+++ b/src/pages/docs/quickstart/developer-tools.mdx
@@ -81,6 +81,12 @@ Bridge assets to Tempo through the [Across app](https://app.across.to/) and expl
 
 Get started with the [Bungee docs](https://docs.bungee.exchange/) or try the [Bungee app](https://bungee.exchange).
 
+### Chainlink CCIP
+
+[Chainlink Cross-Chain Interoperability Protocol (CCIP)](https://chain.link/cross-chain) enables applications to transfer tokens and messages across blockchains. CCIP connects Tempo to supported networks through active cross-chain lanes.
+
+View supported tokens, lanes, fees, and contract configuration in the [Tempo Mainnet CCIP Directory](https://docs.chain.link/ccip/directory/mainnet/chain/tempo-mainnet).
+
 ### Relay
 
 [Relay](https://relay.link) provides instant cross-chain bridging and transaction execution. Relay enables users and applications to move assets to Tempo from other chains with fast finality and low fees, powered by a network of relayers that fill orders on the destination chain.


### PR DESCRIPTION
## Summary
- add Chainlink CCIP to the bridges and exchanges ecosystem page
- add CCIP to the bridge options on the getting funds guide
- add CCIP to the Bridges section of the developer tools page
- link to the active Tempo Mainnet CCIP Directory for current tokens, lanes, fees, and contract configuration

## Validation
- `pnpm check:types`
- `pnpm check:anchors`
- `pnpm build`
- verified both Chainlink links return HTTP 200