### PR TITLE
docs(ecosystem): add Gem Wallet as a self-custodial Tempo wallet

### DIFF
--- a/src/pages/docs/ecosystem/wallets.mdx
+++ b/src/pages/docs/ecosystem/wallets.mdx
@@ -105,6 +105,12 @@ Get started at [Bitget Wallet](https://web3.bitget.com).
 
 Download Bridge Wallet from the [Mt Pelerin website](https://www.mtpelerin.com/bridge-wallet).
 
+### Gem Wallet
+
+[Gem Wallet](https://gemwallet.com) is an open-source, self-custodial mobile wallet for iOS and Android with native Tempo support. Users can store, send, receive, and swap Tempo assets.
+
+Download Gem Wallet from the [Gem Wallet website](https://gemwallet.com) or explore its [open-source repository](https://github.com/gemwalletcom/wallet).
+
 ### OKX Wallet
 
 [OKX Wallet](https://www.okx.com/web3) is a self-custodial multi-chain wallet with native Tempo support. Users can store, swap, and manage Tempo-based assets, with built-in DEX aggregation and DApp connectivity.


### PR DESCRIPTION
## Summary

- add Gem Wallet to the Self-Custodial wallet ecosystem section
- link to the Gem Wallet website and open-source repository
- document native Tempo support for storing, sending, receiving, and swapping Tempo assets

## Integration evidence

Gem Wallet added Tempo support in [`a226cade`](https://github.com/gemwalletcom/wallet/commit/a226cade5f681218649cf75bbe26be07c3977329), including core, swap, iOS, and Android support.

## Validation

- TypeScript type check passed
- generic-heading scan passed
- `git diff --check` passed

@juandolealt Could you help review and merge this ecosystem wallet addition?