### PR TITLE
docs: mark T10 active on testnet

### DIFF
--- a/src/pages/docs/protocol/upgrades/t10.mdx
+++ b/src/pages/docs/protocol/upgrades/t10.mdx
@@ -10,7 +10,7 @@ T10 makes zone creation a native Tempo protocol operation. It enshrines `ZoneFac
 For most partners, T10 matters if you operate a node, create Tempo Zones, or integrate directly with `ZoneFactory` and `ZonePortal`.
 
 :::info[T10 status]
-T10 is scheduled for testnet on August 20, 2026 at 14:00 UTC and mainnet on August 21, 2026 at 14:00 UTC. The forthcoming v1.13.0 release is required; see the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
+T10 is active on testnet as of August 20, 2026 at 14:00 UTC. Mainnet activation is scheduled for August 21, 2026 at 14:00 UTC. The v1.13.0 release is required; see the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
 :::
 
 ## Timeline
@@ -20,7 +20,7 @@ T10 is scheduled for testnet on August 20, 2026 at 14:00 UTC and mainnet on Augu
 | Testnet | August 20, 2026 at 14:00 UTC | `1787234400` |
 | Mainnet | August 21, 2026 at 14:00 UTC | `1787320800` |
 
-Node operators must run v1.13.0 before T10 activates on their network to stay synced.
+Node operators must run v1.13.0 before T10 activates on mainnet to stay synced.
 
 ## T10 upgrade overview
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -909,7 +909,7 @@ export default defineConfig({
             items: [
               {
                 text: 'T10',
-                badge: { text: 'Planned', variant: 'note' as const },
+                badge: { text: 'Testnet', variant: 'note' as const },
                 link: '/docs/protocol/upgrades/t10',
               },
               {


### PR DESCRIPTION
## Summary

- Mark T10 as active on testnet on the upgrade page.
- Change the T10 navigation badge from Planned to Testnet.

## Validation

- `pnpm check:types`
- `node scripts/guard-vocs-config.mjs`
- `pnpm build` *(blocked during Vocs OpenAPI fetching by an external connection timeout after type checking passed)*

Prompted by: @max-digi