### PR TITLE
docs: mark T10 active on mainnet

### DIFF
--- a/src/pages/docs/guide/node/network-upgrades.mdx
+++ b/src/pages/docs/guide/node/network-upgrades.mdx
@@ -15,7 +15,7 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 
 | Release | Date | Network | Description | Priority |
 |---------|------|---------|-------------|----------|
-| v1.13.0 | Aug 17, 2026 | Testnet + Mainnet | Required for T10. Enshrines ZoneFactory, assigns deterministic ZonePortal addresses, and installs canonical shared zone runtimes. Testnet activation is scheduled for Aug 20, 2026; mainnet activation is scheduled for Aug 21, 2026. | <Badge variant="red">Required</Badge> |
+| [v1.13.0](https://github.com/tempoxyz/tempo/releases/tag/v1.13.0) | Aug 17, 2026 | Testnet + Mainnet | Required for T10. Enshrines ZoneFactory, assigns deterministic ZonePortal addresses, and installs canonical shared zone runtimes. T10 is active on testnet and mainnet. | <Badge variant="red">Required</Badge> |
 | [v1.12.0](https://github.com/tempoxyz/tempo/releases/tag/v1.12.0) | Aug 3, 2026 | Testnet + Mainnet | Required for T9. Adds TIP-403 storage for TIP-20 token policy bindings used by zones/provable contract flows, plus a targeted migration path for existing tokens that need one. T9 is active on testnet and mainnet. | <Badge variant="red">Required</Badge> |
 | [v1.11.0](https://github.com/tempoxyz/tempo/releases/tag/v1.11.0) | Jul 22, 2026 | Testnet + Mainnet | Required for T8. Includes current committee state, FeeAMM policy changes, versioned Stablecoin DEX order storage, DEX V2Order support, and final TIP-20 rewards deprecation. T8 is active on testnet and mainnet. | <Badge variant="red">Required</Badge> |
 | [v1.10.1](https://github.com/tempoxyz/tempo/releases/tag/v1.10.1) | Jun 29, 2026 | Testnet + Mainnet | Required for T7; includes storage credits for DEX order storage and TIP-20 channel storage, dynamic base fee behavior, and TIP-20 rewards deprecation. | <Badge variant="red">Required</Badge> |
@@ -45,12 +45,12 @@ For detailed release notes and binaries, see the [Changelog](/docs/changelog).
 | **Scope** | Native ZoneFactory, deterministic ZonePortal accounts, and protocol-managed shared zone runtimes |
 | **TIPs** | [Enshrined ZoneFactory](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1091.md) |
 | **Details** | [T10 network upgrade](/docs/protocol/upgrades/t10) |
-| **Release** | v1.13.0 (forthcoming) |
-| **Testnet** | Scheduled: August 20, 2026 at 14:00 UTC (`1787234400`) |
-| **Mainnet** | Scheduled: August 21, 2026 at 14:00 UTC (`1787320800`) |
+| **Release** | [v1.13.0](https://github.com/tempoxyz/tempo/releases/tag/v1.13.0) |
+| **Testnet** | Live: August 20, 2026 at 14:00 UTC (`1787234400`) |
+| **Mainnet** | Live: August 21, 2026 at 14:00 UTC (`1787320800`) |
 | **Priority** | <Badge variant="red">Required</Badge> |
 
-T10 is scheduled for testnet on August 20, 2026 and mainnet on August 21, 2026. Node operators must upgrade to v1.13.0 before activation once the release is available.
+T10 is active on testnet and mainnet and supported by [v1.13.0](https://github.com/tempoxyz/tempo/releases/tag/v1.13.0), published on August 17, 2026. Node operators were required to run the T10-compatible release before activation to stay synced.
 
 ---
 

--- a/src/pages/docs/protocol/upgrades/t10.mdx
+++ b/src/pages/docs/protocol/upgrades/t10.mdx
@@ -10,17 +10,17 @@ T10 makes zone creation a native Tempo protocol operation. It enshrines `ZoneFac
 For most partners, T10 matters if you operate a node, create Tempo Zones, or integrate directly with `ZoneFactory` and `ZonePortal`.
 
 :::info[T10 status]
-T10 is active on testnet as of August 20, 2026 at 14:00 UTC. Mainnet activation is scheduled for August 21, 2026 at 14:00 UTC. The v1.13.0 release is required; see the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
+T10 is active on testnet and mainnet. Release [v1.13.0](https://github.com/tempoxyz/tempo/releases/tag/v1.13.0) is required for T10; see the [Network Upgrades and Releases table](/docs/guide/node/network-upgrades#node-operator-updates) for the current node-operator release status.
 :::
 
 ## Timeline
 
 | Network | Date | Unix timestamp |
 |---------|------|----------------|
-| Testnet | August 20, 2026 at 14:00 UTC | `1787234400` |
-| Mainnet | August 21, 2026 at 14:00 UTC | `1787320800` |
+| Testnet | Live: August 20, 2026 at 14:00 UTC | `1787234400` |
+| Mainnet | Live: August 21, 2026 at 14:00 UTC | `1787320800` |
 
-Node operators must run v1.13.0 before T10 activates on mainnet to stay synced.
+Node operators were required to run [v1.13.0](https://github.com/tempoxyz/tempo/releases/tag/v1.13.0) before activation to stay synced.
 
 ## T10 upgrade overview
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -909,12 +909,11 @@ export default defineConfig({
             items: [
               {
                 text: 'T10',
-                badge: { text: 'Testnet', variant: 'note' as const },
+                badge: { text: 'Latest', variant: 'info' as const },
                 link: '/docs/protocol/upgrades/t10',
               },
               {
                 text: 'T9',
-                badge: { text: 'Latest', variant: 'info' as const },
                 link: '/docs/protocol/upgrades/t9',
               },
               {


### PR DESCRIPTION
## Summary

- mark T10 live on testnet and mainnet across the upgrade page and node upgrade index
- link the v1.13.0 release and use the established T8/T9 live formatting
- move the Latest navigation badge from T9 to T10

## Validation

- `pnpm check:types`
- `git diff --check`
- `pnpm build` *(blocked during Vocs OpenAPI generation by an external fetch timeout)*

Prompted by: @max-digi