### PR TITLE
fix: refine performance chart axis labels

### DIFF
--- a/src/marketing/app/performance/_components/TpsTrendChart.tsx
+++ b/src/marketing/app/performance/_components/TpsTrendChart.tsx
@@ -79,7 +79,7 @@ export default function TpsTrendChart({
     number,
     number,
   ]
-  const yTicks = ticks(yDomain[0], yDomain[1], 4)
+  const yTicks = ticks(yDomain[0], yDomain[1], 5)
 
   const xAt = scaleLinear([0, n - 1], [PAD.l, Math.max(width - PAD.r, PAD.l + 1)])
   const yAt = scaleLinear(yDomain, [height - PAD.b, PAD.t])

--- a/src/marketing/app/performance/_components/TpsTrendChartFrame.tsx
+++ b/src/marketing/app/performance/_components/TpsTrendChartFrame.tsx
@@ -23,7 +23,8 @@ export const TPS_CHART_DEFAULT_TICKS = [10_000, 15_000, 20_000, 25_000]
 function formatTpsTick(value: number, yTicks: number[]) {
   const tickStep = yTicks.length >= 2 ? Math.abs(yTicks[1] - yTicks[0]) : 1000
   const precision = tickStep >= 1000 ? 0 : tickStep % 100 === 0 ? 1 : 2
-  return `${(value / 1000).toFixed(precision)}K`
+  const compactValue = (value / 1000).toFixed(precision).replace(/\.?0+$/, '')
+  return `${compactValue}K`
 }
 
 export function TpsChartGrid({


### PR DESCRIPTION
## Summary

- increase the weekly TPS chart from two sparse Y-axis ticks to roughly five
- remove redundant trailing zeros from compact labels, such as `9.0K` and `8.50K`

## Validation

- `pnpm exec biome check` on both changed components
- `pnpm check:types`
- `pnpm test` (355 tests passed)
- rendered the chart against a local five-run fixture and verified labels `8.25K`, `8.5K`, `8.75K`, `9K`, and `9.25K`

Prompted by: @tanishqsh