### PR TITLE
docs: add author to human authorization post

### DIFF
--- a/blogs/human-authorization-in-agentic-workflows.md
+++ b/blogs/human-authorization-in-agentic-workflows.md
@@ -3,6 +3,7 @@ title: "Human Authorization in Agentic Workflows"
 excerpt: "How Tempo enables AI-accelerated development securely"
 date: 2026-08-17
 category: [technical, case-studies]
+authors: "Shane da Silva"
 ---
 
 At Tempo, we are building more workflows where software can move quickly on a person's behalf. That is useful, but it can also be risky.


### PR DESCRIPTION
## Summary

- add Shane da Silva as the author of the Human Authorization in Agentic Workflows post
- restore the visible “By Shane da Silva” attribution

## Validation

- `pnpm check:types`

Prompted by: tom