### PR TITLE
fix: add author attribution to authorization blog

### DIFF
--- a/blogs/human-authorization-in-agentic-workflows.md
+++ b/blogs/human-authorization-in-agentic-workflows.md
@@ -1,6 +1,7 @@
 ---
 title: "Human Authorization in Agentic Workflows"
 excerpt: "How Tempo enables AI-accelerated development securely"
+authors: "Shane da Silva"
 date: 2026-08-17
 category: [technical, case-studies]
 ---


### PR DESCRIPTION
Adds Shane da Silva as the author of the Human Authorization in Agentic Workflows post so the page renders the byline consistently with Stablebench.

Validation:
- `pnpm check:types`
- Confirmed the blog renderer consumes `authors` and displays `By {post.authors}`

Prompted by: tom