### PR TITLE
docs: update Chainlink Data Streams address

### DIFF
--- a/src/pages/docs/ecosystem/data-analytics.mdx
+++ b/src/pages/docs/ecosystem/data-analytics.mdx
@@ -36,7 +36,7 @@ Chainlink supports Tempo through:
 - **Cross-Chain Interoperability Protocol (CCIP):** A secure interoperability layer for sending messages and value across chains, enabling cross-chain user flows and multi-chain architectures.  
 Explore CCIP in the [Chainlink CCIP docs](https://docs.chain.link/ccip).
 - **Data Streams:** Chainlink Data Streams delivers low-latency market data offchain, which can be verified onchain. This pull-based design gives dApps on-demand access to high-frequency market data backed by decentralized, fault-tolerant, and transparent infrastructure—an improvement over traditional push-based oracles that update only at fixed intervals or price thresholds.  
-View the Chainlink Data Stream deployed on Tempo [here](https://explore.tempo.xyz/address/0x72790f9eB82db492a7DDb6d2af22A270Dcc3Db64?tab=contract).
+View the Chainlink Data Stream deployed on Tempo [here](https://explore.tempo.xyz/address/0xcE73c8ad08CBDEaCa6078BF0627C8fe0a9a536E7?tab=contract).
 
 Developers can explore Price Feeds, CCIP, Data Streams, and the full Chainlink platform through the [Chainlink Developer Docs](https://docs.chain.link/).
 

--- a/src/pages/docs/quickstart/developer-tools.mdx
+++ b/src/pages/docs/quickstart/developer-tools.mdx
@@ -134,7 +134,7 @@ Chainlink supports Tempo through:
 - **Cross-Chain Interoperability Protocol (CCIP):** A secure interoperability layer for sending messages and value across chains, enabling cross-chain user flows and multi-chain architectures.  
 Explore CCIP in the [Chainlink CCIP docs](https://docs.chain.link/ccip).
 - **Data Streams:** Chainlink Data Streams delivers low-latency market data offchain, which can be verified onchain. This pull-based design gives dApps on-demand access to high-frequency market data backed by decentralized, fault-tolerant, and transparent infrastructure—an improvement over traditional push-based oracles that update only at fixed intervals or price thresholds.  
-View the Chainlink Data Stream deployed on Tempo [here](https://explore.tempo.xyz/address/0x72790f9eB82db492a7DDb6d2af22A270Dcc3Db64?tab=contract).
+View the Chainlink Data Stream deployed on Tempo [here](https://explore.tempo.xyz/address/0xcE73c8ad08CBDEaCa6078BF0627C8fe0a9a536E7?tab=contract).
 
 Developers can explore CCIP, Data Streams, and the full Chainlink platform through the [Chainlink Developer Docs](https://docs.chain.link/).
 


### PR DESCRIPTION
## Summary

- point both Chainlink Data Streams docs references to the verified Tempo mainnet VerifierProxy
- remove the stale contract address from these pages

## Validation

- pnpm check:types
- git diff --check

Prompted by: @joshitzko