### PR TITLE
docs: rename funding api to routes

### DIFF
--- a/src/lib/docs-routing.ts
+++ b/src/lib/docs-routing.ts
@@ -21,6 +21,7 @@ export const proxiedLegacyDocsRoutes = [
   { source: '/docs/developer-tools/indexer', destination: '/docs/api/indexer-api' },
   { source: '/docs/hosted-services', destination: '/docs/api' },
   { source: '/docs/hosted-services/:path*', destination: '/docs/api' },
+  { source: '/docs/api/funding/:path*', destination: '/docs/api/routes/:path*' },
   {
     source: '/docs/guide/use-accounts/add-funds',
     destination: '/docs/guide/getting-funds',

--- a/src/lib/sitemap.test.ts
+++ b/src/lib/sitemap.test.ts
@@ -65,12 +65,12 @@ describe('finalizeSitemap', () => {
     const result = finalizeSitemap(
       sitemap,
       [],
-      ['billing', 'activities', 'funding/quotes', 'billing'],
+      ['billing', 'activities', 'routes/quotes', 'billing'],
     )
 
     expect(result).toContain('<loc>https://tempo.xyz/developers/docs/api/activities</loc>')
     expect(result).toContain('<loc>https://tempo.xyz/developers/docs/api/billing</loc>')
-    expect(result).toContain('<loc>https://tempo.xyz/developers/docs/api/funding/quotes</loc>')
+    expect(result).toContain('<loc>https://tempo.xyz/developers/docs/api/routes/quotes</loc>')
     expect(result.indexOf('/api/activities')).toBeLessThan(result.indexOf('/api/billing'))
     expect(result).not.toMatch(
       /<loc>https:\/\/tempo\.xyz\/developers\/docs\/api\/(?:activities|billing)<\/loc>\s*<lastmod>/,

--- a/src/pages/docs/api.mdx
+++ b/src/pages/docs/api.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Tempo API"
 seoTitle: "Start with the Tempo API | Tempo Docs"
-description: Build stablecoin payment apps with the official Tempo blockchain API for account activity, webhooks, funding, exchange quotes, fee sponsorship, and indexed SQL.
+description: Build stablecoin payment apps with the official Tempo blockchain API for account activity, webhooks, asset routes, exchange quotes, fee sponsorship, and indexed SQL.
 ---
 
 import { Cards, Card, OpenApi } from 'vocs'
 
 # Tempo API
 
-The Tempo API is the official Tempo blockchain API for stablecoin payment applications. Use it to read account and transaction activity, manage webhooks and integrations, quote funding and exchanges, sponsor fees, run indexed SQL, and call Tempo over JSON-RPC.
+The Tempo API is the official Tempo blockchain API for stablecoin payment applications. Use it to read account and transaction activity, manage webhooks and integrations, quote asset routes and exchanges, sponsor fees, run indexed SQL, and call Tempo over JSON-RPC.
 
 :::warning
 The Tempo API is under active development. Endpoints are not yet stable and may change without notice.
@@ -73,7 +73,7 @@ Create production and sandbox API keys in [Tempo API Console](https://console.te
 
 - **Track and reconcile a stablecoin payment.** Look up the [transaction and receipt](/docs/api/transactions), then inspect its [transaction activities](/docs/api/activities#list-transaction-activities) to confirm the token movement. Use [webhooks](/docs/api/webhooks) when your backend needs signed event callbacks.
 - **Monitor an account.** Read [balances](/docs/api/balances) and [activity](/docs/api/activities) to build payment history, treasury, or account views.
-- **Fund and exchange stablecoins.** Compare [funding quotes](/docs/api/funding/quotes) across supported chains and providers, then [create a transfer](/docs/api/funding/transfers) or [create a reusable deposit address](/docs/api/funding/deposit-addresses). Use [exchange quotes](/docs/api/exchange) to prepare unsigned approval and swap calls for you to sign and submit.
+- **Route and exchange stablecoins.** Compare [route quotes](/docs/api/routes/quotes) across supported chains and providers, then [create a transfer](/docs/api/routes/transfers) or [create a reusable deposit address](/docs/api/routes/deposit-addresses). Use [exchange quotes](/docs/api/exchange) to prepare unsigned approval and swap calls for you to sign and submit.
 - **Sponsor transaction fees.** Use the [Fee Payer API](/docs/api/fee-payer) to apply sponsorship policy and fill, sponsor, and broadcast user transactions.
 - **Query custom payment data.** Use the [Indexer API](/docs/api/indexer-api) for read-only SQL across indexed blocks, transactions, receipts, logs, transfers, and exchange data.
 - **Prepare a production integration.** Create projects and keys in [Tempo API Console](/docs/api/console), then review [authentication](/docs/api/authentication), [rate limits](/docs/api/rate-limits), and [errors](/docs/api/errors).
@@ -132,7 +132,7 @@ Browse the [complete Tempo API reference](/docs/api/reference) to find every API
   />
   <Card
     title="Tempo API FAQ"
-    description="Answers about API surfaces, credentials, payment monitoring, funding, and exchange quotes."
+    description="Answers about API surfaces, credentials, payment monitoring, asset routes, and exchange quotes."
     to="/docs/api/faq"
     icon="lucide:circle-help"
   />

--- a/src/pages/docs/api/faq.mdx
+++ b/src/pages/docs/api/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tempo API FAQ
-description: Answers to common Tempo API questions about hosted services, RPC, authentication, webhooks, funding, exchange quotes, and API endpoints.
+description: Answers to common Tempo API questions about hosted services, RPC, authentication, webhooks, asset routes, exchange quotes, and API endpoints.
 ---
 
 # Tempo API FAQ
@@ -9,7 +9,7 @@ Use these answers to choose the right Tempo API surface and understand what each
 
 ## What is the Tempo API?
 
-The Tempo API is Tempo's official hosted integration surface for stablecoin products. It provides indexed data, signed webhooks, funding and exchange quotes, fee sponsorship, read-only SQL, and JSON-RPC access without requiring you to operate the underlying infrastructure.
+The Tempo API is Tempo's official hosted integration surface for stablecoin products. It provides indexed data, signed webhooks, asset route and exchange quotes, fee sponsorship, read-only SQL, and JSON-RPC access without requiring you to operate the underlying infrastructure.
 
 ## How is the Tempo API different from Tempo RPC?
 
@@ -23,9 +23,9 @@ Most read endpoints work without credentials at the public rate limit. Use [MPP 
 
 Read the [transaction and receipt](/docs/api/transactions) to follow execution, then inspect its [transaction activities](/docs/api/activities#list-transaction-activities) to identify the stablecoin movement. Configure [webhooks](/docs/api/webhooks) for signed callbacks instead of polling, and review delivery history when you need to audit an attempt.
 
-## Does the Tempo Funding API execute a transfer?
+## Does the Tempo Routes API execute a transfer?
 
-No. The [Funding API](/docs/api/funding/quotes) compares live quotes across supported chains and providers, but it does not execute a transfer. Execute the chosen transfer separately.
+No. The [Routes API](/docs/api/routes/quotes) compares live quotes across supported chains and providers, but it does not execute a transfer. Execute the chosen transfer separately.
 
 ## Does the Tempo Exchange API submit a transaction?
 

--- a/src/pages/docs/api/reference.mdx
+++ b/src/pages/docs/api/reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tempo API Reference
 seoTitle: "Tempo API Reference ⋅ Tempo Docs"
-description: Browse every Tempo API endpoint for blockchain data, funding, exchange, webhooks, organizations, billing, MPP, MCP, and JSON-RPC requests and responses.
+description: Browse every Tempo API endpoint for blockchain data, asset routes, exchange, webhooks, organizations, billing, MPP, MCP, and JSON-RPC requests and responses.
 ---
 
 import { OpenApi } from 'vocs'

--- a/src/pages/docs/build.mdx
+++ b/src/pages/docs/build.mdx
@@ -12,7 +12,7 @@ Use this section when you are designing payment experiences or payment infrastru
 
 Start with **Make Payments** if you are not sure where to begin. It covers the core transfer flow and introduces the payment primitives used throughout the rest of the docs.
 
-Use the [Tempo API](/docs/api) when your application backend needs indexed payment activity, webhooks, funding or exchange quotes, fee sponsorship, or integration management.
+Use the [Tempo API](/docs/api) when your application backend needs indexed payment activity, webhooks, asset route or exchange quotes, fee sponsorship, or integration management.
 
 Use [Agentic Payments](/docs/guide/machine-payments) when agents, APIs, or services need to pay per request. Use [Private Zones](/docs/guide/private-zones) when your product needs isolated execution, private transfers, or zone bridging flows.
 

--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -83,7 +83,7 @@ If you are new to Tempo, start with **Connect to Tempo**, then use **Stablecoin 
   />
   <Card
     title="Tempo API"
-    description="Read payment activity, use webhooks, quote funding and exchanges, sponsor fees, and query indexed data."
+    description="Read payment activity, use webhooks, quote asset routes and exchanges, sponsor fees, and query indexed data."
     to="/docs/api"
     icon="lucide:cloud"
   />

--- a/vercel.json
+++ b/vercel.json
@@ -737,6 +737,11 @@
       "permanent": true
     },
     {
+      "source": "/developers/docs/api/funding/:path*",
+      "destination": "/developers/docs/api/routes/:path*",
+      "permanent": true
+    },
+    {
       "source": "/developers/docs/guide/use-accounts/add-funds",
       "destination": "/developers/docs/guide/getting-funds",
       "permanent": true


### PR DESCRIPTION
Renames Funding API documentation and links to Routes API for https://github.com/tempoxyz/api/pull/1023. Redirects legacy `/docs/api/funding/*` URLs to `/docs/api/routes/*`.
