### PR TITLE
ci: stabilize docs checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Fetch OpenAPI specification
+        run: |
+          node --experimental-strip-types scripts/fetch-openapi.ts "$RUNNER_TEMP/openapi.json"
+          echo "OPENAPI_SPEC_URL=$RUNNER_TEMP/openapi.json" >> "$GITHUB_ENV"
+
       - name: Check
         run: pnpm run check
 
@@ -96,6 +101,11 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Fetch OpenAPI specification
+        run: |
+          node --experimental-strip-types scripts/fetch-openapi.ts "$RUNNER_TEMP/openapi.json"
+          echo "OPENAPI_SPEC_URL=$RUNNER_TEMP/openapi.json" >> "$GITHUB_ENV"
 
       - name: Build Vercel output
         run: pnpm run build

--- a/scripts/fetch-openapi.ts
+++ b/scripts/fetch-openapi.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env -S node --experimental-strip-types
+
+import fs from 'node:fs/promises'
+
+const output = process.argv[2]
+if (!output) throw new Error('Expected an output file path')
+
+const specUrl = new URL('https://api.tempo.xyz/openapi.json')
+const spec = await fetchJson(specUrl)
+if (!isObject(spec) || !isObject(spec.paths)) throw new Error('Invalid OpenAPI document')
+
+for (const pathItem of Object.values(spec.paths)) {
+  if (!isObject(pathItem)) continue
+  for (const operation of Object.values(pathItem)) {
+    if (!isObject(operation) || typeof operation['x-openrpc'] !== 'string') continue
+    operation['x-openrpc'] = await fetchJson(new URL(operation['x-openrpc'], specUrl))
+  }
+}
+
+await fs.writeFile(output, JSON.stringify(spec))
+
+async function fetchJson(url: URL) {
+  let failure: unknown
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(30_000) })
+      if (!response.ok) throw new Error(`${url} returned ${response.status}`)
+      return (await response.json()) as unknown
+    } catch (error) {
+      failure = error
+      if (attempt < 5) await new Promise((resolve) => setTimeout(resolve, attempt * 1_000))
+    }
+  }
+  throw failure
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/pages/docs/guide/machine-payments/one-time-payments.mdx
+++ b/src/pages/docs/guide/machine-payments/one-time-payments.mdx
@@ -7,7 +7,7 @@ import { Card, Cards } from 'vocs'
 
 # Accept one-time payments
 
-Build a payment-gated API that charges $0.01 per request using `mppx`. The server returns a random photo from [Picsum](https://picsum.photos) behind a paywall.
+Build a payment-gated API that charges $0.01 per request using `mppx`. The server returns a random photo from [Picsum](https://github.com/DMarby/picsum-photos) behind a paywall.
 
 ## One-time payment server setup
 

--- a/src/pages/docs/guide/machine-payments/pay-as-you-go.mdx
+++ b/src/pages/docs/guide/machine-payments/pay-as-you-go.mdx
@@ -10,7 +10,7 @@ import { MermaidDiagram } from '../../../../components/MermaidDiagram'
 
 Use pay-as-you-go sessions when a customer should pay a small amount each time they use an API or service, without sending an on-chain transaction for every request.
 
-This guide uses a simple photo API as the example: the client opens one `mppx` session, then pays $0.01 each time it asks for a photo. `mppx` is the library that manages the MPP session; [Picsum](https://picsum.photos) only supplies sample images for the demo.
+This guide uses a simple photo API as the example: the client opens one `mppx` session, then pays $0.01 each time it asks for a photo. `mppx` is the library that manages the MPP session; [Picsum](https://github.com/DMarby/picsum-photos) only supplies sample images for the demo.
 
 :::info
 Unlike [one-time payments](/docs/guide/machine-payments/one-time-payments), a session opens a payment channel once. Each later request is paid with a signed voucher that the server verifies off-chain.


### PR DESCRIPTION
Downloads and bundles the production OpenAPI documents before verification, avoiding transient fetch failures. Replaces two unavailable Picsum homepage links with its GitHub repository.
