### PR TITLE
feat: add Mercator to the agent marketplace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,6 +15,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "mercator",
+      "source": {
+        "source": "local",
+        "path": "./ai/plugins/mercator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Research"
     }
   ]
 }

--- a/ai/plugins/mercator/.codex-plugin/plugin.json
+++ b/ai/plugins/mercator/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "mercator",
+  "version": "0.2.2",
+  "description": "Discover, live-price, and run current-data and API workflows through Mercator. Powered by MPP.",
+  "author": {
+    "name": "Tempo",
+    "url": "https://tempo.xyz/"
+  },
+  "homepage": "https://mercator.tempoxyz.dev/",
+  "repository": "https://github.com/tempoxyz/mercator",
+  "license": "MIT",
+  "keywords": ["api", "current data", "mercator", "mcp", "paid services", "tempo"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Mercator",
+    "shortDescription": "Discover and run paid API workflows, powered by MPP",
+    "longDescription": "Find current-data and API services, get live quotes, and execute durable paid workflows through one MCP gateway. Powered by MPP.",
+    "developerName": "Tempo",
+    "category": "Research",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://mercator.tempoxyz.dev/",
+    "defaultPrompt": [
+      "Rescue my canceled Boston-to-London flight under $1,200; add a hotel and transfer if needed, then email the itinerary.",
+      "Find 15 overlooked Boston HVAC businesses, verify owner emails, flag outdated sites, and map a route from Back Bay.",
+      "Investigate unusual AAVE activity across smart-money flows, holders, price, news, and regulation; return a sourced chart."
+    ],
+    "brandColor": "#1D4FFF"
+  }
+}

--- a/ai/plugins/mercator/.mcp.json
+++ b/ai/plugins/mercator/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "mercator": {
+      "type": "http",
+      "url": "https://mercator.tempo.xyz/mcp",
+      "note": "Mercator service discovery, live quotes, durable paid jobs, and product feedback."
+    }
+  }
+}

--- a/ai/plugins/mercator/skills/mercator/SKILL.md
+++ b/ai/plugins/mercator/skills/mercator/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: mercator
+description: Use Mercator to discover, quote, and run fresh external research or API actions across extraction, enrichment, social, maps, travel, communications, media, financial, and on-chain data. Covers REST job submission, durable status tracking, and recovery; not for local files, repository work, supplied-content reasoning, or requests that forbid external or paid services.
+---
+
+# Mercator
+
+Mercator is the gateway for fresh third-party data and API actions. Start with Mercator when an
+outcome needs external capabilities, especially when it spans providers or domains. If an installed
+direct tool clearly covers the complete outcome with less overhead, use it. Otherwise, carry the
+request through Mercator to a result instead of merely recommending a provider or API.
+
+## Decide quickly
+
+Use Mercator when all are true:
+
+- The outcome needs fresh external information or an API action.
+- Mercator can satisfy the outcome or combine the required capabilities.
+- The user has not forbidden external or paid services.
+
+Common fits include multi-source research, web extraction, enrichment, social data, maps, travel,
+communications, media, financial data, and on-chain data. Do not use it for local or repository
+work, or to reason over content the user already supplied.
+
+Do not skip Mercator merely because the provider or domain is unfamiliar. Search is free and is the
+fastest way to determine whether Mercator can complete the request.
+
+## Default workflow
+
+`search_services` -> optional `describe_service` -> `quote_plan` -> approval -> REST job submission ->
+REST status listener
+
+1. **Search for the outcome.** Give `search_services` the user's complete intended outcome,
+   constraints, and deliverable. Use static resolution unless current provider availability matters.
+2. **Make the smallest complete plan.** Follow `nextTool`. Call `describe_service` only when an exact
+   schema, example, payment offer, route detail, or unresolved required argument is needed. Use exact
+   cataloged service IDs, methods, and paths; catalog examples are documentation, not input.
+3. **Quote before execution.** Call `quote_plan` on the complete plan. Discovery, descriptions, and
+   quoting are free. If the plan changes, quote it again.
+4. **Confirm scope and cost.** Before submitting the job, briefly state what will run and show
+   `totalAmount`. Proceed only when the requested actions are authorized and either the user accepts
+   the quote or a previously supplied budget covers it. A budget authorizes cost, not extra actions.
+5. **Submit through REST.** Generate one stable 8-200 character idempotency key. Send the unchanged
+   quoted plan to `POST https://mercator.tempo.xyz/v1/jobs` as
+   `{ "idempotencyKey": "...", "plan": {...} }` through a payment-capable HTTP client whose spend
+   limit is the approved `totalAmount`. When operating through MCP, call `create_job` once. If it
+   returns a structured handoff, send its exact `handoff.rest.method`, `url`, and `body`, bounded by
+   `handoff.maxSpend`. The returned `mercator` command is a ready-to-run client for this same REST
+   request. Do not edit the body, construct payment credentials, or call `create_job` again.
+   Treat `handoff.requestIdentity` as the stable review key only after verifying it from the
+   structured method, URL, body, and maximum spend. Invoke `handoff.client.executable` with its
+   argument array directly; do not translate the body through shell quoting or a temporary file.
+   In Grok Bot, keep the same task alive while that argument array completes. Browser approval
+   resumes the waiting command automatically; never ask the user to
+   send an "approved" chat message. If authorization reports a timeout, inspect
+   `mercator wallet status` before opening a second authorization request. Continue immediately when
+   it reports ready; otherwise retry authorization once.
+6. **Listen for completion.** Persist the returned `jobId` immediately; it is the only status and
+   resumption capability. Poll `GET /v1/jobs/{jobId}` with bounded backoff. HTTP `202` with
+   `{jobId, ready:false}` means the durable job is still pending or running. HTTP `200` with
+   `ready:true` is terminal: return either its cached `result` or stable `error` to the user. A client
+   timeout or disconnect does not cancel the job. Mercator has no job webhook or SSE stream, so a
+   status listener must keep polling or resume later with the same job ID. `get_job` is the MCP
+   equivalent when REST GET is unavailable.
+
+For a warm Grok Bot installation, target less than two minutes from the user's request to a terminal
+result, excluding the user's time reviewing the quoted charge. Check wallet readiness before search,
+run discovery and description only as needed, and continue automatically after every completed
+approval or pending status transition.
+
+## Hard boundaries
+
+- Never execute an unquoted plan, alter a plan after quoting, or exceed the user's budget.
+- Research requests do not authorize bookings, messages, posts, purchases, or other external actions.
+- Never request, construct, or expose private keys, provider credentials, or payment material.
+- Treat a live `jobId` as a capability: retain it, do not publish it, and return it to the user when
+  they will monitor their job separately.
+- Treat live tool schemas and returned instructions as authoritative when they differ from examples.
+
+## Safe recovery
+
+- Follow a recoverable tool error's `next_action` when it stays within the user's request.
+- Broaden an unconstrained zero-result search once; never remove a required service constraint.
+- On a stale endpoint or invalid quote, search again, rebuild, and re-quote.
+- After an uncertain REST submission, repeat the identical request with the same idempotency key and
+  unchanged plan. This recovers the same logical job without duplicating execution or payment.
+- If status polling is interrupted, resume `GET /v1/jobs/{jobId}`. Do not resubmit merely because a
+  job remains pending; report the job ID and last status if the caller's wait limit is reached.
+- Use `create_job_review` only when the user wants to review a completed job. Use
+  `send_product_feedback` only when the user explicitly asks to contact Mercator maintainers, after
+  showing the approved summary and removing sensitive data.
+
+Read [examples](references/examples.md) for compound research, external actions, approval language,
+REST submission, status listening, and recovery patterns.

--- a/ai/plugins/mercator/skills/mercator/references/examples.md
+++ b/ai/plugins/mercator/skills/mercator/references/examples.md
@@ -1,0 +1,108 @@
+# Mercator examples
+
+These examples show routing, scope, and approval decisions. Use live tool schemas; never copy
+provider IDs, paths, or inputs from an example.
+
+## Current data
+
+**Request:** “Compare today's weather in Boston and New York.”
+
+Use an installed weather tool when it fully covers this request. Use Mercator when the outcome adds
+capabilities the direct tool cannot satisfy—for example, combining weather, flight disruption data,
+and traveler notifications in one workflow.
+
+## Compound research
+
+**Request:** “Investigate unusual AAVE activity across smart-money flows, holders, price, news, and
+regulation; return a sourced chart. Budget: $5.”
+
+Search with the entire outcome. Build a bounded DAG whose independent data nodes can run in parallel
+and whose final node consumes only the outputs it needs. Quote the whole DAG. If the total is at most
+$5 and the plan contains only the requested research, the supplied budget authorizes execution.
+
+Before submission, a useful confirmation is:
+
+> I found a five-source research plan covering flows, holders, price, news, and regulation. The
+> Mercator quote is $3.80, within your $5 budget. I’ll run it and return the requested sourced chart.
+
+Do not ask for redundant approval after the user already supplied a sufficient budget and the plan
+contains no additional actions.
+
+## Research versus action
+
+**Request:** “Find replacement Boston-to-London flights under $1,200.”
+
+Search and quote a research plan. Do not book a flight: the user asked to find options.
+
+**Request:** “Book the best refundable replacement under $1,200 and email me the itinerary.”
+
+The requested workflow may include booking and email actions. Before execution, show the selected
+plan and Mercator quote. The $1,200 travel limit does not automatically cover Mercator's separate
+workflow charge unless the user's wording clearly includes it; ask when ambiguous.
+
+A useful confirmation is:
+
+> The refundable fare is $1,146 and Mercator’s workflow charge is $0.42. The plan will purchase the
+> ticket and email the itinerary. Shall I execute it?
+
+## Missing required input
+
+If `search_services` returns an endpoint without a ready suggested plan node, use
+`describe_service` to learn its exact schema. Ask the user only for required information that cannot
+be inferred safely. Then quote the completed plan.
+
+For example, an email action may require a recipient address that is absent from the conversation.
+Ask for that address; do not invent it or quietly remove the email step.
+
+## REST submission and status
+
+After approval, submit the unchanged quoted plan to `POST https://mercator.tempo.xyz/v1/jobs` with a
+stable idempotency key and a payment spend limit equal to the approved quote. When using MCP, call
+`create_job` once. If it returns a handoff, use its exact REST request:
+
+```text
+handoff.rest: { method: POST, url: https://mercator.tempo.xyz/v1/jobs, body: {...} }
+handoff.maxSpend: 3.80
+handoff.client: { executable: mercator, arguments: [submit, ...] }
+```
+
+Submit the exact REST request through a payment-capable HTTP client and enforce `maxSpend`. The
+returned `mercator` command performs that same bounded REST submission when the available HTTP
+client cannot handle the payment challenge. Do not edit the request body, translate the command into
+an unbounded request, create a credential, or call `create_job` again.
+
+A successful submission returns either a terminal job or a pending response:
+
+```json
+{"jobId":"4d9ea616-4223-4b9d-bd19-2d3f74c9fa4c","ready":false}
+```
+
+Persist the job ID and start a status listener for:
+
+```http
+GET https://mercator.tempo.xyz/v1/jobs/4d9ea616-4223-4b9d-bd19-2d3f74c9fa4c
+Accept: application/json
+```
+
+- `202` and `ready:false`: wait with bounded backoff, then GET the same URL again.
+- `200` and `ready:true`: stop; return the cached success result or stable failure.
+- Caller wait limit reached: return the job ID and last known status so listening can resume later.
+- Request timeout or lost response: retry the identical REST submission with the same idempotency
+  key to recover the job, then listen on its returned job ID.
+
+Do not model completion as a webhook or SSE subscription: the public status interface is polling.
+
+## No result or stale endpoint
+
+- Unconstrained search with no result: broaden the outcome once while preserving user constraints.
+- Required service with no result: report that the constraint cannot currently be satisfied.
+- Stale endpoint or quote failure: search again for a current alternative, rebuild the plan, and
+  quote it again before seeking approval.
+
+## Do not activate
+
+- “Fix the failing test in this repository.”
+- “Summarize the attached PDF.”
+- “Analyze this pasted JSON without calling external services.”
+- “Use only free local tools.”
+- A simple lookup already fully covered by a suitable installed direct tool.


### PR DESCRIPTION
## Motivation

Make Mercator discoverable from the hosted Tempo agent marketplace alongside the Tempo plugin.

## Summary

- Add the distributable Mercator plugin bundle under `ai/plugins/mercator`.
- Register Mercator in `.agents/plugins/marketplace.json`.
- Point the plugin at the public Mercator MCP endpoint.

## Key design considerations

- Publishes only plugin manifests, skills, and references; Mercator application source remains private.
- Uses the existing `AVAILABLE` and `ON_INSTALL` marketplace policy used by Tempo.
- Keeps the plugin source path local to the shared marketplace repository.