### PR TITLE
docs: document Mercator plugin installation

### DIFF
--- a/src/pages/docs/guide/using-tempo-with-ai.mdx
+++ b/src/pages/docs/guide/using-tempo-with-ai.mdx
@@ -167,6 +167,28 @@ claude plugin install docs@tempo
 ```
 :::
 
+## Install the Mercator plugin
+
+Mercator adds paid API discovery and execution through the Mercator MCP server. The installer installs the CLI, configures detected MCP clients, and bootstraps the local Mercator plugin:
+
+```bash
+curl -fsSL https://mercator.tempo.xyz/downloads/latest/install.sh | sh
+```
+
+To install the plugin directly from the Tempo marketplace, add the public `tempoxyz/docs` source and select `mercator@tempo`:
+
+:::code-group
+```bash [Codex]
+codex plugin marketplace add tempoxyz/docs
+codex plugin add mercator@tempo
+```
+
+```bash [Claude]
+claude plugin marketplace add tempoxyz/docs
+claude plugin install mercator@tempo --scope user --yes
+```
+:::
+
 ## Tempo Docs
 
 ### Docs skill


### PR DESCRIPTION
## Motivation

Make the Mercator installer and marketplace plugin path discoverable from the Tempo AI integration guide.

## Summary

- Document the Mercator installer command.
- Document `tempoxyz/docs` marketplace registration and `mercator@tempo` installation for Codex and Claude.

## Key design considerations

- Keep the existing Tempo Docs plugin instructions unchanged.
- Use the public marketplace source and canonical `mercator@tempo` selector.