### PR TITLE
fix: harden Tempo plugin installation

### DIFF
--- a/src/components/DocsHeader.tsx
+++ b/src/components/DocsHeader.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useConfig } from 'vocs'
 import { useRouter, Link as WakuLink } from 'waku'
+import { tempoPluginInstallCommands } from '../lib/ai-install-commands'
 import { DOCS_SEARCH_PARAM } from '../lib/docs-search'
 import { AmpLogo, ClaudeLogo, CodexLogo } from './AgentLogos'
 
@@ -633,12 +634,12 @@ const pluginCommands = [
   {
     label: 'Codex',
     logo: <CodexLogo aria-hidden="true" className="size-3.5 shrink-0" />,
-    command: 'codex plugin marketplace add tempoxyz/docs\ncodex plugin add docs@tempo',
+    command: tempoPluginInstallCommands.codex,
   },
   {
     label: 'Claude',
     logo: <ClaudeLogo aria-hidden="true" className="size-3.5 shrink-0" />,
-    command: 'claude plugin marketplace add tempoxyz/docs\nclaude plugin install docs@tempo',
+    command: tempoPluginInstallCommands.claude,
   },
 ]
 

--- a/src/lib/ai-install-commands.test.ts
+++ b/src/lib/ai-install-commands.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { tempoPluginInstallCommands } from './ai-install-commands'
+
+describe('tempoPluginInstallCommands', () => {
+  it('uses the canonical Codex marketplace and plugin selectors', () => {
+    expect(tempoPluginInstallCommands.codex).toBe(
+      'codex plugin marketplace add tempoxyz/docs --ref main\ncodex plugin add docs@tempo',
+    )
+  })
+
+  it('uses the canonical Claude marketplace and plugin selectors', () => {
+    expect(tempoPluginInstallCommands.claude).toBe(
+      'claude plugin marketplace add tempoxyz/docs\nclaude plugin install docs@tempo',
+    )
+  })
+})

--- a/src/lib/ai-install-commands.ts
+++ b/src/lib/ai-install-commands.ts
@@ -1,0 +1,5 @@
+/** Copyable commands for installing the Tempo plugin from its public marketplace. */
+export const tempoPluginInstallCommands = {
+  claude: 'claude plugin marketplace add tempoxyz/docs\nclaude plugin install docs@tempo',
+  codex: 'codex plugin marketplace add tempoxyz/docs --ref main\ncodex plugin add docs@tempo',
+} as const

--- a/src/marketing/app/_components/Header.tsx
+++ b/src/marketing/app/_components/Header.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { AmpLogo, ClaudeLogo, CodexLogo } from '../../../components/AgentLogos'
+import { tempoPluginInstallCommands } from '../../../lib/ai-install-commands'
 import { developersPath } from '../_lib/developersPaths'
 import { featurePath } from '../_lib/featurePaths'
 import { TEMPO_SDK_DOCS_URL } from '../_lib/links'
@@ -287,12 +288,12 @@ const pluginCommands = [
   {
     label: 'Codex',
     logo: <CodexLogo aria-hidden="true" className="size-3.5 shrink-0" />,
-    command: 'codex plugin marketplace add tempoxyz/docs\ncodex plugin add docs@tempo',
+    command: tempoPluginInstallCommands.codex,
   },
   {
     label: 'Claude',
     logo: <ClaudeLogo aria-hidden="true" className="size-3.5 shrink-0" />,
-    command: 'claude plugin marketplace add tempoxyz/docs\nclaude plugin install docs@tempo',
+    command: tempoPluginInstallCommands.claude,
   },
 ]
 

--- a/src/pages/docs/guide/using-tempo-with-ai.mdx
+++ b/src/pages/docs/guide/using-tempo-with-ai.mdx
@@ -157,13 +157,24 @@ The Tempo plugin installs a complete agent integration: the Tempo MCP server, wo
 
 :::code-group
 ```bash [Codex]
-codex plugin marketplace add tempoxyz/docs
+codex plugin marketplace add tempoxyz/docs --ref main
 codex plugin add docs@tempo
 ```
 
 ```bash [Claude]
 claude plugin marketplace add tempoxyz/docs
 claude plugin install docs@tempo
+```
+:::
+
+:::warning[Legacy Codex marketplace name]
+If Codex reports that the plugin is missing after finding this marketplace as `docs`, replace that
+pre-rename registration once, then rerun the install:
+
+```bash
+codex plugin marketplace remove docs
+codex plugin marketplace add tempoxyz/docs --ref main
+codex plugin add docs@tempo
 ```
 :::
 
@@ -179,7 +190,7 @@ To install the plugin directly from the Tempo marketplace, add the public `tempo
 
 :::code-group
 ```bash [Codex]
-codex plugin marketplace add tempoxyz/docs
+codex plugin marketplace add tempoxyz/docs --ref main
 codex plugin add mercator@tempo
 ```
 


### PR DESCRIPTION
## Motivation

Existing Codex users can copy the canonical selector from the site while still having the marketplace cached under its pre-rename `docs` identity.

## Summary

- Pin Codex marketplace registration to the public `main` ref across install surfaces.
- Share header install commands between the docs and marketing applications.
- Document the one-time legacy marketplace recovery flow.
- Add coverage for canonical marketplace and plugin selectors.

## Key design considerations

- Keep the normal installation path concise for new users.
- Make destructive legacy cleanup explicit and limited to the obsolete `docs` registration.