### PR TITLE
docs: correct validator failover procedure

### DIFF
--- a/src/pages/docs/guide/node/system-requirements.mdx
+++ b/src/pages/docs/guide/node/system-requirements.mdx
@@ -16,6 +16,10 @@ Validators must run execution state on local NVMe / direct-attached storage. Net
 Consensus state can live on a lower performance volume (for example, EBS), but execution state needs NVMe storage.
 If you want to separate them, use `--datadir` for execution data and `--consensus.datadir` for consensus data.
 
+:::warning[Keep consensus and execution data consistent]
+Mounting consensus data on a separate, slower volume does not make it independent from execution data. Back up, restore, snapshot, copy, and fail over both datasets together. Never combine consensus data from one node or point in time with execution data from another.
+:::
+
 ## RPC Node
 
 | Component | Minimum | Recommended |

--- a/src/pages/docs/guide/node/validator-failover.mdx
+++ b/src/pages/docs/guide/node/validator-failover.mdx
@@ -1,19 +1,15 @@
 ---
-title: "Validator failover: preparing a follower node"
+title: "Validator failover: preparing a replacement node"
 seoTitle: "Validator Failover with Follower Nodes | Docs"
-description: Promote a follower into a Tempo validator.
+description: Prepare a follower near the chain tip before rotating it into the validator role.
 ---
 
-# Validator failover: preparing a follower node
+# Validator failover: preparing a replacement node
 
-This runbook covers a warm failover where a follower is promoted into a validator. A follower running in certified mode stores the same consensus finalization data used to bootstrap the validator. Consensus and execution data are tightly coupled and must remain in the same data directory. Do not separate them during replication, backup, restore, or failover.
+This runbook prepares a follower near the chain tip before rotating an existing validator to it. The follower syncs its own consistent consensus and execution data. It is not a replica that can reuse the current validator's consensus state or signing key.
 
-:::info[Planned maintenance]
-Failover requires fencing the old validator before starting its replacement. For zero-downtime planned maintenance, use [validator identity rotation](/docs/guide/node/validator-lifecycle#rotate-validator-identity) to bring up a replacement while the old validator completes its exit timeline.
-:::
-
-:::danger[Prevent double-signing]
-Only one node may run with a validator signing key at a time. Before promoting the follower, fence the old validator. Do not start the replacement while the old validator can still sign.
+:::danger[Use a new validator identity]
+Generate a new signing key for the replacement and use [validator identity rotation](/docs/guide/node/validator-lifecycle#rotate-validator-identity) to move the validator role to it. Never install the old validator's signing key on the replacement. Keep the old validator running until it completes the rotation exit timeline.
 :::
 
 ## Prepare a follower
@@ -32,42 +28,33 @@ tempo node --datadir <datadir> \
   --http.api eth,net,web3,txpool,trace,consensus
 ```
 
-Do not pass `--consensus.signing-key` while the standby is running as a follower. The standby is syncing certified consensus state, not participating in consensus.
+Do not pass `--consensus.signing-key` while the replacement is running as a follower. It is syncing toward the chain tip, not participating in consensus.
 
-### Verify the follower is current
+### Verify the follower is near the chain tip
 
-Check that execution height is advancing and the certified consensus feed is available:
+Compare the follower's execution height with a trusted public RPC endpoint, and confirm that its consensus feed is available:
 
 ```bash
 cast block-number --rpc-url http://localhost:8545
+cast block-number --rpc-url <PUBLIC_RPC_URL>
 cast rpc consensus_getLatest --rpc-url http://localhost:8545
 ```
 
-If `consensus_getLatest` is unavailable, the follower is not syncing consensus state. Confirm that the upstream endpoint is certified and exposes the `consensus` namespace.
+Wait until the follower is close to the public RPC height before starting rotation. If `consensus_getLatest` is unavailable, the follower is not syncing consensus state. Confirm that the upstream endpoint is certified and exposes the `consensus` namespace.
 
-### Keep validator networking ready
+### Prepare replacement networking
 
-The promoted node must be reachable at the ingress and egress addresses registered onchain. A setup that allows a floating IP or load balancer address that can move from the old validator to the standby will require no onchain updates.
-
-If failover uses a different address, update the validator's onchain IP configuration after fencing the old validator. Follow the [update IP addresses](/docs/guide/node/validator-lifecycle#update-ip-addresses) procedure.
+Prepare the ingress and egress addresses for the replacement. The replacement must use a different ingress address from the old validator while both remain active. Changing the port is sufficient.
 
 :::::
 
-## Promote the follower
+## Rotate to the replacement
 
 :::::steps
 
-### Fence the old validator
-
-Stop the old validator or isolate it from the network before starting the replacement. If you use a floating IP, move it to the standby before validator startup.
-
-```bash
-sudo systemctl stop tempo
-```
-
 ### Stop the follower process
 
-Stop the standby follower cleanly so the same data directory can be reopened in validator mode.
+Once the follower is close to the chain tip, stop it cleanly so its consistent consensus and execution data can be reopened in validator mode.
 
 ```bash
 sudo systemctl stop tempo-follower
@@ -75,19 +62,16 @@ sudo systemctl stop tempo-follower
 
 If the follower is not managed by systemd, send `SIGINT` or `SIGTERM` and wait for the process to exit.
 
-### Restart the standby in validator mode
+### Restart the replacement in validator mode
 
-Restart the same data directory without `--follow`, and add the validator signing key.
-
-Use the same consensus signing key as the validator you are failing over from. This procedure moves an existing validator identity to the standby; it does not rotate the identity. To use a different signing key,
-the validator's onchain configuration must be rotated. Follow the [rotate the validator identity](/docs/guide/node/validator-lifecycle#rotate-validator-identity) procedure.
+Restart the same follower data directory without `--follow`, and add the new validator signing key. Do not copy consensus or execution data from the old validator into this data directory.
 
 ::::code-group
 ```bash [Mainnet]
 tempo node --datadir <datadir> \
   --chain mainnet \
-  --consensus.signing-key <PRIVATE_KEY_PATH> \
-  --consensus.listen-address 0.0.0.0:<REGISTERED_INGRESS_PORT> \
+  --consensus.signing-key <NEW_PRIVATE_KEY_PATH> \
+  --consensus.listen-address 0.0.0.0:<NEW_INGRESS_PORT> \
   --http --http.port 8545 \
   --http.api eth,net,web3,txpool,trace,consensus \
   --telemetry-url <TELEMETRY_URL>
@@ -95,19 +79,23 @@ tempo node --datadir <datadir> \
 ```bash [Testnet]
 tempo node --datadir <datadir> \
   --chain testnet \
-  --consensus.signing-key <PRIVATE_KEY_PATH> \
-  --consensus.listen-address 0.0.0.0:<REGISTERED_INGRESS_PORT> \
+  --consensus.signing-key <NEW_PRIVATE_KEY_PATH> \
+  --consensus.listen-address 0.0.0.0:<NEW_INGRESS_PORT> \
   --http --http.port 8545 \
   --http.api eth,net,web3,txpool,trace,consensus \
   --telemetry-url <TELEMETRY_URL>
 ```
 ::::
 
-Do not delete or resync the data directory during failover. The follower's datadir contains the necessary consensus and execution state that allows the node to restart as a validator without a fresh bootstrap.
+The replacement can wait in validator mode until the onchain rotation activates its new identity.
 
-### Verify validator participation
+### Rotate the validator identity
 
-Check that the node's consensus RPC is live and progressing, then verify the validator status from a public RPC endpoint:
+Follow the [validator identity rotation procedure](/docs/guide/node/validator-lifecycle#rotate-validator-identity) using the replacement's new public key, ingress address, and egress address. Keep the old validator running throughout rotation and until it reports `in_committee: false`.
+
+### Verify replacement participation
+
+Check that the replacement's consensus RPC is live and progressing, then verify its validator status from a public RPC endpoint:
 
 ```bash
 cast rpc consensus_getLatest --rpc-url http://localhost:8545
@@ -115,19 +103,19 @@ cast rpc consensus_getLatest --rpc-url http://localhost:8545
 
 ::::code-group
 ```bash [Mainnet]
-tempo consensus validator <pubkey> --rpc-url https://rpc.tempo.xyz
+tempo consensus validator <NEW_PUBLIC_KEY> --rpc-url https://rpc.tempo.xyz
 ```
 ```bash [Testnet]
-tempo consensus validator <pubkey> --rpc-url https://rpc.testnet.tempo.xyz
+tempo consensus validator <NEW_PUBLIC_KEY> --rpc-url https://rpc.testnet.tempo.xyz
 ```
 ::::
 
-The validator should remain `in_committee: true` if it was already active. If you changed IP addresses during failover, wait for the IP update to finalize and for peer discovery to pick up the new address.
+The replacement follows the [standard validator state transitions](/docs/guide/node/validator-status#state-transitions). Continue monitoring both identities until the replacement is participating and the old validator reports `in_committee: false`.
 
 :::::
 
 ## After failover
 
-Treat the promoted node as the active validator until you intentionally move the role again.
+Treat the replacement as the active validator after rotation completes.
 
-Use the [validator status metrics](/docs/guide/node/validator-status#checking-state-via-metrics) to confirm the promoted node is connected to peers and participating in consensus.
+Use the [validator status metrics](/docs/guide/node/validator-status#checking-state-via-metrics) to confirm the replacement is connected to peers and participating in consensus.

--- a/src/pages/docs/guide/node/validator-failover.mdx
+++ b/src/pages/docs/guide/node/validator-failover.mdx
@@ -8,8 +8,8 @@ description: Prepare a follower near the chain tip before rotating it into the v
 
 This runbook prepares a follower near the chain tip before rotating an existing validator to it. The follower syncs its own consistent consensus and execution data. It is not a replica that can reuse the current validator's consensus state or signing key.
 
-:::danger[Use a new validator identity]
-Generate a new signing key for the replacement and use [validator identity rotation](/docs/guide/node/validator-lifecycle#rotate-validator-identity) to move the validator role to it. Never install the old validator's signing key on the replacement. Keep the old validator running until it completes the rotation exit timeline.
+:::warning[Correction to earlier failover guidance]
+Earlier versions of this guide implied that a failover could combine consensus-layer (CL) and execution-layer (EL) data directories from different node states. It cannot. CL and EL data must remain a consistent pair, even when stored on separate mounted volumes.
 :::
 
 ## Prepare a follower
@@ -91,7 +91,53 @@ The replacement can wait in validator mode until the onchain rotation activates 
 
 ### Rotate the validator identity
 
-Follow the [validator identity rotation procedure](/docs/guide/node/validator-lifecycle#rotate-validator-identity) using the replacement's new public key, ingress address, and egress address. Keep the old validator running throughout rotation and until it reports `in_committee: false`.
+The ed25519 key can be changed while keeping your validator index stable. This provides zero-downtime planned failover without leaving and rejoining the committee. [Generate a new signing key](/docs/guide/node/validator-keys#generating-a-signing-key) first.
+
+The rotation command submits a transaction to the validator contract. The transaction signer must control the validator operator address, but it does not need to be a plaintext EOA key. Use the CLI signer backend that matches your custody setup; see [validator operator address custody](/docs/guide/node/validator-keys#validator-operator-address-custody).
+
+:::danger[Do not shut down the old validator]
+Unlike Ethereum, you must **keep your old validator running** after rotation. The rotated-out validator is still a dealer in the committee for at least one more epoch. Shutting it down early will degrade network liveness. See the [exit timeline](/docs/guide/node/validator-lifecycle#exit-timeline) for the full epoch-by-epoch breakdown.
+
+Keep the old validator running until it shows `in_committee: false`:
+
+::::code-group
+```bash [Mainnet]
+tempo consensus validator <OLD_PUBLIC_KEY> --rpc-url https://rpc.tempo.xyz
+```
+```bash [Testnet]
+tempo consensus validator <OLD_PUBLIC_KEY> --rpc-url https://rpc.testnet.tempo.xyz
+```
+::::
+:::
+
+::::code-group
+```bash [Mainnet]
+tempo consensus rotate-validator \
+  --validator-address <YOUR_VALIDATOR_ADDRESS> \
+  --public-key <NEW_PUBLIC_KEY> \
+  --ingress <NEW_IP:PORT> \
+  --egress <NEW_IP> \
+  --signing-key <NEW_PRIVATE_KEY_PATH> \
+  --rpc-url https://rpc.tempo.xyz
+```
+```bash [Testnet]
+tempo consensus rotate-validator \
+  --validator-address <YOUR_VALIDATOR_ADDRESS> \
+  --public-key <NEW_PUBLIC_KEY> \
+  --ingress <NEW_IP:PORT> \
+  --egress <NEW_IP> \
+  --signing-key <NEW_PRIVATE_KEY_PATH> \
+  --rpc-url https://rpc.testnet.tempo.xyz
+```
+::::
+
+If self-service rotation is not yet enabled for your validator, use `tempo consensus create-rotate-validator-signature` to generate the signature and provide it to the Tempo team.
+
+:::info
+Rotation preserves your validator index and active validator count. The old entry is appended to history as deactivated, and the entry at your index is updated in place. You must use a different ingress address. Changing the port is sufficient.
+:::
+
+After rotation, the replacement validator goes through the [standard state transitions](/docs/guide/node/validator-status#state-transitions) with the new identity.
 
 ### Verify replacement participation
 

--- a/src/pages/docs/guide/node/validator-failover.mdx
+++ b/src/pages/docs/guide/node/validator-failover.mdx
@@ -6,7 +6,11 @@ description: Promote a follower into a Tempo validator.
 
 # Validator failover: preparing a follower node
 
-This runbook covers a warm failover where a follower is promoted into a validator. A follower running in certified mode stores the same consensus finalization data used to bootstrap the validator.
+This runbook covers a warm failover where a follower is promoted into a validator. A follower running in certified mode stores the same consensus finalization data used to bootstrap the validator. Consensus and execution data are tightly coupled and must remain in the same data directory. Do not separate them during replication, backup, restore, or failover.
+
+:::info[Planned maintenance]
+Failover requires fencing the old validator before starting its replacement. For zero-downtime planned maintenance, use [validator identity rotation](/docs/guide/node/validator-lifecycle#rotate-validator-identity) to bring up a replacement while the old validator completes its exit timeline.
+:::
 
 :::danger[Prevent double-signing]
 Only one node may run with a validator signing key at a time. Before promoting the follower, fence the old validator. Do not start the replacement while the old validator can still sign.


### PR DESCRIPTION
## Summary

- add a correction warning that failover cannot combine CL and EL data directories from different node states
- prepare a follower close to the chain tip, then rotate the validator to its new identity
- include the complete validator identity rotation procedure directly in the failover guide
- clarify that consensus and execution data must remain consistent even when consensus uses slower storage

## Validation

- `pnpm check:types`
- `pnpm check` (passes with existing warnings)
- generic heading scan
- `git diff --check`
- `pnpm build` reached Vocs, then an external OpenAPI fetch timed out

Prompted by: @SuperFluffy