### PR TITLE
ci: open the broken-links issue with gh instead of a third-party action

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -58,8 +58,6 @@ jobs:
 
       - name: Open issue on scheduled failure
         if: failure() && github.event_name == 'schedule'
-        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
-        with:
-          title: "Broken external links detected"
-          content-filepath: ./lychee/out.md
-          labels: docs, links
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh issue create --title "Broken external links detected" --body-file lychee/out.md --label docs --label links


### PR DESCRIPTION
## Summary

The scheduled link check opens an issue when lychee finds broken external links. This replaces the third-party `peter-evans/create-issue-from-file` step with an inline `gh issue create` call, using the GitHub CLI already present on the runner and the job's `GITHUB_TOKEN`.

Same title ("Broken external links detected"), same body (`lychee/out.md`), same labels (`docs`, `links`). As before, each failing scheduled run opens a new issue.

## Verification

- `actionlint` passes; `zizmor` (regular persona, offline) reports no new findings (0 -> 0).