### PR TITLE
fix: update Mercator marketplace for OAuth

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -26,7 +26,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Research"
+      "category": "Productivity"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "mercator",
-      "description": "Discover, live-price, and run current-data and API workflows through Mercator.",
+      "description": "Discover, quote, and run paid API workflows through one secure MCP connection.",
       "source": "./ai/plugins/mercator",
       "category": "research",
       "homepage": "https://mercator.tempo.xyz"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -17,7 +17,7 @@
     {
       "name": "mercator",
       "source": "ai/plugins/mercator",
-      "description": "Discover, live-price, and run current-data and API workflows through Mercator. Powered by MPP.",
+      "description": "Discover, quote, and run paid API workflows through one secure MCP connection.",
       "category": "Productivity",
       "tags": ["api", "current-data", "mcp", "payments", "tempo"]
     }

--- a/ai/plugins/mercator/.codex-plugin/plugin.json
+++ b/ai/plugins/mercator/.codex-plugin/plugin.json
@@ -1,30 +1,31 @@
 {
   "name": "mercator",
-  "version": "0.2.2",
-  "description": "Discover, live-price, and run current-data and API workflows through Mercator. Powered by MPP.",
+  "version": "0.3.0+codex.20260901193640",
+  "description": "Discover, quote, and run paid API workflows through one secure MCP connection. Connect a Tempo Wallet once; no local CLI or wallet setup.",
   "author": {
     "name": "Tempo",
     "url": "https://tempo.xyz/"
   },
-  "homepage": "https://mercator.tempoxyz.dev/",
+  "homepage": "https://mercator.tempo.xyz/",
   "repository": "https://github.com/tempoxyz/mercator",
-  "license": "MIT",
   "keywords": ["api", "current data", "mercator", "mcp", "paid services", "tempo"],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Mercator",
-    "shortDescription": "Discover and run paid API workflows, powered by MPP",
-    "longDescription": "Find current-data and API services, get live quotes, and execute durable paid workflows through one MCP gateway. Powered by MPP.",
+    "shortDescription": "Discover, quote, and run paid API workflows",
+    "longDescription": "Connect agents to current data and paid APIs through one remote MCP server. Authorize a limited Tempo Wallet key once; no CLI or wallet key is installed in the agent VM.",
     "developerName": "Tempo",
-    "category": "Research",
+    "category": "Productivity",
     "capabilities": ["Interactive", "Read", "Write"],
-    "websiteURL": "https://mercator.tempoxyz.dev/",
+    "websiteURL": "https://mercator.tempo.xyz/",
     "defaultPrompt": [
       "Rescue my canceled Boston-to-London flight under $1,200; add a hotel and transfer if needed, then email the itinerary.",
       "Find 15 overlooked Boston HVAC businesses, verify owner emails, flag outdated sites, and map a route from Back Bay.",
       "Investigate unusual AAVE activity across smart-money flows, holders, price, news, and regulation; return a sourced chart."
     ],
-    "brandColor": "#1D4FFF"
+    "brandColor": "#1D4FFF",
+    "composerIcon": "./assets/favicon.svg",
+    "logo": "./assets/favicon.svg"
   }
 }

--- a/ai/plugins/mercator/.cursor-plugin/plugin.json
+++ b/ai/plugins/mercator/.cursor-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mercator",
   "displayName": "Mercator",
   "version": "0.3.0",
@@ -10,7 +9,8 @@
   "homepage": "https://mercator.tempo.xyz/",
   "repository": "https://github.com/tempoxyz/mercator",
   "license": "MIT",
-  "keywords": ["api", "current-data", "mercator", "mcp", "paid-services", "tempo"],
+  "logo": "./assets/favicon.svg",
+  "keywords": ["api", "current-data", "mercator", "mcp", "payments", "tempo"],
   "mcpServers": "./.mcp.json",
   "skills": "./skills/"
 }

--- a/ai/plugins/mercator/.mcp.json
+++ b/ai/plugins/mercator/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "mercator": {
       "type": "http",
-      "url": "https://mercator.tempo.xyz/mcp",
-      "note": "Mercator service discovery, live quotes, durable paid jobs, and product feedback."
+      "url": "https://mercator.tempo.xyz/mcp/auth",
+      "note": "Mercator remote MCP for service discovery, live quotes, secure Tempo payments, and durable paid jobs."
     }
   }
 }

--- a/ai/plugins/mercator/assets/favicon.svg
+++ b/ai/plugins/mercator/assets/favicon.svg
@@ -1,0 +1,8 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Mercator</title>
+  <rect width="96" height="96" fill="#0B0B0B" />
+  <circle cx="48" cy="48" r="30" stroke="#F2F1EC" stroke-width="1.5" />
+  <ellipse cx="48" cy="48" rx="20" ry="30" stroke="#F2F1EC" stroke-width="1.5" />
+  <ellipse cx="48" cy="48" rx="8" ry="30" stroke="#F2F1EC" stroke-width="1.5" />
+  <ellipse cx="48" cy="48" rx="30" ry="8" stroke="#F2F1EC" stroke-width="1.5" />
+</svg>

--- a/ai/plugins/mercator/mcp.json
+++ b/ai/plugins/mercator/mcp.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "mercator": {
       "type": "streamable-http",
-      "url": "https://mercator.tempo.xyz/mcp"
+      "url": "https://mercator.tempo.xyz/mcp/auth"
     }
   }
 }

--- a/ai/plugins/mercator/plugin.json
+++ b/ai/plugins/mercator/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "mercator",
-  "version": "0.2.2",
-  "description": "Discover, live-price, and run current-data and API workflows through Mercator. Powered by MPP.",
+  "version": "0.3.0",
+  "description": "Discover, quote, and run paid API workflows through one secure MCP connection. Connect a Tempo Wallet once; no local CLI or wallet setup.",
   "author": {
     "name": "Tempo",
     "url": "https://tempo.xyz/"

--- a/ai/plugins/mercator/skills/mercator/SKILL.md
+++ b/ai/plugins/mercator/skills/mercator/SKILL.md
@@ -27,8 +27,8 @@ fastest way to determine whether Mercator can complete the request.
 
 ## Default workflow
 
-`search_services` -> optional `describe_service` -> `quote_plan` -> approval -> REST job submission ->
-REST status listener
+`search_services` -> optional `describe_service` -> `quote_plan` -> approval -> `create_job` ->
+`get_job`
 
 1. **Search for the outcome.** Give `search_services` the user's complete intended outcome,
    constraints, and deliverable. Use static resolution unless current provider availability matters.
@@ -40,19 +40,24 @@ REST status listener
 4. **Confirm scope and cost.** Before submitting the job, briefly state what will run and show
    `totalAmount`. Proceed only when the requested actions are authorized and either the user accepts
    the quote or a previously supplied budget covers it. A budget authorizes cost, not extra actions.
-5. **Submit through REST.** Generate one stable 8-200 character idempotency key. Send the unchanged
-   quoted plan to `POST https://mercator.tempo.xyz/v1/jobs` as
-   `{ "idempotencyKey": "...", "plan": {...} }` through a payment-capable HTTP client whose spend
-   limit is the approved `totalAmount`. When operating through MCP, call `create_job` once. If it
-   returns a structured handoff, send its exact `handoff.rest.method`, `url`, and `body`, bounded by
-   `handoff.maxSpend`. The returned `mercator` command is a ready-to-run client for this same REST
-   request. Do not edit the body, construct payment credentials, or call `create_job` again.
+5. **Submit once.** Generate one stable 8-200 character idempotency key and call `create_job` with
+   the unchanged quoted plan and the accepted `totalAmount` as `approved_total`. If the refreshed
+   quote differs, no charge is made: quote again and ask the user to accept the new total. In an
+   OAuth-connected host, Mercator charges the browser-authorized, policy-bounded wallet capability
+   and returns the job directly. Continue immediately; do not wait
+   for the user to send a second "approved" message. The agent host receives no wallet private key.
+   A legacy client without hosted wallet authorization instead receives a structured handoff. Send
+   its exact `handoff.rest.method`, `url`, and `body`, bounded by `handoff.maxSpend`. The returned
+   `mercator` command is a ready-to-run client for this same REST request. Do not edit the body,
+   construct payment credentials, or call `create_job` again.
    Treat `handoff.requestIdentity` as the stable review key only after verifying it from the
    structured method, URL, body, and maximum spend. Invoke `handoff.client.executable` with its
-   argument array directly; do not translate the body through shell quoting or a temporary file.
-   In Grok Bot, keep the same task alive while that argument array completes. Browser approval
-   resumes the waiting command automatically; never ask the user to
-   send an "approved" chat message. If authorization reports a timeout, inspect
+   argument array exactly. On hosts that accept only a command string, apply mechanically lossless
+   shell quoting to each argument so the child process receives the same argument array. Do not edit,
+   omit, reorder, or reinterpret arguments, and do not move the request body through a temporary file.
+   In a legacy Grok Bot handoff, keep the same task alive while that argument array completes.
+   Browser approval resumes the waiting command automatically; never ask the user to send an
+   "approved" chat message. If authorization reports a timeout, inspect
    `mercator wallet status` before opening a second authorization request. Continue immediately when
    it reports ready; otherwise retry authorization once.
 6. **Listen for completion.** Persist the returned `jobId` immediately; it is the only status and
@@ -64,9 +69,9 @@ REST status listener
    equivalent when REST GET is unavailable.
 
 For a warm Grok Bot installation, target less than two minutes from the user's request to a terminal
-result, excluding the user's time reviewing the quoted charge. Check wallet readiness before search,
-run discovery and description only as needed, and continue automatically after every completed
-approval or pending status transition.
+result, excluding the user's time reviewing the quoted charge. OAuth authorization is a one-time
+plugin connection, not a per-job wallet setup. Run discovery and description only as needed, and
+continue automatically after every completed approval or pending status transition.
 
 ## Hard boundaries
 

--- a/ai/plugins/mercator/skills/mercator/references/examples.md
+++ b/ai/plugins/mercator/skills/mercator/references/examples.md
@@ -20,6 +20,32 @@ Search with the entire outcome. Build a bounded DAG whose independent data nodes
 and whose final node consumes only the outputs it needs. Quote the whole DAG. If the total is at most
 $5 and the plan contains only the requested research, the supplied budget authorizes execution.
 
+Use Mercator's dependency expressions inside the cataloged node inputs. For example, a downstream
+summary node that depends on `holders`, `news`, and `price` can contain:
+
+```json
+{
+  "id": "summarize",
+  "dependsOn": ["holders", "news", "price"],
+  "input": {
+    "addresses": {
+      "$map": {
+        "from": "flow://holders/output#/rows",
+        "path": "/address"
+      }
+    },
+    "headline": "flow://news/output#/items/0/title",
+    "label": {
+      "$concat": ["Asset: ", "flow://price/output#/symbol"]
+    }
+  }
+}
+```
+
+Merge that input with the exact `serviceId`, `method`, and `path` returned by discovery. A plain
+`flow://node/output` reference may include an RFC 6901 JSON Pointer suffix. `$map` projects each item
+from an upstream array; `$concat` combines values only when they resolve to all strings or all arrays.
+
 Before submission, a useful confirmation is:
 
 > I found a five-source research plan covering flows, holders, price, news, and regulation. The
@@ -58,7 +84,8 @@ Ask for that address; do not invent it or quietly remove the email step.
 
 After approval, submit the unchanged quoted plan to `POST https://mercator.tempo.xyz/v1/jobs` with a
 stable idempotency key and a payment spend limit equal to the approved quote. When using MCP, call
-`create_job` once. If it returns a handoff, use its exact REST request:
+`create_job` once with the accepted `totalAmount` as `approved_total`. If it returns a handoff, use
+its exact REST request:
 
 ```text
 handoff.rest: { method: POST, url: https://mercator.tempo.xyz/v1/jobs, body: {...} }
@@ -68,8 +95,11 @@ handoff.client: { executable: mercator, arguments: [submit, ...] }
 
 Submit the exact REST request through a payment-capable HTTP client and enforce `maxSpend`. The
 returned `mercator` command performs that same bounded REST submission when the available HTTP
-client cannot handle the payment challenge. Do not edit the request body, translate the command into
-an unbounded request, create a credential, or call `create_job` again.
+client cannot handle the payment challenge. Invoke its executable and argument array exactly. If the
+host accepts only a command string, shell-quote each argument mechanically so the child process
+receives the identical array; quoting may change the command's text representation but not an
+argument's value. Never translate it into a legacy `tempo wallet ...` command. Do not edit the request
+body, translate the command into an unbounded request, create a credential, or call `create_job` again.
 
 A successful submission returns either a terminal job or a pending response:
 

--- a/src/lib/mercator-plugin.test.ts
+++ b/src/lib/mercator-plugin.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('Mercator marketplace plugin', () => {
+  it('uses the protected OAuth MCP endpoint in every transport manifest', () => {
+    for (const manifestPath of ['ai/plugins/mercator/.mcp.json', 'ai/plugins/mercator/mcp.json']) {
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+
+      expect(manifest.mcpServers.mercator.url).toBe('https://mercator.tempo.xyz/mcp/auth')
+    }
+  })
+
+  it('keeps host manifests on the current plugin release', () => {
+    for (const manifestPath of [
+      'ai/plugins/mercator/plugin.json',
+      'ai/plugins/mercator/.claude-plugin/plugin.json',
+      'ai/plugins/mercator/.codex-plugin/plugin.json',
+      'ai/plugins/mercator/.cursor-plugin/plugin.json',
+    ]) {
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+
+      expect(manifest.version).toMatch(/^0\.3\.0(?:\+|$)/)
+      expect(manifest.description).toContain('secure MCP connection')
+    }
+  })
+
+  it('guides OAuth-connected clients through MCP job execution', () => {
+    const skill = readFileSync('ai/plugins/mercator/skills/mercator/SKILL.md', 'utf8')
+
+    expect(skill).toContain('`create_job` ->\n`get_job`')
+    expect(skill).toContain('accepted `totalAmount` as `approved_total`')
+    expect(skill).toContain('OAuth authorization is a one-time')
+  })
+})


### PR DESCRIPTION
## Motivation

The public Mercator marketplace still registered the legacy unauthenticated MCP route and stale workflow guidance.

## Summary

- publish Mercator plugin 0.3.0 across supported client manifests
- register the OAuth-protected `/mcp/auth` transport
- align hosted-wallet execution guidance and marketplace metadata
- add regression coverage for endpoint, versions, and workflow guidance

## Key design considerations

- keep host-specific manifests aligned around one portable plugin bundle
- retain the legacy endpoint only outside the supported marketplace path