### PR TITLE
fix: publish MCP-only Mercator guidance

### DIFF
--- a/ai/plugins/mercator/.claude-plugin/plugin.json
+++ b/ai/plugins/mercator/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mercator",
   "displayName": "Mercator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Discover, quote, and run paid API workflows through one secure MCP connection. Connect a Tempo Wallet once; no local CLI or wallet setup.",
   "author": {
     "name": "Tempo"

--- a/ai/plugins/mercator/.codex-plugin/plugin.json
+++ b/ai/plugins/mercator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mercator",
-  "version": "0.3.0+codex.20260901193640",
+  "version": "0.3.1+codex.20260902183800",
   "description": "Discover, quote, and run paid API workflows through one secure MCP connection. Connect a Tempo Wallet once; no local CLI or wallet setup.",
   "author": {
     "name": "Tempo",

--- a/ai/plugins/mercator/.cursor-plugin/plugin.json
+++ b/ai/plugins/mercator/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mercator",
   "displayName": "Mercator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Discover, quote, and run paid API workflows through one secure MCP connection. Connect a Tempo Wallet once; no local CLI or wallet setup.",
   "author": {
     "name": "Tempo"

--- a/ai/plugins/mercator/plugin.json
+++ b/ai/plugins/mercator/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "mercator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Discover, quote, and run paid API workflows through one secure MCP connection. Connect a Tempo Wallet once; no local CLI or wallet setup.",
   "author": {
     "name": "Tempo",

--- a/ai/plugins/mercator/skills/mercator/SKILL.md
+++ b/ai/plugins/mercator/skills/mercator/SKILL.md
@@ -46,8 +46,9 @@ fastest way to determine whether Mercator can complete the request.
    OAuth-connected host, Mercator charges the browser-authorized, policy-bounded wallet capability
    and returns the job directly. Continue immediately; do not wait for the user to send a second
    "approved" message. The agent host receives no wallet private key. Other clients complete payment
-   challenges through MCP metadata. Never install or invoke a CLI, translate the request into REST,
-   construct payment credentials, or call `create_job` again.
+   challenges through MCP metadata. If MCP submission and one retry both fail, a host that already
+   has a ready local Mercator wallet may submit the equivalent bounded REST request with the same
+   plan, idempotency key, and approved total. Never install, create, or connect a wallet for fallback.
 6. **Listen for completion.** Persist the returned `jobId` immediately; it is the only status and
    resumption capability. Poll `get_job` with bounded backoff. `ready:false` means the durable job is
    still pending or running. `ready:true` is terminal: return either its cached `result` or stable
@@ -75,6 +76,9 @@ continue automatically after every completed approval or pending status transiti
 - On a stale endpoint or invalid quote, search again, rebuild, and re-quote.
 - After an uncertain MCP submission, call `create_job` with the same idempotency key and unchanged
   plan. This recovers the same logical job without duplicating execution or payment.
+- If that retry fails and a ready local Mercator wallet already exists, a payment-capable local client
+  may submit the same plan to `POST /v1/jobs` with the same idempotency key and a maximum spend equal
+  to `approved_total`. This is an explicit fallback, never an MCP response handoff.
 - If status polling is interrupted, resume `get_job` with the job ID. Do not resubmit merely because a
   job remains pending; report the job ID and last status if the caller's wait limit is reached.
 - Use `create_job_review` only when the user wants to review a completed job. Use

--- a/ai/plugins/mercator/skills/mercator/SKILL.md
+++ b/ai/plugins/mercator/skills/mercator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mercator
-description: Use Mercator to discover, quote, and run fresh external research or API actions across extraction, enrichment, social, maps, travel, communications, media, financial, and on-chain data. Covers REST job submission, durable status tracking, and recovery; not for local files, repository work, supplied-content reasoning, or requests that forbid external or paid services.
+description: Use Mercator to discover, quote, and run fresh external research or API actions across extraction, enrichment, social, maps, travel, communications, media, financial, and on-chain data. Covers MCP job submission, durable status tracking, and recovery; not for local files, repository work, supplied-content reasoning, or requests that forbid external or paid services.
 ---
 
 # Mercator
@@ -44,29 +44,15 @@ fastest way to determine whether Mercator can complete the request.
    the unchanged quoted plan and the accepted `totalAmount` as `approved_total`. If the refreshed
    quote differs, no charge is made: quote again and ask the user to accept the new total. In an
    OAuth-connected host, Mercator charges the browser-authorized, policy-bounded wallet capability
-   and returns the job directly. Continue immediately; do not wait
-   for the user to send a second "approved" message. The agent host receives no wallet private key.
-   A legacy client without hosted wallet authorization instead receives a structured handoff. Send
-   its exact `handoff.rest.method`, `url`, and `body`, bounded by `handoff.maxSpend`. The returned
-   `mercator` command is a ready-to-run client for this same REST request. Do not edit the body,
+   and returns the job directly. Continue immediately; do not wait for the user to send a second
+   "approved" message. The agent host receives no wallet private key. Other clients complete payment
+   challenges through MCP metadata. Never install or invoke a CLI, translate the request into REST,
    construct payment credentials, or call `create_job` again.
-   Treat `handoff.requestIdentity` as the stable review key only after verifying it from the
-   structured method, URL, body, and maximum spend. Invoke `handoff.client.executable` with its
-   argument array exactly. On hosts that accept only a command string, apply mechanically lossless
-   shell quoting to each argument so the child process receives the same argument array. Do not edit,
-   omit, reorder, or reinterpret arguments, and do not move the request body through a temporary file.
-   In a legacy Grok Bot handoff, keep the same task alive while that argument array completes.
-   Browser approval resumes the waiting command automatically; never ask the user to send an
-   "approved" chat message. If authorization reports a timeout, inspect
-   `mercator wallet status` before opening a second authorization request. Continue immediately when
-   it reports ready; otherwise retry authorization once.
 6. **Listen for completion.** Persist the returned `jobId` immediately; it is the only status and
-   resumption capability. Poll `GET /v1/jobs/{jobId}` with bounded backoff. HTTP `202` with
-   `{jobId, ready:false}` means the durable job is still pending or running. HTTP `200` with
-   `ready:true` is terminal: return either its cached `result` or stable `error` to the user. A client
-   timeout or disconnect does not cancel the job. Mercator has no job webhook or SSE stream, so a
-   status listener must keep polling or resume later with the same job ID. `get_job` is the MCP
-   equivalent when REST GET is unavailable.
+   resumption capability. Poll `get_job` with bounded backoff. `ready:false` means the durable job is
+   still pending or running. `ready:true` is terminal: return either its cached `result` or stable
+   `error` to the user. A client timeout or disconnect does not cancel the job. Mercator has no job
+   webhook or SSE stream, so a status listener must keep polling or resume later with the same job ID.
 
 For a warm Grok Bot installation, target less than two minutes from the user's request to a terminal
 result, excluding the user's time reviewing the quoted charge. OAuth authorization is a one-time
@@ -87,13 +73,13 @@ continue automatically after every completed approval or pending status transiti
 - Follow a recoverable tool error's `next_action` when it stays within the user's request.
 - Broaden an unconstrained zero-result search once; never remove a required service constraint.
 - On a stale endpoint or invalid quote, search again, rebuild, and re-quote.
-- After an uncertain REST submission, repeat the identical request with the same idempotency key and
-  unchanged plan. This recovers the same logical job without duplicating execution or payment.
-- If status polling is interrupted, resume `GET /v1/jobs/{jobId}`. Do not resubmit merely because a
+- After an uncertain MCP submission, call `create_job` with the same idempotency key and unchanged
+  plan. This recovers the same logical job without duplicating execution or payment.
+- If status polling is interrupted, resume `get_job` with the job ID. Do not resubmit merely because a
   job remains pending; report the job ID and last status if the caller's wait limit is reached.
 - Use `create_job_review` only when the user wants to review a completed job. Use
   `send_product_feedback` only when the user explicitly asks to contact Mercator maintainers, after
   showing the approved summary and removing sensitive data.
 
 Read [examples](references/examples.md) for compound research, external actions, approval language,
-REST submission, status listening, and recovery patterns.
+MCP submission, status listening, and recovery patterns.

--- a/ai/plugins/mercator/skills/mercator/references/examples.md
+++ b/ai/plugins/mercator/skills/mercator/references/examples.md
@@ -107,6 +107,13 @@ Persist the job ID and start a status listener with:
 
 Do not model completion as a webhook or SSE subscription: the public status interface is polling.
 
+## Existing local wallet fallback
+
+Use REST only when MCP submission fails, one identical retry also fails, and the host already has a
+ready local Mercator wallet. Submit the same plan to `POST https://mercator.tempo.xyz/v1/jobs` with
+the same idempotency key and a maximum spend equal to `approved_total`. Never install, create, or
+connect a wallet for fallback. Resume job polling through MCP `get_job` with the returned job ID.
+
 ## No result or stale endpoint
 
 - Unconstrained search with no result: broaden the outcome once while preserving user constraints.

--- a/ai/plugins/mercator/skills/mercator/references/examples.md
+++ b/ai/plugins/mercator/skills/mercator/references/examples.md
@@ -80,26 +80,12 @@ be inferred safely. Then quote the completed plan.
 For example, an email action may require a recipient address that is absent from the conversation.
 Ask for that address; do not invent it or quietly remove the email step.
 
-## REST submission and status
+## MCP submission and status
 
-After approval, submit the unchanged quoted plan to `POST https://mercator.tempo.xyz/v1/jobs` with a
-stable idempotency key and a payment spend limit equal to the approved quote. When using MCP, call
-`create_job` once with the accepted `totalAmount` as `approved_total`. If it returns a handoff, use
-its exact REST request:
-
-```text
-handoff.rest: { method: POST, url: https://mercator.tempo.xyz/v1/jobs, body: {...} }
-handoff.maxSpend: 3.80
-handoff.client: { executable: mercator, arguments: [submit, ...] }
-```
-
-Submit the exact REST request through a payment-capable HTTP client and enforce `maxSpend`. The
-returned `mercator` command performs that same bounded REST submission when the available HTTP
-client cannot handle the payment challenge. Invoke its executable and argument array exactly. If the
-host accepts only a command string, shell-quote each argument mechanically so the child process
-receives the identical array; quoting may change the command's text representation but not an
-argument's value. Never translate it into a legacy `tempo wallet ...` command. Do not edit the request
-body, translate the command into an unbounded request, create a credential, or call `create_job` again.
+After approval, call `create_job` once with the unchanged quoted plan, a stable idempotency key, and
+the accepted `totalAmount` as `approved_total`. OAuth-connected hosts charge the bounded wallet
+inside Mercator. Other clients complete any payment challenge through MCP metadata. Never install a
+CLI or translate MCP submission into a REST request.
 
 A successful submission returns either a terminal job or a pending response:
 
@@ -107,18 +93,17 @@ A successful submission returns either a terminal job or a pending response:
 {"jobId":"4d9ea616-4223-4b9d-bd19-2d3f74c9fa4c","ready":false}
 ```
 
-Persist the job ID and start a status listener for:
+Persist the job ID and start a status listener with:
 
-```http
-GET https://mercator.tempo.xyz/v1/jobs/4d9ea616-4223-4b9d-bd19-2d3f74c9fa4c
-Accept: application/json
+```json
+{"job_id":"4d9ea616-4223-4b9d-bd19-2d3f74c9fa4c"}
 ```
 
-- `202` and `ready:false`: wait with bounded backoff, then GET the same URL again.
-- `200` and `ready:true`: stop; return the cached success result or stable failure.
+- `ready:false`: wait with bounded backoff, then call `get_job` again.
+- `ready:true`: stop; return the cached success result or stable failure.
 - Caller wait limit reached: return the job ID and last known status so listening can resume later.
-- Request timeout or lost response: retry the identical REST submission with the same idempotency
-  key to recover the job, then listen on its returned job ID.
+- Request timeout or lost response: call `create_job` with the identical plan and idempotency key to
+  recover the job, then listen on its returned job ID.
 
 Do not model completion as a webhook or SSE subscription: the public status interface is polling.
 

--- a/src/lib/mercator-plugin.test.ts
+++ b/src/lib/mercator-plugin.test.ts
@@ -19,7 +19,7 @@ describe('Mercator marketplace plugin', () => {
     ]) {
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
 
-      expect(manifest.version).toMatch(/^0\.3\.0(?:\+|$)/)
+      expect(manifest.version).toMatch(/^0\.3\.1(?:\+|$)/)
       expect(manifest.description).toContain('secure MCP connection')
     }
   })
@@ -30,5 +30,7 @@ describe('Mercator marketplace plugin', () => {
     expect(skill).toContain('`create_job` ->\n`get_job`')
     expect(skill).toContain('accepted `totalAmount` as `approved_total`')
     expect(skill).toContain('OAuth authorization is a one-time')
+    expect(skill).toContain('ready local Mercator wallet')
+    expect(skill).toContain('Never install, create, or connect a wallet for fallback')
   })
 })


### PR DESCRIPTION
## Motivation

The public Mercator marketplace plugin still instructed clients to leave MCP and execute a REST/CLI handoff that the server no longer returns.

## Summary

- publish Mercator plugin version 0.3.1 across supported manifests
- keep payment challenges in MCP metadata
- use create_job and get_job for submission, recovery, and polling

## Key design considerations

- mirrors the canonical Mercator skill exactly
- leaves explicit REST integrations unchanged