### PR TITLE
feat(ai): support Tempo product feedback submissions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -24,8 +24,12 @@ Use the hosted MCP server at `https://mcp.tempo.xyz` first. It exposes these too
 | `find_pages` | Find matching page URLs from a source index |
 | `read_page` | Read one cleaned documentation page |
 | `code` | Run multi-step documentation lookups |
+| `send_product_feedback` | Submit approved, sanitized Tempo feedback when available |
 
-If a user reports stale, missing, or confusing Tempo docs while using MCP context, send sanitized feedback to `https://tempo.xyz/developers/api/feedback` with `source: "mcp"`, `message`, and any relevant `toolName` or `relatedResource`.
+Use `send_product_feedback` only when the user explicitly asks to submit feedback
+or report a bug and the server lists the tool. Troubleshooting is not submission
+authorization. Return the report ID after a successful submission; if the tool
+is unavailable or fails, do not imply that the report was accepted.
 
 ## Direct fallbacks
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -18,15 +18,15 @@ Use the hosted MCP server:
 https://mcp.tempo.xyz
 ```
 
-The current server exposes `search`, `find_pages`, `read_page`, and `code` for documentation search, page discovery, cleaned page reads, and multi-step lookups. Wallet and paid-request workflows are handled by the `tempo-wallet` skill using the Tempo CLI.
+The server exposes `search`, `find_pages`, `read_page`, and `code` for documentation search, page discovery, cleaned page reads, and multi-step lookups. Deployments that list `send_product_feedback` can also submit explicitly approved, sanitized Tempo feedback. Wallet and paid-request workflows are handled by the `tempo-wallet` skill using the Tempo CLI.
 
-Feedback from MCP clients should be sent to the shared docs ingress:
+The MCP server sends approved product feedback to the shared docs ingress:
 
 ```txt
 POST https://tempo.xyz/developers/api/feedback
 ```
 
-Use `source: "mcp"` plus a short `message`, and include `toolName`, `relatedResource`, or `client` when available.
+Clients must use the registered MCP tool rather than posting to the ingress directly.
 
 ## Codex
 

--- a/ai/plugins/tempo/skills/tempo/SKILL.md
+++ b/ai/plugins/tempo/skills/tempo/SKILL.md
@@ -7,7 +7,8 @@ description: >
   MPP, the Tempo API, indexer queries, stablecoin issuance, the Stablecoin
   DEX, contract verification, SDKs, or Tempo protocol concepts. For agent
   wallet setup, service discovery, or paid HTTP requests, use the tempo-wallet
-  skill.
+  skill. Also use this skill when the user explicitly asks to submit Tempo
+  product feedback or a Tempo bug report.
 ---
 
 # Tempo Developer Skill
@@ -37,6 +38,24 @@ verify them from docs before writing code.
 
 Read the relevant page before answering an integration question or changing
 code. Use the docs page’s linked examples when available.
+
+## Product feedback
+
+Use `send_product_feedback` only when the user explicitly asks to send Tempo
+feedback or report a bug and the hosted MCP server currently exposes the tool.
+Mentioning an error or asking for troubleshooting is not authorization to submit
+a report. Diagnose the issue first when that is what the user requested.
+
+Before submission, show or confirm the concise report content. Include only the
+minimum sanitized reproduction details. Never include secrets, credentials,
+private keys, payment material, personal data, wallet or session identifiers,
+transaction hashes, or raw tool inputs or outputs. `tempo wallet debug` may help
+with diagnosis, but never attach its complete output automatically.
+
+On success, return the `report_id` to the user. On failure, say that submission
+failed and do not imply acceptance. If `send_product_feedback` is absent, explain
+that the installed MCP server cannot submit the report; do not post directly to
+an undocumented endpoint or claim the report was sent.
 
 ## Implementation Defaults
 

--- a/src/lib/feedback-api.test.ts
+++ b/src/lib/feedback-api.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const submit = vi.fn()
+
+vi.mock('vocs/config', () => ({
+  Feedback: {
+    slack: () => ({ submit }),
+  },
+}))
+
+import feedback from '../pages/_api/api/feedback'
+
+beforeEach(() => {
+  process.env.SLACK_FEEDBACK_WEBHOOK = 'https://hooks.slack.test/services/example'
+  submit.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  delete process.env.SLACK_FEEDBACK_WEBHOOK
+  vi.clearAllMocks()
+})
+
+describe('product feedback API', () => {
+  it('acknowledges a delivered product feedback report', async () => {
+    const response = await feedback(
+      new Request('https://tempo.xyz/api/feedback', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          source: 'mcp',
+          kind: 'feedback',
+          summary: 'Search result ordering',
+          details: 'Prefer exact title matches first.',
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toMatchObject({
+      accepted: true,
+      report_id: expect.stringMatching(/^fb_[a-z0-9]+_[0-9a-f-]{36}$/),
+    })
+    expect(submit).toHaveBeenCalledOnce()
+  })
+
+  it('does not acknowledge a product feedback delivery failure', async () => {
+    submit.mockRejectedValue(new Error('delivery unavailable'))
+    const response = await feedback(
+      new Request('https://tempo.xyz/api/feedback', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          source: 'mcp',
+          kind: 'bug_report',
+          summary: 'Search misses a page',
+          details: 'The page does not appear in search results.',
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      accepted: false,
+      error: 'Submission failed',
+    })
+  })
+})

--- a/src/lib/feedback.test.ts
+++ b/src/lib/feedback.test.ts
@@ -63,6 +63,38 @@ describe('normalizeFeedback', () => {
     expect(() => normalizeFeedback({ source: 'mcp', toolName: 'read_page' })).toThrow(FeedbackError)
   })
 
+  it('normalizes structured MCP product feedback', () => {
+    const feedback = normalizeFeedback({
+      kind: 'bug_report',
+      summary: 'Search misses a page',
+      details: 'A documented page does not appear in search results.',
+      steps_to_reproduce: 'Search for the exact page title.',
+      expected_behavior: 'The page is returned.',
+      actual_behavior: 'No matching page is returned.',
+    })
+
+    expect(feedback).toMatchObject({
+      id: expect.stringMatching(/^fb_[a-z0-9]+_[0-9a-f-]{36}$/),
+      source: 'mcp',
+      kind: 'bug_report',
+      summary: 'Search misses a page',
+      details: 'A documented page does not appear in search results.',
+      stepsToReproduce: 'Search for the exact page title.',
+      expectedBehavior: 'The page is returned.',
+      actualBehavior: 'No matching page is returned.',
+    })
+  })
+
+  it('rejects incomplete structured MCP product feedback', () => {
+    expect(() =>
+      normalizeFeedback({
+        kind: 'feedback',
+        summary: 'Search result ordering',
+        details: '',
+      }),
+    ).toThrow(FeedbackError)
+  })
+
   it('requires docs helpful value', () => {
     expect(() =>
       normalizeFeedback({ source: 'docs', pageUrl: 'https://tempo.xyz/developers' }),

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -6,7 +6,7 @@ const maxMessageLength = 4_000
 const maxShortLength = 160
 const maxUrlLength = 2_048
 
-const feedbackInputSchema = z
+const legacyFeedbackInputSchema = z
   .object({
     source: z.enum(['docs', 'mcp']).optional(),
     helpful: z.boolean().optional(),
@@ -24,6 +24,20 @@ const feedbackInputSchema = z
   })
   .strict()
 
+const productFeedbackInputSchema = z
+  .object({
+    source: z.literal('mcp').optional(),
+    kind: z.enum(['bug_report', 'feedback']),
+    summary: z.string().trim().min(1).max(200),
+    details: z.string().trim().min(1).max(3_000),
+    steps_to_reproduce: z.string().trim().min(1).max(2_000).optional(),
+    expected_behavior: z.string().trim().min(1).max(2_000).optional(),
+    actual_behavior: z.string().trim().min(1).max(2_000).optional(),
+  })
+  .strict()
+
+const feedbackInputSchema = z.union([legacyFeedbackInputSchema, productFeedbackInputSchema])
+
 export type FeedbackInput = z.input<typeof feedbackInputSchema>
 
 export type NormalizedFeedback = {
@@ -40,6 +54,12 @@ export type NormalizedFeedback = {
   relatedResource?: string | undefined
   client?: string | undefined
   requestId?: string | undefined
+  kind?: 'bug_report' | 'feedback' | undefined
+  summary?: string | undefined
+  details?: string | undefined
+  stepsToReproduce?: string | undefined
+  expectedBehavior?: string | undefined
+  actualBehavior?: string | undefined
 }
 
 export type SubmitFeedbackResult = {
@@ -76,6 +96,8 @@ export function normalizeFeedback(input: FeedbackInput): NormalizedFeedback {
   if (!parsed.success) throw new FeedbackError('Invalid feedback payload', 400)
 
   const data = parsed.data
+  if ('kind' in data) return normalizeProductFeedback(data)
+
   const source = data.source ?? (typeof data.helpful === 'boolean' ? 'docs' : 'mcp')
   const pageUrl = cleanUrl(data.pageUrl)
   const path = cleanPath(data.path ?? pathFromUrl(pageUrl))
@@ -103,6 +125,23 @@ export function normalizeFeedback(input: FeedbackInput): NormalizedFeedback {
     throw new FeedbackError('MCP feedback requires message or category', 400)
 
   return feedback
+}
+
+function normalizeProductFeedback(
+  data: z.infer<typeof productFeedbackInputSchema>,
+): NormalizedFeedback {
+  return {
+    id: `fb_${Date.now().toString(36)}_${crypto.randomUUID()}`,
+    source: 'mcp',
+    sentiment: 'neutral',
+    timestamp: new Date().toISOString(),
+    kind: data.kind,
+    summary: redactSecrets(data.summary),
+    details: redactSecrets(data.details),
+    stepsToReproduce: optionalRedactedText(data.steps_to_reproduce),
+    expectedBehavior: optionalRedactedText(data.expected_behavior),
+    actualBehavior: optionalRedactedText(data.actual_behavior),
+  }
 }
 
 export function redactSecrets(value: string): string {
@@ -139,6 +178,10 @@ function cleanText(value: string | undefined, maxLength: number) {
   if (typeof value !== 'string') return undefined
   const cleaned = redactSecrets(value.replace(/\s+/g, ' ').trim()).slice(0, maxLength)
   return cleaned || undefined
+}
+
+function optionalRedactedText(value: string | undefined) {
+  return value ? redactSecrets(value) : undefined
 }
 
 function cleanPath(value: string | undefined) {
@@ -183,6 +226,23 @@ function sentimentFromHelpful(helpful: boolean | undefined) {
 }
 
 function toVocsFeedback(feedback: NormalizedFeedback) {
+  if (feedback.kind) {
+    return {
+      helpful: false,
+      category: feedback.kind === 'bug_report' ? 'MCP bug report' : 'MCP product feedback',
+      message: compact([
+        `Report ID: ${feedback.id}`,
+        feedback.summary,
+        feedback.details,
+        feedback.stepsToReproduce && `Steps to reproduce: ${feedback.stepsToReproduce}`,
+        feedback.expectedBehavior && `Expected behavior: ${feedback.expectedBehavior}`,
+        feedback.actualBehavior && `Actual behavior: ${feedback.actualBehavior}`,
+      ]).join('\n\n'),
+      pageUrl: 'https://mcp.tempo.xyz',
+      timestamp: feedback.timestamp,
+    }
+  }
+
   if (feedback.source === 'docs') {
     return {
       helpful: feedback.helpful ?? feedback.sentiment === 'positive',

--- a/src/pages/_api/api/feedback.ts
+++ b/src/pages/_api/api/feedback.ts
@@ -17,6 +17,10 @@ app.post('/api/feedback', async (c) => {
   try {
     const body = await parseFeedbackRequest(c.req.raw)
     const result = await submitFeedback(body)
+    if (result.feedback.kind) {
+      if (!result.delivered) return c.json({ accepted: false, error: 'Submission failed' }, 503)
+      return c.json({ accepted: true, report_id: result.feedback.id }, 201)
+    }
     return c.json({ success: true, id: result.feedback.id, delivered: result.delivered })
   } catch (error) {
     if (error instanceof FeedbackError) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,9 +115,9 @@ function marketingPages(): Plugin {
 }
 
 const llmsAgentNotice = [
-  '> Tempo MCP: Use `search`, `find_pages`, `read_page`, and `code` at `https://mcp.tempo.xyz` for current Tempo and related documentation.',
+  '> Tempo MCP: Use `search`, `find_pages`, `read_page`, and `code` at `https://mcp.tempo.xyz` for current Tempo and related documentation. When the server lists `send_product_feedback`, use it only after the user explicitly asks to submit Tempo feedback or a bug report.',
   '>',
-  '> Feedback: If these docs are stale, missing, or confusing, post sanitized feedback to `https://tempo.xyz/developers/api/feedback` with `source: "mcp"`, a short `message`, and any relevant `toolName`, `relatedResource`, or `client`.',
+  '> Feedback: Troubleshooting is not authorization to submit a report. Never send secrets, personal data, wallet or session identifiers, transaction hashes, payment material, or raw tool inputs or outputs.',
   '',
 ].join('\n')
 


### PR DESCRIPTION
## Summary

- extend the existing feedback ingress with the structured Tempo product-feedback contract and confirmed delivery acknowledgements
- return `accepted: true` with a stable `report_id` only after the receiving Slack path succeeds
- update the canonical Tempo skill and linked provider copy with explicit-authorization, sanitization, troubleshooting, and failure rules

## Validation

- `pnpm check`
- `pnpm check:types`
- `CI=true OPENAPI_SPEC_URL=<minimal-local-spec> pnpm test -- src/lib/feedback.test.ts src/lib/feedback-api.test.ts` (367 tests)
- `quick_validate.py ai/plugins/tempo/skills/tempo`
- `quick_validate.py .`
- `pnpm build` reached link validation; the live OpenAPI spec was unavailable in the sandbox, and the minimal substitute cannot provide generated API routes

Prompted by: @mattsse