### PR TITLE
docs(validator): document follower WebSocket setup

### DIFF
--- a/src/pages/docs/guide/node/validator-topology.mdx
+++ b/src/pages/docs/guide/node/validator-topology.mdx
@@ -31,7 +31,7 @@ The validator has two types of network relationships:
 - **Consensus P2P:** The validator communicates directly with other Tempo validators.
 - **Execution P2P:** The validator peers only with its operator's trusted RPC nodes over TCP and UDP. It does not establish execution P2P connections with other validators or public peers.
 
-The execution P2P layer is open, so place trusted RPC nodes between the validator and that network. Configure each trusted RPC node with `--follow <VALIDATOR_JSON_RPC>` so it syncs in lockstep with the validator.
+The execution P2P layer is open, so place trusted RPC nodes between the validator and that network. Configure each trusted RPC node with `--follow ws://<VALIDATOR_PRIVATE_IP>:8546` so it syncs in lockstep with the validator over a private WebSocket connection.
 
 Run at least two trusted RPC nodes for each validator to avoid a single point of failure for execution P2P and transaction ingress:
 
@@ -88,7 +88,8 @@ Firewall for the validator (default ports):
 | --- | --- | --- | --- |
 | Consensus P2P | Other Tempo validators | `8000/TCP` | Allow |
 | Execution P2P | Trusted RPC hosts | `30303/TCP` and `30303/UDP` | Allow |
-| JSON-RPC | Trusted RPC hosts | `8545/TCP` | Allow |
+| WebSocket JSON-RPC | Trusted RPC hosts | `8546/TCP` | Allow |
+| HTTP JSON-RPC management | Validator host only (loopback) | `8545/TCP` | Deny remote access |
 | All other inbound traffic | Any source | Any port | Deny |
 
 Restrict the validator's execution peer configuration to the trusted follower RPC nodes. Do not include other validators in this allowlist, and do not rely on peer discovery alone to provide isolation.
@@ -109,7 +110,11 @@ Concatenate these `enode://` URLs, passed to the validator command:
 tempo node <EXISTING_ARGUMENTS> \
   --disable-discovery \
   --trusted-only \
-  --trusted-peers "enode://<FOLLOWER_A_PUBLIC_KEY>@<FOLLOWER_A_PRIVATE_IP>:30303,enode://<FOLLOWER_B_PUBLIC_KEY>@<FOLLOWER_B_PRIVATE_IP>:30303"
+  --trusted-peers "enode://<FOLLOWER_A_PUBLIC_KEY>@<FOLLOWER_A_PRIVATE_IP>:30303,enode://<FOLLOWER_B_PUBLIC_KEY>@<FOLLOWER_B_PRIVATE_IP>:30303" \
+  --ws \
+  --ws.addr <VALIDATOR_PRIVATE_IP> \
+  --ws.port 8546 \
+  --ws.api eth,consensus
 ```
 
 Each flag serves a specific purpose:
@@ -122,18 +127,25 @@ Each flag serves a specific purpose:
 
 Keep the firewall allowlist in place. The enode allowlist authenticates the followers' execution P2P identities, while the firewall restricts which private IPs can reach the validator's P2P port.
 
-## Add or remove trusted RPC nodes without restarting
+The `--ws` flags enable the validator's WebSocket endpoint for followers. Follow mode uses `consensus` RPC subscriptions and finalization data, plus `eth` RPC calls to fetch blocks. `--http` alone does not enable WebSocket subscriptions. Bind WebSocket RPC to the validator's private interface and allow port `8546/TCP` only from trusted RPC hosts.
 
-Enable the `admin` RPC namespace on a localhost-only management endpoint at validator startup to change the in-memory trusted peer set while the validator is running. Never add `admin` to an endpoint reachable by followers, clients, or the public internet:
+### Add or remove trusted RPC nodes without restarting
+
+Enable the `admin` RPC namespace on a localhost-only HTTP management endpoint at validator startup to change the in-memory trusted peer set while the validator is running. Add these flags to the validator command above, keeping its private WebSocket endpoint enabled:
 
 ```bash
 tempo node <EXISTING_ARGUMENTS> \
   --http \
   --http.addr 127.0.0.1 \
+  --http.port 8545 \
   --http.api eth,net,web3,admin
 ```
 
-If the validator already enables other HTTP namespaces on this localhost-only endpoint, preserve them when adding `admin`. Use a separate, network-private transport for the follower's `--follow` connection. Enabling the namespace after startup requires a validator restart.
+Here, "trusted" means the RPC node is allowed to exchange execution P2P traffic with the validator. It does not grant permission to administer the validator. `--trusted-peers` and `--trusted-only` control execution P2P connections; they do not authenticate or restrict JSON-RPC callers. A compromised follower must not be able to change the validator's peer allowlist.
+
+Keep `admin` on `http://127.0.0.1:8545`, accessible only from the validator host. Never include it in `--ws.api` on the follower-facing endpoint or expose the management endpoint through a proxy to followers, clients, or the public internet. The two endpoints belong to the same validator process but use separate bind addresses, ports, and RPC namespace lists.
+
+If the validator already enables other HTTP namespaces on this localhost-only endpoint, preserve them when adding `admin`. Enabling the namespace after startup requires a validator restart. Run the following management commands on the validator host.
 
 Add a trusted RPC node immediately:
 
@@ -161,11 +173,28 @@ These methods update only the validator's in-memory peer set. Update the durable
 
 Place each trusted RPC node on a separate machine or instance from the validator, preferably in a separate network segment. Configure each node to:
 
-- Run in follow mode with `--follow` pointed at the validator's RPC endpoint.
+- Run in follow mode with `--follow` pointed at the validator's private WebSocket RPC endpoint.
 - Participate in the public Tempo execution P2P network.
 - Accept transaction submissions from clients or an internal load balancer instead of exposing the validator's JSON-RPC endpoint.
 
 On startup, RPC nodes discover a starting set of peers from bootnodes and connect to new peers through P2P discovery. Their P2P ports must be reachable by the public execution network, subject to the operator's host-hardening and traffic-control policy.
+
+### Follow the validator over WebSocket
+
+On each trusted RPC host, add an explicit validator URL to the node's existing chain, data directory, and discovery-secret configuration:
+
+```bash
+tempo node <EXISTING_ARGUMENTS> \
+  --follow ws://<VALIDATOR_PRIVATE_IP>:8546 \
+  --http \
+  --http.addr <FOLLOWER_PRIVATE_IP> \
+  --http.port 8545 \
+  --http.api eth,net,web3
+```
+
+Use the same chain as the validator and the discovery secret used to derive that follower's allowlisted enode. Replace an existing bare `--follow` with this explicit URL so the node follows your validator instead of the chain's default upstream. Keep peer discovery enabled on the followers; the `--disable-discovery` and `--trusted-only` flags above apply to the validator.
+
+The follower opens an outbound WebSocket connection to the validator. It does not need its own `--ws` server enabled to follow. Its `--http` flags expose a separate endpoint for clients or an internal load balancer; restrict access to that endpoint to the intended callers. For setup and snapshot instructions, see [running RPC and standby nodes](/docs/guide/node/rpc).
 
 ## Failure and maintenance considerations
 
@@ -182,6 +211,7 @@ After deployment or a firewall change, confirm that:
 - Internet hosts cannot reach the validator on any ports.
 - The validator cannot establish execution P2P connections to internet peers or other validators.
 - Each follower is configured with `--follow` against the validator and remains synced.
+- Each follower can reach the validator's private WebSocket endpoint on port `8546`, but cannot reach its localhost HTTP management endpoint on port `8545` or call `admin` methods over WebSocket.
 - Transactions submitted through either follower reach the validator.
 - Clients cannot submit transactions directly to the validator.
 - Transaction submission continues after either follower is removed from service.


### PR DESCRIPTION
Document the validator's private WebSocket endpoint and an explicit `--follow ws://<VALIDATOR_PRIVATE_IP>:8546` command for each trusted RPC node. Nest runtime peer management under execution peer configuration and explain that P2P trust does not grant RPC administration privileges; keep HTTP `admin` on localhost and omit it from follower-facing WebSocket RPC.

Checked the follow transport and required `eth`/`consensus` RPCs against Tempo source. Type checking, MDX parsing, internal anchor checks, and `git diff --check` passed. The full build timed out fetching `https://api.tempo.xyz/openapi.json`, so generated Markdown and the rendered page could not be verified locally.

Prompted by: @SuperFluffy
