### PR TITLE
docs(validator): clarify firewall and shared RPC requirements

### DIFF
--- a/src/pages/docs/guide/node/security.mdx
+++ b/src/pages/docs/guide/node/security.mdx
@@ -26,11 +26,15 @@ See [Managing validator keys](/docs/guide/node/validator-keys) for the full key 
 Deploy validators using the [validator network topology](/docs/guide/node/validator-topology). Isolate the validator, allow direct consensus traffic only with other validators, and route execution P2P through internal follower RPC nodes.
 :::
 
-Tempo's networking layer includes built-in protections, making a cloud firewall or NAT gateway unnecessary in most setups. The node:
+Enforce validator isolation with a network firewall using the [validator firewall policy](/docs/guide/node/validator-topology#validator-firewall-policy). Keep this policy in place even when the node restricts execution peers. A NAT gateway is a separate deployment choice and does not replace the firewall policy.
+
+Tempo's networking layer provides additional safeguards:
 
 - Only accepts consensus connections from validators that can prove their identity
-- Only accepts connections from trusted IP addresses (active validators on-chain)
+- Checks consensus connections against trusted validator IP addresses
 - Rate-limits connections and messages in both consensus and execution layers
+
+Consensus authentication and IP checks do not restrict the public execution P2P network to validators. Restrict the validator's execution connections to its trusted follower RPC nodes at both the firewall and peer-configuration layers.
 
 ### Recommendations
 

--- a/src/pages/docs/guide/node/system-requirements.mdx
+++ b/src/pages/docs/guide/node/system-requirements.mdx
@@ -108,10 +108,14 @@ Restart the node after applying for the changes to take effect.
 
 ## Ports
 
-| Port | Protocol | Purpose | Expose |
-|------|----------|---------|--------|
-| 30303 | TCP/UDP | Execution P2P | Public |
-| 8000 | TCP | Consensus P2P | Validators only |
-| 8545 | TCP | HTTP RPC | Optional (internal for validators) |
-| 8546 | TCP | WebSocket RPC | Optional (internal for validators) |
-| 9000 | TCP | Metrics | Internal |
+Use the [validator firewall policy](/docs/guide/node/validator-topology#validator-firewall-policy) for validator ingress and egress rules. The table below summarizes default ports by node role.
+
+| Port | Protocol | Purpose | Validator exposure | RPC-node exposure |
+|------|----------|---------|--------------------|-------------------|
+| 30303 | TCP/UDP | Execution P2P | Trusted follower RPC hosts only | Public |
+| 8000 | TCP | Consensus P2P | Other Tempo validators only | Not required |
+| 8545 | TCP | HTTP RPC | Private follower endpoint only, if enabled | Optional client access |
+| 8546 | TCP | WebSocket RPC | Private follower endpoint only, if enabled | Optional client access |
+| 9000 | TCP | Metrics | Private monitoring hosts only | Private monitoring hosts only |
+
+Keep validator management RPC on localhost and host management access on a private management network. Never expose the `admin` RPC namespace on follower or client endpoints.

--- a/src/pages/docs/guide/node/validator-topology.mdx
+++ b/src/pages/docs/guide/node/validator-topology.mdx
@@ -33,7 +33,11 @@ The validator has two types of network relationships:
 
 The execution P2P layer is open, so place trusted RPC nodes between the validator and that network. Configure each trusted RPC node with `--follow ws://<VALIDATOR_PRIVATE_IP>:8546` so it syncs in lockstep with the validator over a private WebSocket connection.
 
-Run at least two trusted RPC nodes for each validator to avoid a single point of failure for execution P2P and transaction ingress:
+Run at least two trusted RPC nodes to provide redundant execution P2P and transaction ingress. An operator can share the same two RPC nodes across multiple validators on the same chain. Configure every validator to peer with both RPC nodes so either RPC can continue relaying transactions if the other is unavailable. Size the shared RPC pool for the combined load, including operation with one RPC unavailable.
+
+Each RPC node still follows one configured validator upstream over WebSocket; it can exchange execution P2P traffic with multiple validators independently of that upstream. When sharing RPC nodes, use different validator upstreams for the followers so one upstream validator outage does not interrupt both followers.
+
+The diagram below shows separate operators, each with a trusted RPC pool. Operators with multiple validators can connect them to the same pool:
 
 <StaticMermaidDiagram chart={`---
 config:
@@ -179,7 +183,8 @@ These methods update only the validator's in-memory peer set. Update the durable
 
 Place each trusted RPC node on a separate machine or instance from the validator, preferably in a separate network segment. Configure each node to:
 
-- Run in follow mode with `--follow` pointed at the validator's private WebSocket RPC endpoint.
+- Run in follow mode with `--follow` pointed at one of the operator's validators over its private WebSocket RPC endpoint.
+- For a shared RPC pool, allow execution P2P connections with every validator the pool serves. Add both RPC identities and private IPs to each validator's trusted-peer and firewall allowlists.
 - Participate in the public Tempo execution P2P network.
 - Accept transaction submissions from clients or an internal load balancer instead of exposing the validator's JSON-RPC endpoint.
 
@@ -204,9 +209,9 @@ The follower opens an outbound WebSocket connection to the validator. It does no
 
 ## Failure and maintenance considerations
 
-Both follower RPC nodes are on the validator's transaction-ingress path. Monitor their execution peer counts, block heights, resource utilization, transaction-submission health, and private links to the validator.
+The trusted RPC pool provides transaction ingress for the validators it serves. Monitor the RPC nodes' execution peer counts, block heights, resource utilization, transaction-submission health, and private links to those validators. A shared pool also shares its failure impact across those validators.
 
-Run the followers independently so either node can continue accepting and relaying transactions when the other is unavailable. Configure clients or an internal load balancer to remove an unhealthy follower from rotation. Verify that failure of either follower does not interrupt transaction submission through the remaining node.
+Run the followers independently so either node can continue accepting and relaying transactions when the other is unavailable. Configure clients or an internal load balancer to remove an unhealthy follower from rotation. Verify that failure of either follower or its configured validator upstream does not interrupt transaction submission to the remaining validators through the other follower.
 
 ## Validate the isolation boundary
 
@@ -216,11 +221,11 @@ After deployment or a firewall change, confirm that:
 - The validator's execution peer count exactly matches the number of trusted RPC nodes.
 - Untrusted internet hosts cannot reach validator services; authorized validators can still reach consensus P2P.
 - The validator cannot establish execution P2P connections to internet peers or other validators.
-- Each follower is configured with `--follow` against the validator and remains synced.
+- Each follower is configured with `--follow` against its selected validator upstream and remains synced.
 - Each follower can reach the validator's private WebSocket endpoint on port `8546`, but cannot reach its localhost HTTP management endpoint on port `8545` or call `admin` methods over WebSocket.
-- Transactions submitted through either follower reach the validator.
+- Transactions submitted through either follower reach every validator served by the pool.
 - Clients cannot submit transactions directly to the validator.
-- Transaction submission continues after either follower is removed from service.
+- Transaction submission to the remaining validators continues after either follower or its validator upstream is removed from service.
 - Monitoring reaches both hosts only through the private monitoring network.
 
 See [system requirements and ports](/docs/guide/node/system-requirements#ports), [validator monitoring](/docs/guide/node/validator-monitoring), and [node security](/docs/guide/node/security) for the related operational controls.

--- a/src/pages/docs/guide/node/validator-topology.mdx
+++ b/src/pages/docs/guide/node/validator-topology.mdx
@@ -76,20 +76,26 @@ flowchart TB
     style OPERATOR_B stroke-dasharray: 8 6
 `} />
 
-No validator P2P or RPC port should be directly accessible from the internet. Do not allow execution P2P between `V1` and `V2`; transactions cross the validator isolation boundary only through `R1` or `R2`.
+Do not expose validator P2P or RPC ports to untrusted internet hosts. Allow other Tempo validators to reach the consensus port, including over the internet when needed. Do not allow execution P2P between `V1` and `V2`; transactions cross the validator isolation boundary only through `R1` or `R2`.
 
 ## Validator firewall policy
 
 Enforce the topology at the network firewall even when the node's peer configuration restricts discovery or has a fixed peer list.
 
-Firewall for the validator (default ports):
+Firewall for the validator (default destination ports; use the configured ports if you override them):
 
-| Traffic | Source or destination | Port | Policy |
-| --- | --- | --- | --- |
-| Consensus P2P | Other Tempo validators | `8000/TCP` | Allow |
-| Execution P2P | Trusted RPC hosts | `30303/TCP` and `30303/UDP` | Allow |
-| JSON-RPC | Trusted RPC hosts | `8545/TCP` | Allow |
-| All other inbound traffic | Any source | Any port | Deny |
+| Traffic | Direction relative to validator | Allowed source or destination | Port | Policy |
+| --- | --- | --- | --- | --- |
+| Consensus P2P | Inbound and outbound | Other Tempo validators | `8000/TCP` | Allow |
+| Execution P2P | Inbound and outbound | Trusted RPC hosts | `30303/TCP` and `30303/UDP` | Allow only these peers |
+| JSON-RPC | Inbound | Trusted RPC hosts | `8545/TCP`, or `8546/TCP` for WebSocket if enabled | Allow on the private follower endpoint |
+| Metrics | Inbound | Private monitoring hosts | `9000/TCP` if enabled | Allow |
+| Host management | Inbound | Private management network | Configured management ports | Allow only as needed |
+| All other inbound traffic | Inbound | Any source | Any port | Deny |
+
+Allow return traffic for permitted connections. Block outbound execution P2P to public peers and other validators, including peers using non-default ports. If you also restrict other outbound traffic, explicitly allow required operational services such as DNS, time synchronization, and configured telemetry endpoints. Keep the `admin` RPC namespace on localhost only.
+
+Keep consensus firewall rules aligned with validator address changes and committee membership so authorized validators remain reachable.
 
 Restrict the validator's execution peer configuration to the trusted follower RPC nodes. Do not include other validators in this allowlist, and do not rely on peer discovery alone to provide isolation.
 
@@ -179,7 +185,7 @@ After deployment or a firewall change, confirm that:
 
 - Other validators can reach the validator's consensus port.
 - The validator's execution peer count exactly matches the number of trusted RPC nodes.
-- Internet hosts cannot reach the validator on any ports.
+- Untrusted internet hosts cannot reach validator services; authorized validators can still reach consensus P2P.
 - The validator cannot establish execution P2P connections to internet peers or other validators.
 - Each follower is configured with `--follow` against the validator and remains synced.
 - Transactions submitted through either follower reach the validator.


### PR DESCRIPTION
The security page says a firewall is unnecessary, while validator topology requires one and the ports table labels execution P2P public for every node. Align all three pages around firewall-enforced validator isolation and distinguish validator exposure from public RPC-node exposure.

Clarify the consensus connectivity exception, inbound and outbound rules, private monitoring and management access, and the scope of consensus IP checks. Keep the topology page as the firewall policy reference. Preserve the follower WebSocket setup from [#867](https://github.com/tempoxyz/docs/pull/867): followers use private port `8546` with `eth,consensus`, while HTTP management on `8545` remains localhost-only in both port tables.

Explain that two trusted RPC nodes provide redundancy and can serve multiple validators belonging to the same operator on the same chain. Each validator peers with both RPCs; each RPC follows one selected validator upstream. Cover shared-pool capacity, distinct upstreams, and transaction delivery when a follower or upstream is unavailable.

Validation: TypeScript checks, topology MDX parsing, and `git diff --check` passed for the shared-RPC clarification. Earlier validation also checked internal anchors and all three changed pages. The earlier full build stopped because fetching the hosted OpenAPI specification timed out; production rendering remains unverified.

Prompted by: @max-digi
