### PR TITLE
docs(validator): clarify and align network topology

### DIFF
--- a/src/components/ValidatorTopologyDiagram.tsx
+++ b/src/components/ValidatorTopologyDiagram.tsx
@@ -3,10 +3,10 @@ export function ValidatorTopologyDiagram() {
     <div style={{ margin: '1.5rem 0', overflowX: 'auto' }}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 840 490"
+        viewBox="-200 0 1040 490"
         role="img"
         aria-labelledby="validator-topology-title validator-topology-description"
-        style={{ display: 'block', width: '100%', minWidth: 640, height: 'auto' }}
+        style={{ display: 'block', width: '100%', minWidth: 800, height: 'auto' }}
         fontFamily="ui-sans-serif, system-ui, sans-serif"
         fontSize="16"
         fill="currentColor"
@@ -18,7 +18,8 @@ export function ValidatorTopologyDiagram() {
           above its validator (V1 or V2). Both RPC groups connect to the public execution P2P
           network and to each other over execution P2P. Each RPC group follows its own validator
           over WebSocket and also has a bidirectional execution P2P connection to it. V1 and V2
-          communicate directly over bidirectional consensus P2P.
+          communicate directly over bidirectional consensus P2P. A client outside the validator
+          units submits a transaction to R1 over JSON-RPC.
         </desc>
         <defs>
           <marker
@@ -113,6 +114,42 @@ export function ValidatorTopologyDiagram() {
             </text>
           </g>
         ))}
+
+        <rect
+          x="-180"
+          y="275"
+          width="100"
+          height="46"
+          rx="4"
+          fill="var(--vocs-background-color-primary, #ffffff)"
+        />
+        <rect
+          x="-180"
+          y="275"
+          width="100"
+          height="46"
+          rx="4"
+          fill="none"
+          stroke="currentColor"
+          strokeOpacity="0.25"
+        />
+        <text x="-130" y="304">
+          Client
+        </text>
+        <path
+          d="M -80 298 H 60"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          opacity="0.6"
+          markerEnd="url(#validator-topology-arrow)"
+        />
+        <text x="-10" y="263">
+          Submit TX
+          <tspan x="-10" dy="20">
+            (JSON-RPC)
+          </tspan>
+        </text>
 
         <path
           d="M 353 119 C 320 122 313 78 338 66 C 331 36 368 19 390 34 C 408 8 450 15 461 39 C 493 29 519 56 506 82 C 537 108 505 142 478 126 C 459 149 430 145 415 132 C 394 148 365 142 353 119 Z"

--- a/src/components/ValidatorTopologyDiagram.tsx
+++ b/src/components/ValidatorTopologyDiagram.tsx
@@ -17,7 +17,8 @@ export function ValidatorTopologyDiagram() {
           Two separate Validator units sit side by side. Each contains trusted RPC nodes (R1 or R2)
           above its validator (V1 or V2). Both RPC groups connect to the public execution P2P
           network and to each other over execution P2P. Each RPC group follows its own validator
-          over WebSocket and also has a bidirectional execution P2P connection to it.
+          over WebSocket and also has a bidirectional execution P2P connection to it. V1 and V2
+          communicate directly over bidirectional consensus P2P.
         </desc>
         <defs>
           <marker
@@ -133,6 +134,7 @@ export function ValidatorTopologyDiagram() {
           <path d="M 353 119 L 100 175 V 275" />
           <path d="M 478 126 L 740 175 V 275" />
           <path d="M 310 298 H 530" />
+          <path d="M 310 425 H 530" />
         </g>
         <text x="240" y="180">
           Execution P2P
@@ -142,6 +144,9 @@ export function ValidatorTopologyDiagram() {
         </text>
         <text x="420" y="288">
           Execution P2P
+        </text>
+        <text x="420" y="415">
+          Consensus P2P
         </text>
       </svg>
     </div>

--- a/src/components/ValidatorTopologyDiagram.tsx
+++ b/src/components/ValidatorTopologyDiagram.tsx
@@ -1,0 +1,149 @@
+export function ValidatorTopologyDiagram() {
+  return (
+    <div style={{ margin: '1.5rem 0', overflowX: 'auto' }}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 840 490"
+        role="img"
+        aria-labelledby="validator-topology-title validator-topology-description"
+        style={{ display: 'block', width: '100%', minWidth: 640, height: 'auto' }}
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="16"
+        fill="currentColor"
+        textAnchor="middle"
+      >
+        <title id="validator-topology-title">Recommended validator topology</title>
+        <desc id="validator-topology-description">
+          Two separate Validator units sit side by side. Each contains trusted RPC nodes (R1 or R2)
+          above its validator (V1 or V2). Both RPC groups connect to the public execution P2P
+          network and to each other over execution P2P. Each RPC group follows its own validator
+          over WebSocket and also has a bidirectional execution P2P connection to it.
+        </desc>
+        <defs>
+          <marker
+            id="validator-topology-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+          </marker>
+        </defs>
+
+        {/* Matching coordinates keep both operator boundaries and nodes aligned. */}
+        {[
+          { x: 20, id: 1 },
+          { x: 490, id: 2 },
+        ].map(({ x, id }) => (
+          <g key={id} transform={`translate(${x} 0)`}>
+            <rect
+              x="0"
+              y="210"
+              width="330"
+              height="255"
+              rx="8"
+              fill="var(--vocs-background-color-surface, #f4f4f5)"
+            />
+            <rect
+              x="0"
+              y="210"
+              width="330"
+              height="255"
+              rx="8"
+              fill="none"
+              stroke="currentColor"
+              strokeOpacity="0.35"
+              strokeDasharray="8 6"
+            />
+            <text x="165" y="243" fontWeight="600">
+              Validator
+            </text>
+            {[
+              { y: 275, label: `R${id}: Trusted RPC nodes` },
+              { y: 402, label: `V${id}: Validator` },
+            ].map(({ y, label }) => (
+              <g key={label}>
+                <rect
+                  x="40"
+                  y={y}
+                  width="250"
+                  height="46"
+                  rx="4"
+                  fill="var(--vocs-background-color-primary, #ffffff)"
+                />
+                <rect
+                  x="40"
+                  y={y}
+                  width="250"
+                  height="46"
+                  rx="4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeOpacity="0.25"
+                />
+                <text x="165" y={y + 29}>
+                  {label}
+                </text>
+              </g>
+            ))}
+            <g stroke="currentColor" strokeWidth="1.5" opacity="0.6" fill="none">
+              <path d="M 100 321 V 402" markerEnd="url(#validator-topology-arrow)" />
+              <path
+                d="M 230 321 V 402"
+                markerStart="url(#validator-topology-arrow)"
+                markerEnd="url(#validator-topology-arrow)"
+              />
+            </g>
+            <g fill="var(--vocs-background-color-surface, #f4f4f5)">
+              <rect x="40" y="341" width="120" height="43" />
+              <rect x="169" y="350" width="122" height="24" />
+            </g>
+            <text x="100" y="358">
+              --follow
+              <tspan x="100" dy="20">
+                (WebSocket)
+              </tspan>
+            </text>
+            <text x="230" y="367">
+              Execution P2P
+            </text>
+          </g>
+        ))}
+
+        <path
+          d="M 353 119 C 320 122 313 78 338 66 C 331 36 368 19 390 34 C 408 8 450 15 461 39 C 493 29 519 56 506 82 C 537 108 505 142 478 126 C 459 149 430 145 415 132 C 394 148 365 142 353 119 Z"
+          fill="var(--vocs-background-color-primary, #ffffff)"
+          stroke="currentColor"
+          strokeOpacity="0.35"
+        />
+        <text x="420" y="87">
+          Public Nodes
+        </text>
+        <g
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          opacity="0.6"
+          markerStart="url(#validator-topology-arrow)"
+          markerEnd="url(#validator-topology-arrow)"
+        >
+          <path d="M 353 119 L 100 175 V 275" />
+          <path d="M 478 126 L 740 175 V 275" />
+          <path d="M 310 298 H 530" />
+        </g>
+        <text x="240" y="180">
+          Execution P2P
+        </text>
+        <text x="600" y="180">
+          Execution P2P
+        </text>
+        <text x="420" y="288">
+          Execution P2P
+        </text>
+      </svg>
+    </div>
+  )
+}

--- a/src/lib/markdown-output.test.ts
+++ b/src/lib/markdown-output.test.ts
@@ -79,6 +79,30 @@ Status: <Badge variant="red">Required</Badge>
     expect(output).not.toMatch(/<\/?[A-Z]/)
   })
 
+  test('preserves validator topology relationships in plain Markdown', async () => {
+    const output = await render(`
+import { ValidatorTopologyDiagram } from './ValidatorTopologyDiagram'
+
+<ValidatorTopologyDiagram />
+
+No validator P2P or RPC port should be directly accessible from the internet.
+`)
+
+    expect(output).toContain('R1 with V1, and R2 with V2')
+    expect(output).toContain('submits a transaction to R1 over JSON-RPC')
+    expect(output).toContain(
+      'R1 and R2 each connect to Public Nodes and to each other over bidirectional execution P2P',
+    )
+    expect(output).toContain('R1 follows V1 and R2 follows V2 using --follow over WebSocket')
+    expect(output).toContain('each pair also has a bidirectional execution P2P connection')
+    expect(output).toContain('V1 and V2 communicate over bidirectional consensus P2P')
+    expect(output).toContain('no execution P2P connection between them')
+    expect(output).toContain(
+      'No validator P2P or RPC port should be directly accessible from the internet.',
+    )
+    expect(output).not.toContain('ValidatorTopologyDiagram')
+  })
+
   test('explains interactive and OpenAPI-only content', async () => {
     const output = await render(`
 <OpenApi.Playground operationId="getAddressBalances" hideQueryParams />

--- a/src/lib/markdown-output.ts
+++ b/src/lib/markdown-output.ts
@@ -52,6 +52,13 @@ const interactiveDescriptions: Record<string, string> = {
     'The interactive terminal creates a test wallet, funds it, and makes a paid request.',
   TidxQuery: 'Use the interactive web page to run SQL against the public Tempo indexer.',
   TokenListDemo: 'The interactive web page displays the current Tempo token list.',
+  ValidatorTopologyDiagram:
+    'Two separate Validator units each contain a trusted RPC group and its validator: ' +
+    'R1 with V1, and R2 with V2. A client outside both units submits a transaction to R1 over JSON-RPC. ' +
+    'R1 and R2 each connect to Public Nodes and to each other over bidirectional execution P2P. ' +
+    'R1 follows V1 and R2 follows V2 using --follow over WebSocket; each pair also has a ' +
+    'bidirectional execution P2P connection. V1 and V2 communicate over bidirectional consensus P2P, ' +
+    'with no execution P2P connection between them.',
 }
 
 const demoStepLabels: Record<string, string> = {

--- a/src/pages/docs/guide/node/validator-topology.mdx
+++ b/src/pages/docs/guide/node/validator-topology.mdx
@@ -4,7 +4,7 @@ seoTitle: "Validator Network Topology | Tempo Docs"
 description: Isolate a Tempo validator behind RPC nodes and restrict its consensus and execution peer connectivity.
 ---
 
-import { StaticMermaidDiagram } from '../../../../components/StaticMermaidDiagram'
+import { ValidatorTopologyDiagram } from '../../../../components/ValidatorTopologyDiagram'
 
 # Validator network topology
 
@@ -35,36 +35,7 @@ The execution P2P layer is open, so place trusted RPC nodes between the validato
 
 Run at least two trusted RPC nodes for each validator to avoid a single point of failure for execution P2P and transaction ingress:
 
-<StaticMermaidDiagram chart={`---
-config:
-  layout: elk
----
-flowchart TB
-    EXTERNAL@{ shape: cloud, label: "Public Nodes" }
-
-    subgraph OPERATOR_A["Validator"]
-        direction TB
-        R1["R1: Trusted RPC nodes"]
-        V1["V1: Validator"]
-        R1 -->|"--follow (WebSocket)"| V1
-        R1 <-->|"Execution P2P"| V1
-    end
-
-    subgraph OPERATOR_B["Validator"]
-        direction TB
-        R2["R2: Trusted RPC nodes"]
-        V2["V2: Validator"]
-        R2 -->|"--follow (WebSocket)"| V2
-        R2 <-->|"Execution P2P"| V2
-    end
-
-    EXTERNAL <-->|"Execution P2P"| R1
-    EXTERNAL <-->|"Execution P2P"| R2
-    R1 <-->|"Execution P2P"| R2
-
-    style OPERATOR_A stroke-dasharray: 8 6
-    style OPERATOR_B stroke-dasharray: 8 6
-`} />
+<ValidatorTopologyDiagram />
 
 No validator P2P or RPC port should be directly accessible from the internet. Do not allow execution P2P between `V1` and `V2`; transactions cross the validator isolation boundary only through `R1` or `R2`.
 

--- a/src/pages/docs/guide/node/validator-topology.mdx
+++ b/src/pages/docs/guide/node/validator-topology.mdx
@@ -42,24 +42,20 @@ config:
 flowchart TB
     EXTERNAL@{ shape: cloud, label: "Public Nodes" }
 
-    subgraph VALIDATORS["Validators"]
-        direction LR
+    subgraph OPERATOR_A["Validator"]
+        direction TB
+        R1["R1: Trusted RPC nodes"]
+        V1["V1: Validator"]
+        R1 -->|"--follow (WebSocket)"| V1
+        R1 <-->|"Execution P2P"| V1
+    end
 
-        subgraph OPERATOR_A["&nbsp;"]
-            direction TB
-            R1["R1: Trusted RPC nodes"]
-            V1["V1: Validator"]
-            R1 -->|"--follow (WebSocket)"| V1
-            R1 <-->|"Execution P2P"| V1
-        end
-
-        subgraph OPERATOR_B["&nbsp;"]
-            direction TB
-            R2["R2: Trusted RPC nodes"]
-            V2["V2: Validator"]
-            R2 -->|"--follow (WebSocket)"| V2
-            R2 <-->|"Execution P2P"| V2
-        end
+    subgraph OPERATOR_B["Validator"]
+        direction TB
+        R2["R2: Trusted RPC nodes"]
+        V2["V2: Validator"]
+        R2 -->|"--follow (WebSocket)"| V2
+        R2 <-->|"Execution P2P"| V2
     end
 
     EXTERNAL <-->|"Execution P2P"| R1

--- a/src/pages/docs/guide/node/validator-topology.mdx
+++ b/src/pages/docs/guide/node/validator-topology.mdx
@@ -40,16 +40,7 @@ config:
   layout: elk
 ---
 flowchart TB
-    subgraph EXTERNAL["Public Nodes"]
-        direction TB
-
-        E1["External RPC node"]
-        E2["External RPC node"]
-        E3["External RPC node"]
-
-        E1 <-->|"Execution P2P"| E2
-        E1 <-->|"Execution P2P"| E3
-    end
+    EXTERNAL@{ shape: cloud, label: "Public Nodes" }
 
     subgraph VALIDATORS["Validators"]
         direction LR
@@ -71,8 +62,9 @@ flowchart TB
         end
     end
 
-    E2 <-->|"Execution P2P"| R1
-    E3 <-->|"Execution P2P"| R2
+    EXTERNAL <-->|"Execution P2P"| R1
+    EXTERNAL <-->|"Execution P2P"| R2
+    R1 <-->|"Execution P2P"| R2
 
     style OPERATOR_A stroke-dasharray: 8 6
     style OPERATOR_B stroke-dasharray: 8 6

--- a/src/pages/docs/guide/node/validator-topology.mdx
+++ b/src/pages/docs/guide/node/validator-topology.mdx
@@ -56,16 +56,16 @@ flowchart TB
 
         subgraph OPERATOR_A["&nbsp;"]
             direction TB
-            R1["Trusted RPC nodes"]
-            V1["Validator"]
+            R1["R1: Trusted RPC nodes"]
+            V1["V1: Validator"]
             R1 -->|"--follow (WebSocket)"| V1
             R1 <-->|"Execution P2P"| V1
         end
 
         subgraph OPERATOR_B["&nbsp;"]
             direction TB
-            R2["Trusted RPC nodes"]
-            V2["Validator"]
+            R2["R2: Trusted RPC nodes"]
+            V2["V2: Validator"]
             R2 -->|"--follow (WebSocket)"| V2
             R2 <-->|"Execution P2P"| V2
         end

--- a/src/pages/docs/guide/node/validator-topology.mdx
+++ b/src/pages/docs/guide/node/validator-topology.mdx
@@ -58,14 +58,16 @@ flowchart TB
             direction TB
             R1["Trusted RPC nodes"]
             V1["Validator"]
-            R1 -->|"--follow"| V1
+            R1 -->|"--follow (WebSocket)"| V1
+            R1 <-->|"Execution P2P"| V1
         end
 
         subgraph OPERATOR_B["&nbsp;"]
             direction TB
             R2["Trusted RPC nodes"]
             V2["Validator"]
-            R2 -->|"--follow"| V2
+            R2 -->|"--follow (WebSocket)"| V2
+            R2 <-->|"Execution P2P"| V2
         end
     end
 


### PR DESCRIPTION
The recommended validator topology diagram omitted connections and node identifiers referenced by the accompanying text. Adding the RPC-to-RPC edge also caused Mermaid to stagger the two validator units vertically.

Use a dedicated SVG component with two aligned, equally sized boxes labeled "Validator" and a public-network cloud centered above them. Label the nodes `R1`, `R2`, `V1`, and `V2`; show execution P2P between both RPC groups, from each group to the cloud, and from each group to its validator; and show directed `--follow (WebSocket)` connections to each validator. Connect `V1` and `V2` with a bidirectional consensus P2P line. The fixed layout keeps these connections from moving the boxes or overlapping labels. It uses the docs theme colors, includes an accessible description, and scrolls horizontally on narrow screens.

An external client submits a transaction to `R1` through a directed "Submit TX (JSON-RPC)" arrow, making the transaction ingress path explicit outside the validator boundary.

Validation: type checking, component Biome checks, and `git diff --check` passed. Browser preview verified equal box positions and dimensions, connection labels and arrow directions (including the client-to-R1 submission), light/dark colors, and contained horizontal scrolling at a 390px viewport. `pnpm build` remains blocked by a connection timeout fetching the existing OpenAPI spec; full-page validation is unavailable in this environment.

Prompted by: @SuperFluffy
