### PR TITLE
docs(protocol): update guides for T11 activation

### DIFF
--- a/src/pages/docs/guide/payments/send-parallel-transactions.mdx
+++ b/src/pages/docs/guide/payments/send-parallel-transactions.mdx
@@ -18,6 +18,8 @@ Tempo enables concurrent transaction execution through its [expiring nonce](/doc
 
 ## Parallel transaction demo
 
+After [T11 activates](/docs/protocol/upgrades/t11) on the network, expiring nonce transactions can set `validBefore` up to 300 seconds (five minutes) ahead of the current block timestamp. Before activation, the maximum is 30 seconds. This is a protocol limit, not an SDK default: check your SDK's expiry settings if you need a longer window. Shorter windows remain valid. See [expiring nonce configuration](/docs/guide/tempo-transaction#expiring-nonces).
+
 By the end of this guide you will understand how to send parallel payments using expiring nonces under-the-hood.
 
 <Demo.Container name="Send Parallel Payments" footerVariant="balances" tokens={[Token.alphaUsd]}>

--- a/src/pages/docs/guide/payments/send-parallel-transactions.mdx
+++ b/src/pages/docs/guide/payments/send-parallel-transactions.mdx
@@ -18,7 +18,7 @@ Tempo enables concurrent transaction execution through its [expiring nonce](/doc
 
 ## Parallel transaction demo
 
-After [T11 activates](/docs/protocol/upgrades/t11) on the network, expiring nonce transactions can set `validBefore` up to 300 seconds (five minutes) ahead of the current block timestamp. Before activation, the maximum is 30 seconds. This is a protocol limit, not an SDK default: check your SDK's expiry settings if you need a longer window. Shorter windows remain valid. See [expiring nonce configuration](/docs/guide/tempo-transaction#expiring-nonces).
+Since [T11](/docs/protocol/upgrades/t11), expiring nonce transactions can set `validBefore` up to 300 seconds (five minutes) ahead of the current block timestamp. Before activation, the maximum was 30 seconds. This is a protocol limit, not an SDK default: check your SDK's expiry settings if you need a longer window. Shorter windows remain valid. See [expiring nonce configuration](/docs/guide/tempo-transaction#expiring-nonces).
 
 By the end of this guide you will understand how to send parallel payments using expiring nonces under-the-hood.
 

--- a/src/pages/docs/protocol/fees/spec-fee.mdx
+++ b/src/pages/docs/protocol/fees/spec-fee.mdx
@@ -38,6 +38,14 @@ Congestion is managed through:
 
 The payment lane mechanism ensures that payment transactions are not crowded out by other network activity. General network congestion from non-payment use cases cannot affect payment throughput or fees, providing the consistency that payment applications require.
 
+## Precompile input and validation gas
+
+After [T11 activates](/docs/protocol/upgrades/t11), every Tempo precompile call charges `30 * ceil(calldata_length / 32)` execution gas for its input, up from `6 * ceil(calldata_length / 32)`. The length includes all input bytes, including the function selector. This charge is deducted before dispatch or argument decoding; insufficient gas halts execution with out-of-gas. See [TIP-1100](https://tips.sh/1100).
+
+[TIP-1105](https://tips.sh/1105) adds a separate charge of 20 gas per value processed by duplicate checks for AccountKeychain call-scope targets, selectors, and recipients, and ZoneFactory allowed-account, gateway, and sequencer lists. Insufficient gas halts execution before sorting. ZoneFactory rejects duplicate addresses within or across those role lists.
+
+T11 also requires canonical ABI encoding for Tempo precompile calls. Gaps, overlaps, trailing data, and non-zero padding are rejected. Use standard ABI encoders and estimate gas on the network where the transaction will execute, especially for large inputs or integrations with fixed gas limits.
+
 ## Fee payment
 
 Before the execution of each transaction, the protocol takes the following steps:

--- a/src/pages/docs/protocol/fees/spec-fee.mdx
+++ b/src/pages/docs/protocol/fees/spec-fee.mdx
@@ -40,7 +40,7 @@ The payment lane mechanism ensures that payment transactions are not crowded out
 
 ## Precompile input and validation gas
 
-After [T11 activates](/docs/protocol/upgrades/t11), every Tempo precompile call charges `30 * ceil(calldata_length / 32)` execution gas for its input, up from `6 * ceil(calldata_length / 32)`. The length includes all input bytes, including the function selector. This charge is deducted before dispatch or argument decoding; insufficient gas halts execution with out-of-gas. See [TIP-1100](https://tips.sh/1100).
+Since [T11](/docs/protocol/upgrades/t11), every Tempo precompile call charges `30 * ceil(calldata_length / 32)` execution gas for its input, up from `6 * ceil(calldata_length / 32)`. The length includes all input bytes, including the function selector. This charge is deducted before dispatch or argument decoding; insufficient gas halts execution with out-of-gas. See [TIP-1100](https://tips.sh/1100).
 
 [TIP-1105](https://tips.sh/1105) adds a separate charge of 20 gas per value processed by duplicate checks for AccountKeychain call-scope targets, selectors, and recipients, and ZoneFactory allowed-account, gateway, and sequencer lists. Insufficient gas halts execution before sorting. ZoneFactory rejects duplicate addresses within or across those role lists.
 

--- a/src/pages/docs/protocol/tips/tip-1009.mdx
+++ b/src/pages/docs/protocol/tips/tip-1009.mdx
@@ -10,6 +10,10 @@ protocolVersion: T1
 
 # TIP-1009: Expiring Nonces
 
+:::info[T11 supersedes the window and capacity below]
+After [T11 activates](/docs/protocol/upgrades/t11), [TIP-1093](https://tips.sh/1093) increases the maximum expiry window from 30 to 300 seconds and the replay-protection buffer from 300,000 to 3,000,000 entries. The post-T11 validity rule is `now < validBefore <= now + 300`, where `now` is the current block timestamp. The 30-second limits, 300,000-entry capacity, pseudocode, and boundary tests below describe the original pre-T11 specification.
+:::
+
 ## Abstract
 
 TIP-1009 introduces expiring nonces, an alternative replay protection mechanism where transactions are valid only within a specified time window. Instead of tracking sequential nonces, the protocol uses transaction hashes with expiry timestamps to prevent replay attacks. This enables use cases like gasless transactions, meta-transactions, and simplified UX where users don't need to manage nonce ordering.

--- a/src/pages/docs/protocol/tips/tip-1009.mdx
+++ b/src/pages/docs/protocol/tips/tip-1009.mdx
@@ -11,7 +11,7 @@ protocolVersion: T1
 # TIP-1009: Expiring Nonces
 
 :::info[T11 supersedes the window and capacity below]
-After [T11 activates](/docs/protocol/upgrades/t11), [TIP-1093](https://tips.sh/1093) increases the maximum expiry window from 30 to 300 seconds and the replay-protection buffer from 300,000 to 3,000,000 entries. The post-T11 validity rule is `now < validBefore <= now + 300`, where `now` is the current block timestamp. The 30-second limits, 300,000-entry capacity, pseudocode, and boundary tests below describe the original pre-T11 specification.
+Since [T11](/docs/protocol/upgrades/t11), [TIP-1093](https://tips.sh/1093) increases the maximum expiry window from 30 to 300 seconds and the replay-protection buffer from 300,000 to 3,000,000 entries. The post-T11 validity rule is `now < validBefore <= now + 300`, where `now` is the current block timestamp. The 30-second limits, 300,000-entry capacity, pseudocode, and boundary tests below describe the original pre-T11 specification.
 :::
 
 ## Abstract

--- a/src/pages/docs/protocol/tips/tip-1020.mdx
+++ b/src/pages/docs/protocol/tips/tip-1020.mdx
@@ -10,6 +10,10 @@ protocolVersion: T3
 
 # TIP-1020: Signature Verification Precompile
 
+:::info[T11 supersedes the input gas price below]
+After [T11 activates](/docs/protocol/upgrades/t11), [TIP-1100](https://tips.sh/1100) increases the input charge from 6 to 30 gas per 32-byte word, rounded up over the full calldata including the function selector. The 6-gas input price below describes the original pre-T11 specification; signature verification gas is unchanged. [TIP-1105](https://tips.sh/1105) also requires canonical ABI encoding for precompile calls.
+:::
+
 ## Abstract
 
 This TIP introduces a signature verification precompile that enables contracts to verify Tempo signature types (secp256k1, P256, WebAuthn) without relying on custom verifier contracts.

--- a/src/pages/docs/protocol/tips/tip-1020.mdx
+++ b/src/pages/docs/protocol/tips/tip-1020.mdx
@@ -11,7 +11,7 @@ protocolVersion: T3
 # TIP-1020: Signature Verification Precompile
 
 :::info[T11 supersedes the input gas price below]
-After [T11 activates](/docs/protocol/upgrades/t11), [TIP-1100](https://tips.sh/1100) increases the input charge from 6 to 30 gas per 32-byte word, rounded up over the full calldata including the function selector. The 6-gas input price below describes the original pre-T11 specification; signature verification gas is unchanged. [TIP-1105](https://tips.sh/1105) also requires canonical ABI encoding for precompile calls.
+Since [T11](/docs/protocol/upgrades/t11), [TIP-1100](https://tips.sh/1100) increases the input charge from 6 to 30 gas per 32-byte word, rounded up over the full calldata including the function selector. The 6-gas input price below describes the original pre-T11 specification; signature verification gas is unchanged. [TIP-1105](https://tips.sh/1105) also requires canonical ABI encoding for precompile calls.
 :::
 
 ## Abstract

--- a/src/pages/docs/protocol/transactions/AccountKeychain.mdx
+++ b/src/pages/docs/protocol/transactions/AccountKeychain.mdx
@@ -15,7 +15,7 @@ The Account Keychain precompile manages authorized Access Keys for accounts, ena
 
 ## T11 input validation and gas
 
-After [T11 activates](/docs/protocol/upgrades/t11), calls to this precompile must use canonical ABI encoding. Gaps, overlaps, trailing data, and non-zero padding are rejected. Use a standard ABI encoder when constructing calls.
+Since [T11](/docs/protocol/upgrades/t11), calls to this precompile must use canonical ABI encoding. Gaps, overlaps, trailing data, and non-zero padding are rejected. Use a standard ABI encoder when constructing calls.
 
 The input charge increases from 6 to 30 gas per 32-byte word, rounded up over the full calldata including the function selector, and is deducted before decoding. Call-scope duplicate checks additionally charge 20 gas per target, selector, or recipient processed. Insufficient gas halts execution before sorting; duplicate targets, selectors, and recipients remain invalid. Estimate gas on the target network when authorizing keys or updating permissions.
 

--- a/src/pages/docs/protocol/transactions/AccountKeychain.mdx
+++ b/src/pages/docs/protocol/transactions/AccountKeychain.mdx
@@ -13,6 +13,14 @@ The Account Keychain precompile manages authorized Access Keys for accounts, ena
 
 `authorizeKey(...)` takes a `KeyRestrictions` tuple that bundles expiry, spending limits, and call scopes. `authorizeAdminKey(...)` provisions an admin key for account key management. Access-key-signed transactions cannot create contracts; use a Root Key for deployment flows.
 
+## T11 input validation and gas
+
+After [T11 activates](/docs/protocol/upgrades/t11), calls to this precompile must use canonical ABI encoding. Gaps, overlaps, trailing data, and non-zero padding are rejected. Use a standard ABI encoder when constructing calls.
+
+The input charge increases from 6 to 30 gas per 32-byte word, rounded up over the full calldata including the function selector, and is deducted before decoding. Call-scope duplicate checks additionally charge 20 gas per target, selector, or recipient processed. Insufficient gas halts execution before sorting; duplicate targets, selectors, and recipients remain invalid. Estimate gas on the target network when authorizing keys or updating permissions.
+
+See [TIP-1100](https://tips.sh/1100) for input pricing and [TIP-1105](https://tips.sh/1105) for strict decoding and duplicate-validation pricing.
+
 ## Motivation
 
 The Tempo Transaction type unlocks a number of new signature schemes, including WebAuthn (Passkeys). However, for an Account using a Passkey as its Root Key, the sender will subsequently be prompted with passkey prompts for every signature request. This can be a poor user experience for highly interactive or multi-step flows. Additionally, users would also see "Sign In" copy in prompts for signing transactions which is confusing. This proposal introduces the concept of the Root Key being able to provision a scoped Access Key that can be used for subsequent transactions, without the need for repetitive end-user prompting. T6 extends this model with admin access keys for key management. Recurring spending budgets and explicit call scoping make limited keys suitable for subscriptions, connected apps, and session-key-style flows.

--- a/src/snippets/tempo-tx-properties.mdx
+++ b/src/snippets/tempo-tx-properties.mdx
@@ -1557,7 +1557,9 @@ The [expiring nonces specification](https://github.com/tempoxyz/tempo/blob/main/
 - Automatic replay protection via circular buffer
 - No permanent state bloat from unused nonce keys
 
-Expiring nonces can be used by setting `nonceKey` to `maxUint256` and `validBefore` to a time in the future (within 30 seconds).
+Use expiring nonces by setting `nonceKey` to `maxUint256`, `nonce` to `0`, and `validBefore` to a future Unix timestamp in seconds. After [T11 activates](/docs/protocol/upgrades/t11) on the network, the maximum window is 300 seconds (five minutes): `now < validBefore <= now + 300`, where `now` is the current block timestamp. Before activation, the maximum is 30 seconds. See [TIP-1093](https://tips.sh/1093).
+
+Shorter windows remain valid. The examples below use 20 seconds; the five-minute protocol maximum does not imply that an SDK selects that window by default.
 
 <Tabs stateKey="library-exp">
   <Tab title="Viem">
@@ -1781,7 +1783,7 @@ Expiring nonces can be used by setting `nonceKey` to `maxUint256` and `validBefo
       access_list,
       nonce_key, // set to `maxUint256` // [!code focus]
       nonce,
-      valid_before, // set to `now + <30 seconds` // [!code focus]
+      valid_before, // e.g. `now + 20`; maximum `now + 300` after T11, `now + 30` before // [!code focus]
       valid_after,
       fee_token,
       fee_payer_signature,

--- a/src/snippets/tempo-tx-properties.mdx
+++ b/src/snippets/tempo-tx-properties.mdx
@@ -1557,9 +1557,9 @@ The [expiring nonces specification](https://github.com/tempoxyz/tempo/blob/main/
 - Automatic replay protection via circular buffer
 - No permanent state bloat from unused nonce keys
 
-Use expiring nonces by setting `nonceKey` to `maxUint256`, `nonce` to `0`, and `validBefore` to a future Unix timestamp in seconds. After [T11 activates](/docs/protocol/upgrades/t11) on the network, the maximum window is 300 seconds (five minutes): `now < validBefore <= now + 300`, where `now` is the current block timestamp. Before activation, the maximum is 30 seconds. See [TIP-1093](https://tips.sh/1093).
+Use expiring nonces by setting `nonceKey` to `maxUint256`, `nonce` to `0`, and `validBefore` to a future Unix timestamp in seconds. Since [T11](/docs/protocol/upgrades/t11), the maximum window is 300 seconds (five minutes): `now < validBefore <= now + 300`, where `now` is the current block timestamp. Before activation, the maximum was 30 seconds. See [TIP-1093](https://tips.sh/1093).
 
-Shorter windows remain valid. The examples below use 20 seconds; the five-minute protocol maximum does not imply that an SDK selects that window by default.
+Shorter windows remain valid. The examples below use shorter windows; the five-minute protocol maximum does not imply that an SDK selects that window by default.
 
 <Tabs stateKey="library-exp">
   <Tab title="Viem">


### PR DESCRIPTION
Update the transaction and parallel-payment guides for the 300-second expiring-nonce maximum after T11, preserving shorter examples and distinguishing protocol limits from SDK defaults. Document precompile input pricing, strict ABI decoding, and duplicate-validation charges in the fee and AccountKeychain references; mark the original TIP-1009 and TIP-1020 values as superseded.

Scoped to the first four requested items. The T11 upgrade page is unchanged.

Validation: type checks, MDX parsing for all six changed files, and `git diff --check` pass. The full build is blocked by an external OpenAPI fetch connection timeout in Vocs; the generated-Markdown audit consequently has no build output to inspect.

Protocol references: [TIP-1093](https://tips.sh/1093), [TIP-1100](https://tips.sh/1100), [TIP-1105](https://tips.sh/1105).

Prompted by: @max-digi
