### PR TITLE
docs(payments): remove stale post-T6 callout, document held payments inline

### DIFF
--- a/src/pages/docs/guide/payments/accept-a-payment.mdx
+++ b/src/pages/docs/guide/payments/accept-a-payment.mdx
@@ -19,6 +19,8 @@ Accept stablecoin payments in your application. Learn how to receive payments, v
 
 Payments are automatically credited to the recipient's address when a transfer is executed. You don't need to do anything special to "accept" a payment, it happens automatically onchain.
 
+If you want to limit which tokens or senders your account accepts, set a [receive policy](/docs/guide/payments/configure-receive-policies). Payments that don't match the policy still succeed onchain, but the funds are held in `ReceivePolicyGuard` (`0xB10C000000000000000000000000000000000000`) for your recovery authority to claim, instead of being credited to your balance.
+
 In this basic receiving demo you can see the balances update after you add funds to your account, using the `getBalance` and `watchEvent` calls documented below.
 
 <Demo.Container name="Receive a Payment" footerVariant="balances" tokens={[Token.alphaUsd, Token.betaUsd, Token.thetaUsd]} src="tempoxyz/examples/tree/main/examples/payments">
@@ -183,6 +185,8 @@ Check if a payment has been received by querying the token balance or listening 
 
 ### Listen for TIP-20 transfer events
 
+Filter `Transfer` events by the `to` address you expect to be paid at. If your account has a receive policy, a blocked payment emits a `Transfer` whose `to` is `ReceivePolicyGuard` rather than your address, followed by a `TransferBlocked` event from `ReceivePolicyGuard`. Treat those as held, not received, and index `TransferBlocked` so the recovery authority can claim them. See [Configure Receive Policies](/docs/guide/payments/configure-receive-policies#understand-receive-policy-behavior).
+
 <Tabs stateKey="library">
   <Tab title="Viem">
 
@@ -203,6 +207,7 @@ Check if a payment has been received by querying the token balance or listening 
           { name: 'value', type: 'uint256' },
         ],
       },
+      args: { to: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEbb' }, // only payments to you // [!code focus]
       onLogs: (logs) => { // [!code focus]
         logs.forEach((log) => { // [!code focus]
           console.log('Received payment:', { // [!code focus]
@@ -599,6 +604,7 @@ contract PaymentReceiver {
 2. **Use memos**: Request memos from payers to link payments to invoices or orders
 3. **Check confirmations**: Wait for transaction finality (~1 second on Tempo) before processing
 4. **Handle edge cases**: Account for partial payments, refunds, and failed transactions
+5. **Check the recipient, not just success**: A payment blocked by a [receive policy](/docs/guide/payments/configure-receive-policies) still succeeds but credits `ReceivePolicyGuard`. Only treat a `Transfer` as received when `to` is your address or the master wallet for your virtual address, and index `TransferBlocked` to recover held funds
 
 ## Cross-Stablecoin Payments
 

--- a/src/pages/docs/guide/payments/send-a-payment.mdx
+++ b/src/pages/docs/guide/payments/send-a-payment.mdx
@@ -16,15 +16,6 @@ import { Tabs, Tab } from 'vocs'
 
 Send stablecoin payments between accounts on Tempo. Payments can include optional memos for reconciliation and tracking.
 
-:::warning[Confirm delivery, not just transaction success]
-On post-T6 networks, a blocked TIP-20 `transfer` / `transferFrom` still succeeds, but credits `ReceivePolicyGuard` at `0xB10C000000000000000000000000000000000000` instead of the intended receiver.
-
-- Before marking a payment, withdrawal, or deposit delivered, confirm the `Transfer` recipient is the intended receiver or the master wallet for its virtual address.
-- Index `ReceivePolicyGuard.TransferBlocked` so redirected funds can be surfaced and claimed later.
-
-See [Configure Receive Policies](/docs/guide/payments/configure-receive-policies).
-:::
-
 ## Send payment demo
 
 By the end of this guide you will be able to send payments on Tempo with an optional memo.
@@ -155,23 +146,36 @@ function SendPaymentWithMemo() {
 
 Now that you can send a payment, you can display the transaction receipt on success.
 
+A successful transaction does not always mean the receiver was credited. If the receiver has a [receive policy](/docs/guide/payments/configure-receive-policies) that blocks the token or sender, the transfer still succeeds but the funds are held in `ReceivePolicyGuard` (`0xB10C000000000000000000000000000000000000`) for recovery. Check the `Transfer` event's recipient before showing the payment as delivered.
+
 :::code-group
 
 ```tsx twoslash [SendPaymentWithMemo.tsx]
 import { Hooks } from 'wagmi/tempo'
-import { parseUnits, stringToHex, pad } from 'viem'
+import { Abis } from 'viem/tempo'
+import { parseUnits, stringToHex, pad, parseEventLogs } from 'viem'
+
+const RECEIVE_POLICY_GUARD = '0xB10C000000000000000000000000000000000000' // [!code ++]
 
 // @noErrors
 function SendPaymentWithMemo() {
   const sendPayment = Hooks.token.useTransferSync()
 
+  const transfer = sendPayment.data // [!code ++]
+    ? parseEventLogs({ abi: Abis.tip20, logs: sendPayment.data.receipt.logs, eventName: 'Transfer' })[0] // [!code ++]
+    : undefined // [!code ++]
+  const held = transfer?.args.to === RECEIVE_POLICY_GUARD // [!code ++]
+
   return (
     <>
       {/* ... your payment form ... */}
       {sendPayment.data && ( // [!code ++]
-        <a href={`https://explore.tempo.xyz/tx/${sendPayment.data.receipt.transactionHash}`}> {/* [!code ++] */}
-          View receipt {/* [!code ++] */}
-        </a> {/* [!code ++] */}
+        <> {/* [!code ++] */}
+          <p>{held ? 'Held by receiver policy' : 'Delivered'}</p> {/* [!code ++] */}
+          <a href={`https://explore.tempo.xyz/tx/${sendPayment.data.receipt.transactionHash}`}> {/* [!code ++] */}
+            View receipt {/* [!code ++] */}
+          </a> {/* [!code ++] */}
+        </> {/* [!code ++] */}
       )} {/* [!code ++] */}
     </>
   )
@@ -1011,9 +1015,23 @@ When you send a payment, the token contract emits events:
 - **Transfer**: Standard ERC-20 transfer event
 - **TransferWithMemo**: Additional event with memo (if using `transferWithMemo`)
 
-You can filter these events to track payments in your off-chain systems.
+If the receiver's [receive policy](/docs/guide/payments/configure-receive-policies) blocks the payment, the `Transfer` event names `ReceivePolicyGuard` (`0xB10C000000000000000000000000000000000000`) as the recipient, and `ReceivePolicyGuard` emits one more event:
+
+- **TransferBlocked**: The payment was held and a receipt was recorded. The `receipt` field is what the recovery authority later passes to `claim`.
+
+Index all three events to track payments in your off-chain systems, and treat a `Transfer` to `ReceivePolicyGuard` as **held**, not delivered.
 
 ## Stablecoin payment best practices
+
+### Confirm delivery, not just transaction success
+
+A TIP-20 `transfer` or `transferFrom` succeeds even when the receiver's receive policy blocks it. In that case the funds are credited to `ReceivePolicyGuard` instead of the receiver. Your payment flow should distinguish three outcomes:
+
+- **Failed**: the transaction reverted. Nothing moved.
+- **Delivered**: the `Transfer` recipient is the intended receiver, or the master wallet for its virtual address.
+- **Held**: the `Transfer` recipient is `ReceivePolicyGuard`. Surface the `TransferBlocked` receipt so the recovery authority can claim the funds.
+
+Only mark a payment, withdrawal, or deposit as delivered in the second case. See [Configure Receive Policies](/docs/guide/payments/configure-receive-policies) for how receivers set policies and how held funds are claimed.
 
 ### Payment loading states
 Users should see a loading state when the payment is being processed.
@@ -1052,5 +1070,11 @@ function SendPayment() {
     to="/docs/protocol/transactions"
     icon="lucide:send"
     title="Transactions"
+  />
+  <Card
+    description="Control which tokens and senders an account accepts, and recover held payments"
+    to="/docs/guide/payments/configure-receive-policies"
+    icon="lucide:shield-check"
+    title="Receive Policies"
   />
 </Cards>


### PR DESCRIPTION
Receive policies are live, so the payment guides should explain held payments where readers send and verify them instead of opening with a stale “post-T6” warning.

- Keep the receipt example focused on displaying a receipt link. Document delivery verification separately: match the token, sender, recipient, and amount; handle virtual-address forwarding; and leave delivery unconfirmed when no matching events are found.
- Explain how to track `TransferBlocked` and retain receipt bytes for the authorized claimer, with links to the existing receive-policy guide.
- Filter incoming transfer examples by recipient in Viem, Rust, and Python. Clarify that held payments are tracked separately from received payments.
- Remove repeated explanations, unused imports, invalid JSX annotations, and error suppression from the receipt example.

Validation: `pnpm build` (including TypeScript and Twoslash), `pnpm check:anchors`, `pnpm check:markdown`, and `git diff --check` passed. The Viem watcher also passed a standalone strict TypeScript check; the Python example passed syntax validation. Rust and Python filter APIs were checked against their library references, but were not exercised against a live node.
