### PR TITLE
Add Wirex and Coinbase ecosystem documentation

### DIFF
--- a/src/pages/docs/ecosystem/bridges.mdx
+++ b/src/pages/docs/ecosystem/bridges.mdx
@@ -26,6 +26,12 @@ Get started with the [Tempo Bungee guide](/docs/guide/bridge-bungee), read the [
 
 View supported tokens, lanes, fees, and contract configuration in the [Tempo Mainnet CCIP Directory](https://docs.chain.link/ccip/directory/mainnet/chain/tempo-mainnet).
 
+## Coinbase
+
+[Coinbase Wrapped BTC (cbBTC)](https://www.coinbase.com/cbbtc) is available on Tempo through Chainlink CCIP, giving applications access to Bitcoin alongside stablecoin payments.
+
+Read the [cbBTC on Tempo announcement](https://tempo.xyz/blog/cbbtc-on-tempo/) and check supported routes and token configuration in the [Tempo Mainnet CCIP Directory](https://docs.chain.link/ccip/directory/mainnet/chain/tempo-mainnet).
+
 ## LayerZero
 
 [LayerZero](https://layerzero.network) is an omnichain interoperability protocol that enables secure, low-level message passing between blockchains. Stargate is the global interface for value movement onchain. Within Tempo, Stargate enables native, 1&#58;1 asset transfers into and out of the ecosystem.

--- a/src/pages/docs/ecosystem/orchestration.mdx
+++ b/src/pages/docs/ecosystem/orchestration.mdx
@@ -76,6 +76,12 @@ UR supports Swiss IBAN accounts, seven fiat currencies, SEPA and SWIFT transfers
 
 Get started with [UR's partner portal](https://partner.ur.app/) or [book a demo](https://ur.app/partners/tempo).
 
+## Wirex
+
+[Wirex](https://www.wirexapp.com/) provides card issuance, wallets, and stablecoin settlement infrastructure. Its integration lets partners use Tempo as the onchain settlement layer for enterprise stablecoin card programs.
+
+Explore the [Wirex platform documentation](https://docs.wirexapp.com/) and [supported environments and chains](https://docs.wirexapp.com/docs/retail-environments) to plan an integration.
+
 ## XFX
 
 [XFX](https://xfx.io) provides institutional FX execution and settlement infrastructure, unifying fiat and stablecoin liquidity into one execution venue (API, web, or OTC) — delivering best price, instant settlement, and zero pre-funding for capital-efficient FX.


### PR DESCRIPTION
Adds Wirex to issuance and orchestration docs and Coinbase to bridges and exchanges docs. Wirex links to its platform docs and supported chains; Coinbase is scoped to cbBTC on Tempo via Chainlink CCIP and links to the CCIP directory.

Validation: type checks, production build, generated Markdown audit, and diff checks passed.

Sources: [Wirex supported chains](https://docs.wirexapp.com/docs/retail-environments), [Wirex announcement](https://tempo.xyz/blog/wirex-is-now-live-on-tempo/), and [cbBTC announcement](https://tempo.xyz/blog/cbbtc-on-tempo/).
