### PR TITLE
Expand Coinbase docs to platform and Prime support

### DIFF
--- a/src/pages/docs/ecosystem/bridges.mdx
+++ b/src/pages/docs/ecosystem/bridges.mdx
@@ -28,9 +28,11 @@ View supported tokens, lanes, fees, and contract configuration in the [Tempo Mai
 
 ## Coinbase
 
-[Coinbase Wrapped BTC (cbBTC)](https://www.coinbase.com/cbbtc) is available on Tempo through Chainlink CCIP, giving applications access to Bitcoin alongside stablecoin payments.
+[Coinbase](https://www.coinbase.com/) supports Tempo across custody, trading, and transfers, including in its iOS and Android apps.
 
-Read the [cbBTC on Tempo announcement](https://tempo.xyz/blog/cbbtc-on-tempo/) and check supported routes and token configuration in the [Tempo Mainnet CCIP Directory](https://docs.chain.link/ccip/directory/mainnet/chain/tempo-mainnet).
+Retail and exchange customers can use Coinbase's existing stablecoin markets, then select Tempo as the network when sending or receiving. Eligible Coinbase Prime clients can also access custody support, with availability varying by asset and contracting entity.
+
+For businesses and developers using Tempo, this adds a familiar route to source supported stablecoins and move them between Coinbase and the network. That reduces the operational steps between exchange or custody infrastructure and stablecoin payments or treasury activity on Tempo.
 
 ## LayerZero
 

--- a/src/pages/docs/ecosystem/wallets.mdx
+++ b/src/pages/docs/ecosystem/wallets.mdx
@@ -67,6 +67,12 @@ Turnkey has a [`with-tempo`](https://github.com/tkhq/sdk/tree/main/examples/chai
 
 Get started through the [BitGo platform](https://www.bitgo.com) or explore their [developer docs](https://developers.bitgo.com/).
 
+### Coinbase
+
+Eligible [Coinbase Prime](https://www.coinbase.com/prime) clients can access custody support for Tempo, with availability varying by asset and contracting entity.
+
+Coinbase also supports Tempo for retail and exchange trading and transfers, including in its iOS and Android apps. Customers can use existing stablecoin markets, then select Tempo as the network when sending or receiving. See [Coinbase trading and transfers](/docs/ecosystem/bridges#coinbase) for more context.
+
 ### Cubist
 
 [Cubist](https://cubist.dev) provides high-performance, institutional-grade infrastructure spanning wallets, tokenization, payments, and private smart contracts. Institutions use Cubist to manage their treasuries, automate internal operations, and programmatically control how digital assets move while delivering cryptographic audit trails for regulators. Developers use Cubist to provision wallets with familiar authentication methods and gas sponsorship for end users and AI agents.


### PR DESCRIPTION
Broadens Coinbase documentation from cbBTC to Tempo support across custody, trading, and transfers, including iOS and Android, using the supplied launch copy.

Updates Bridges & Exchanges with the retail and exchange workflow and its business use. Adds Coinbase to Custodial & Institutional wallets, preserving Prime eligibility limits by asset and contracting entity and cross-linking the transfer workflow.

Validation: type checks, production build, and diff checks passed. Confirmed the updated copy and cross-link in both generated HTML pages.
